### PR TITLE
Update Rehearsal's tsMigrate workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "conventional-changelog-cli": "^2.1.1",
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
-    "ts-migrate-server": "^0.1.26"
+    "ts-migrate-server": "^0.1.27"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,9 +59,9 @@
     "listr2": "^4.0.2",
     "semver": "^7.3.5",
     "tmp": "^0.2.1",
-    "ts-migrate": "^0.1.26",
-    "ts-migrate-plugins": "^0.1.26",
-    "ts-migrate-server": "^0.1.26",
+    "ts-migrate": "^0.1.28",
+    "ts-migrate-plugins": "^0.1.28",
+    "ts-migrate-server": "^0.1.27",
     "which": "^2.0.2",
     "winston": "^3.3.3"
   },

--- a/packages/cli/src/ts-migrate.ts
+++ b/packages/cli/src/ts-migrate.ts
@@ -1,19 +1,46 @@
 import { migrate, MigrateConfig } from "ts-migrate-server";
 import { pluginTSMigrateAutofix } from "@rehearsal/plugin-ts-migrate";
+import {
+  eslintFixPlugin,
+  stripTSIgnorePlugin,
+  tsIgnorePlugin,
+} from "ts-migrate-plugins";
 
 import type { Reporter } from "@rehearsal/reporter";
 
-export type PluginOptions = { reporter: Reporter };
-
 export async function tsMigrateAutofix(
   srcDir: string,
-  reporter: Reporter
+  reporter: Reporter,
+  transformCode: boolean
 ): Promise<number> {
-  const pluginOptions = { reporter };
-  const config = new MigrateConfig().addPlugin(
-    pluginTSMigrateAutofix,
-    pluginOptions
-  );
+  const config = new MigrateConfig()
+    .addPlugin(stripTSIgnorePlugin, {})
+
+    // TODO: Review following plugins and enable them pr remove
+    // Errors: 2551
+    //.addPlugin(declareMissingClassPropertiesPlugin, {})
+
+    // Errors: 2459, 2525, 2683, 7006, 7008, 7019, 7031, 7034
+    //.addPlugin(explicitAnyPlugin, {})
+
+    // Errors: 2571
+    //.addPlugin(addConversionsPlugin, {})
+
+    // Run eslint-fix to fix up formatting before running transforms.
+    .addPlugin(eslintFixPlugin, {})
+
+    // Adds ts-expect-error() comments above the lines need to be fixed
+    .addPlugin(tsIgnorePlugin, { messageLimit: 300 })
+
+    // Run transforms to fix lines marked by tsIgnorePlugin plugin
+    .addPlugin(pluginTSMigrateAutofix, {
+      updateCommentsOnly: !transformCode,
+      reporter: reporter,
+    })
+
+    // Run eslint-fix again after to fix up formatting possibly broken by transforms.
+    .addPlugin(eslintFixPlugin, {});
+
   const exitCode = await migrate({ rootDir: srcDir, config });
 
   return exitCode;

--- a/packages/cli/test/commands/ts.test.ts
+++ b/packages/cli/test/commands/ts.test.ts
@@ -50,8 +50,7 @@ describe("ts:command against fixture", async () => {
     ]);
 
     expect(ctx.stdout).to.contain(`Rehearsing with typescript@`);
-    expect(ctx.stdout).to.contain(`Running TS-Migrate Reignore`);
-    expect(ctx.stdout).to.contain(`Autofix successful`);
+    expect(ctx.stdout).to.contain(`Autofix successful: code changes applied`);
     assert.ok(
       existsSync(RESULTS_FILEPATH),
       `result file ${RESULTS_FILEPATH} should exists`
@@ -89,7 +88,7 @@ describe("ts:command against fixture", async () => {
         FIXTURE_APP_PATH
       ]);
 
-      expect(ctx.stdout).to.contain(`Autofix not enabled`);
+      expect(ctx.stdout).to.contain(`Autofix successful: ts-expect-error comments added`);
     });
   });
 }).afterEach(afterEachCleanup);

--- a/packages/cli/test/fixtures/app_with_comments/foo.ts
+++ b/packages/cli/test/fixtures/app_with_comments/foo.ts
@@ -21,12 +21,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// @ts-expect-error ts-migrate(7006) FIXME: Parameter 'p' implicitly has an 'any' type.
+// @ts-expect-error ts-migrate(6133) FIXME: 'msToSeconds' is declared but its value is never read.
 function msToSeconds(ms: number): number {
   return Math.round(ms / 1000);
 }
 
