### PR TITLE
Create reporter per command run to avoid write issues

### DIFF
--- a/packages/cli/src/commands/ts.ts
+++ b/packages/cli/src/commands/ts.ts
@@ -33,9 +33,6 @@ const DEFAULT_TS_BUILD = "beta";
 let TSC_PATH = "";
 let TS_MIGRATE_PATH = "";
 
-// cwd for development only
-const REPORTER = new Reporter({ cwd: process.cwd() });
-
 type Context = {
   tsVersion: string;
   latestELRdBuild: string;
@@ -86,10 +83,13 @@ export default class TS extends Command {
 
     // grab the consuming apps project name
     const projectName = await determineProjectName();
-    REPORTER.projectName = projectName ? projectName : "";
+
+    const reporter = new Reporter({ cwd: process.cwd() });
+
+    reporter.projectName = projectName ? projectName : "";
 
     if (flags.report_output || flags.is_test) {
-      REPORTER.setCWD(resolvedSrcDir);
+      reporter.setCWD(resolvedSrcDir);
     }
 
     const tasks = new Listr<Context>(
@@ -138,7 +138,7 @@ export default class TS extends Command {
                   ) {
                     ctx.tsVersion = ctx.latestELRdBuild;
                     parent.title = `Rehearsing with typescript@${ctx.tsVersion}`;
-                    REPORTER.tscVersion = ctx.tsVersion;
+                    reporter.tscVersion = ctx.tsVersion;
                   } else {
                     parent.title = `This application is already on the latest version of TypeScript@${ctx.currentTSVersion}. Exiting.`;
                     // this is a master skip that will skip the remainder of the tasks
@@ -237,7 +237,7 @@ export default class TS extends Command {
 
             const exitCode = await tsMigrateAutofix(
               resolvedSrcDir,
-              REPORTER,
+              reporter,
               runTransforms
             );
 
@@ -273,7 +273,7 @@ export default class TS extends Command {
 
       // end the reporter stream
       // and parse the results into a json file
-      await REPORTER.end(() => {
+      await reporter.end(() => {
         console.log(
           `Duration:              ${Math.floor(
             timestamp(true) - startTime

--- a/packages/cli/test/commands/ts.test.ts
+++ b/packages/cli/test/commands/ts.test.ts
@@ -77,19 +77,19 @@ describe("ts:command against fixture", async () => {
     assert.equal(firstFileReportError.isAutofixed, true);
     assert.equal(firstFileReportError.stringLocation.end, 326);
     assert.equal(firstFileReportError.stringLocation.start, 236);
+  });
 
-    test.stdout().it("NO autofix", async (ctx) => {
-      await TS.run([
-        "--src_dir",
-        FIXTURE_APP_PATH,
-        "--dry_run",
-        "--is_test",
-        "--report_output",
-        FIXTURE_APP_PATH
-      ]);
+  test.stdout().it("NO autofix", async (ctx) => {
+    await TS.run([
+      "--src_dir",
+      FIXTURE_APP_PATH,
+      "--dry_run",
+      "--is_test",
+      "--report_output",
+      FIXTURE_APP_PATH
+    ]);
 
-      expect(ctx.stdout).to.contain(`Autofix successful: ts-expect-error comments added`);
-    });
+    expect(ctx.stdout).to.contain(`Autofix successful: ts-expect-error comments added`);
   });
 }).afterEach(afterEachCleanup);
 


### PR DESCRIPTION
The `NO autofix` test case was not in the right place and never run.

Another issues came out of blue after I fixed the test:

```
 Error: Error: write after end
    at DerivedLogger.<anonymous> (/Users/everbits/Sites/rehearsal-js/packages/reporter/src/reporter.ts:181:13)
    at DerivedLogger.emit (node:events:390:28)
    at DerivedLogger.emit (node:domain:475:12)
    at errorOrDestroy (/Users/everbits/Sites/rehearsal-js/node_modules/readable-stream/lib/internal/streams/destroy.js:98:101)
    at writeAfterEnd (/Users/everbits/Sites/rehearsal-js/node_modules/readable-stream/lib/_stream_writable.js:263:3)
    at DerivedLogger.Writable.write (/Users/everbits/Sites/rehearsal-js/node_modules/readable-stream/lib/_stream_writable.js:305:21)
    at DerivedLogger.log (/Users/everbits/Sites/rehearsal-js/node_modules/winston/lib/winston/logger.js:252:14)
    at Object.run (/Users/everbits/Sites/rehearsal-js/packages/plugin-ts-migrate/src/plugin-ts-migrate-autofix.ts:137:25)
```

To avoid this we need to create a separate reporter object for every command run.