-// @ts-expect-error ts-migrate(6133) FIXME: 'readJSON' is declared but its value is never read... Remove this comment to see the full error message
+// @ts-expect-error ts-migrate(6133) FIXME: 'readJSON' is declared but its value is never read.
 function readJSON<TJson = unknown>(file: string): TJson | undefined {
   const text = readText(file);
   if (text !== undefined) {
@@ -57,12 +57,12 @@ function readFile(
   }
 }
 
-// @ts-expect-error ts-migrate(6133) FIXME: 'timestamp' is declared but its value is never rea... Remove this comment to see the full error message
+// @ts-expect-error ts-migrate(6133) FIXME: 'timestamp' is declared but its value is never read.
 function timestamp(inSeconds = false): number {
   return inSeconds ? Date.now() / 1000 : Date.now();
 }
 
-// @ts-expect-error ts-migrate(6133) FIXME: 'parseLongDescribe' is declared but its value is n... Remove this comment to see the full error message
+// @ts-expect-error ts-migrate(6133) FIXME: 'parseLongDescribe' is declared but its value is never read.
 function parseLongDescribe(desc: string): GitDescribe {
   const result = /^(.+)-(\d+)-g([a-f0-9]+)(?:-(dirty))?$/.exec(desc);
 
@@ -80,7 +80,7 @@ function parseLongDescribe(desc: string): GitDescribe {
   };
 }
 
-// @ts-expect-error ts-migrate(6133) FIXME: 'normalizeVersionString' is declared but its value... Remove this comment to see the full error message
+// @ts-expect-error ts-migrate(6133) FIXME: 'normalizeVersionString' is declared but its value is never read.
 function normalizeVersionString(versionString: string): string {
   if (VERSION_PATTERN.test(versionString)) {
     const result = VERSION_PATTERN.exec(versionString);

--- a/packages/plugin-ts-migrate/package.json
+++ b/packages/plugin-ts-migrate/package.json
@@ -33,7 +33,7 @@
     "@rehearsal/tsc-transforms": "^0.0.12",
     "debug": "^4.3.3",
     "recast": "^0.20.5",
-    "ts-migrate-server": "^0.1.26"
+    "ts-migrate-server": "^0.1.27"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,15 +6057,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
+json-schema@0.4.0, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
-json-schema@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.3.0.tgz#90a9c5054bd065422c00241851ce8d59475b701b"
-  integrity sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -9018,17 +9013,17 @@ triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
-ts-migrate-plugins@^0.1.26, ts-migrate-plugins@^0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/ts-migrate-plugins/-/ts-migrate-plugins-0.1.27.tgz#e7244d1d56661e51b07258944cede065bd0605f4"
-  integrity sha512-+pDSRA2lCS7k0wvSB0oDDO+FMqGrsXMKkYYAvK2HuLpzsO1EwVZ5mPjZpidr2yCfXOxkkT87zjiBf7uEXqfB0w==
+ts-migrate-plugins@^0.1.28:
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/ts-migrate-plugins/-/ts-migrate-plugins-0.1.28.tgz#08d4f41eb4447aaa221e1b5c8665e06242d0a3c5"
+  integrity sha512-ZDmrRg6nD9cNXMtmVm1n2AyBvdXAb9Ga/VVDGFB3LFr7V+C4IEgox/GJDybUVkbAH8e6PQKUyHopD9u2W+nZmA==
   dependencies:
     eslint "^7.14.0"
     jscodeshift "^0.13.0"
-    json-schema "^0.3.0"
+    json-schema "^0.4.0"
     ts-migrate-server "^0.1.27"
 
-ts-migrate-server@^0.1.26, ts-migrate-server@^0.1.27:
+ts-migrate-server@^0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/ts-migrate-server/-/ts-migrate-server-0.1.27.tgz#daa95b01634a651f4dd5ff90d35b93791e564905"
   integrity sha512-sDcrBx2oUL/Ycs3YNwqMz5KxPtNjwMIDGpVbvuxDkVXDG+ly4tyF+tc5byQzKpVGx2mI+ccxrX8VG74wICTJlg==
@@ -9037,15 +9032,15 @@ ts-migrate-server@^0.1.26, ts-migrate-server@^0.1.27:
     pretty-ms "^7.0.1"
     updatable-log "^0.2.0"
 
-ts-migrate@^0.1.26:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/ts-migrate/-/ts-migrate-0.1.27.tgz#4b21f6eedcb33734579afd29df781cab994387c0"
-  integrity sha512-nwZwLfCX635Fiaw5JKB0bQjNvbLfeA+010+n00KnIu5/I9s8CbypJ6b49wFyTdZCnIYklh8n/JxcTQIodTHAqQ==
+ts-migrate@^0.1.28:
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/ts-migrate/-/ts-migrate-0.1.28.tgz#08f3ca920c6029fd4a62e03bb06a55581023ca5e"
+  integrity sha512-xKpbJPata0Z6F6MP/GrLFKFiypXU7zc+wO8bjLwFS3RzwtQrjvdQit+nYBrXAKI97Be6Q26G1kko/toJayRXBw==
   dependencies:
     create-jest-runner "^0.5.3"
     json5 "^2.1.1"
     json5-writer "^0.1.8"
-    ts-migrate-plugins "^0.1.27"
+    ts-migrate-plugins "^0.1.28"
     ts-migrate-server "^0.1.27"
     updatable-log "^0.2.0"
     yargs "^15.0.2"


### PR DESCRIPTION
Configure Rehearsal ts-migrate flow instead of running ts-migrate cli.

This gives us more control over ts-migrate plugin configs:
- have full error messages after running tsIgnorePlugin
- run eslintFixPlugin plugin after pluginTSMigrateAutofix

We can, probably, even merge tsIgnorePlugin and pluginTSMigrateAutofix into a single plugin in future.