### PR TITLE
refactor: integrate reporter to the migrate function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
-.rehearsal.json
-.rehearsal-diagnostics.json
+.rehearsal*.md
+.rehearsal*.json
 
 .idea/
 .history/

--- a/packages/migration/src/reporter/formatters/json.ts
+++ b/packages/migration/src/reporter/formatters/json.ts
@@ -1,4 +1,4 @@
-import { Report } from '../reporter';
+import { Report } from '../types';
 
 export default function json(report: Report): string {
   return JSON.stringify(report, null, 2);

--- a/packages/migration/src/reporter/formatters/pull-request-md.ts
+++ b/packages/migration/src/reporter/formatters/pull-request-md.ts
@@ -1,0 +1,32 @@
+import { Report } from '../types';
+
+export default function pullRequestMd(report: Report): string {
+  const fileNames = [...new Set(report.items.map((item) => item.file))];
+
+  let text = ``;
+
+  text += `### Summary:\n`;
+  text += `Typescript Version: ${report.summary.tsVersion}\n`;
+  text += `Files Tested: ${fileNames.length}\n`;
+  text += `\n`;
+  text += `### Results:\n`;
+
+  for (const fileName of fileNames) {
+    const items = report.items.filter((item) => item.file === fileName);
+    const relativeFileName = fileName.replace(report.summary.basePath, '');
+
+    text += `\n`;
+    text += `#### File: ${relativeFileName}, issues: ${items.length}:\n`;
+
+    for (const item of items) {
+      text += `\n`;
+      text += `**${item.category} TS${item.code}**: ${
+        item.fixed ? 'FIXED' : 'NEED TO BE FIXED MANUALLY'
+      }\n`;
+      text += `${item.hint}\n`;
+      text += `Code: \`${item.nodeText}\`\n`;
+    }
+  }
+
+  return text;
+}

--- a/packages/migration/src/reporter/types.ts
+++ b/packages/migration/src/reporter/types.ts
@@ -1,0 +1,28 @@
+export type ReportSummary = {
+  projectName: string;
+  basePath: string;
+  tsVersion: string;
+  timestamp: string;
+};
+
+export type ReportItem = {
+  file: string;
+  code: number;
+  category: string;
+  message: string;
+  hint?: string;
+  fixed?: boolean;
+  nodeKind?: string;
+  nodeText?: string;
+  location: {
+    start: number;
+    length: number;
+    line: number;
+    character: number;
+  };
+};
+
+export type Report = {
+  summary: ReportSummary;
+  items: ReportItem[];
+};

--- a/packages/migration/test/fixtures/migrate/.rehearsal-report.output.json
+++ b/packages/migration/test/fixtures/migrate/.rehearsal-report.output.json
@@ -1,0 +1,234 @@
+{
+  "summary": {
+    "projectName": "@rehearsal/test",
+    "tsVersion": "",
+    "timestamp": "",
+    "basePath": ""
+  },
+  "items": [
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'fs' is declared but its value is never read.",
+      "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
+      "fixed": true,
+      "nodeKind": "ImportDeclaration",
+      "nodeText": "import fs from 'fs';",
+      "location": {
+        "start": 0,
+        "length": 20,
+        "line": 0,
+        "character": 0
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'parse' is declared but its value is never read.",
+      "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
+      "fixed": true,
+      "nodeKind": "ImportSpecifier",
+      "nodeText": "parse",
+      "location": {
+        "start": 18,
+        "length": 5,
+        "line": 0,
+        "character": 18
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 2307,
+      "category": "Error",
+      "message": "Cannot find module 'path' or its corresponding type declarations.",
+      "hint": "Cannot find module 'path' or its corresponding type declarations.",
+      "fixed": false,
+      "nodeKind": "StringLiteral",
+      "nodeText": "'path'",
+      "location": {
+        "start": 24,
+        "length": 6,
+        "line": 0,
+        "character": 24
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'sleep' is declared but its value is never read.",
+      "hint": "The declaration 'sleep' is never read or used. Remove the declaration or use it.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "sleep",
+      "location": {
+        "start": 159,
+        "length": 5,
+        "line": 3,
+        "character": 9
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'inSeconds' is declared but its value is never read.",
+      "hint": "The declaration 'inSeconds' is never read or used. Remove the declaration or use it.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "inSeconds",
+      "location": {
+        "start": 448,
+        "length": 9,
+        "line": 11,
+        "character": 19
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'timestamp' is declared but its value is never read.",
+      "hint": "The declaration 'timestamp' is never read or used. Remove the declaration or use it.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "timestamp",
+      "location": {
+        "start": 675,
+        "length": 9,
+        "line": 15,
+        "character": 13
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'b' is declared but its value is never read.",
+      "hint": "The declaration 'b' is never read or used. Remove the declaration or use it.",
+      "fixed": true,
+      "nodeKind": "Identifier",
+      "nodeText": "b",
+      "location": {
+        "start": 852,
+        "length": 1,
+        "line": 17,
+        "character": 14
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 6133,
+      "category": "Error",
+      "message": "'b' is declared but its value is never read.",
+      "hint": "The declaration 'b' is never read or used. Remove the declaration or use it.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "b",
+      "location": {
+        "start": 856,
+        "length": 1,
+        "line": 17,
+        "character": 14
+      }
+    },
+    {
+      "file": "first.ts",
+      "code": 2322,
+      "category": "Error",
+      "message": "Type 'string' is not assignable to type 'void'.",
+      "hint": "Type 'string' is not assignable to type 'void'.",
+      "fixed": false,
+      "nodeKind": "ReturnStatement",
+      "nodeText": "return a;",
+      "location": {
+        "start": 992,
+        "length": 9,
+        "line": 19,
+        "character": 8
+      }
+    },
+    {
+      "file": "react.tsx",
+      "code": 2304,
+      "category": "Error",
+      "message": "Cannot find name 'DoesNotExist'.",
+      "hint": "Cannot find name 'DoesNotExist'.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "DoesNotExist",
+      "location": {
+        "start": 80,
+        "length": 12,
+        "line": 5,
+        "character": 7
+      }
+    },
+    {
+      "file": "second.ts",
+      "code": 2304,
+      "category": "Error",
+      "message": "Cannot find name 'readFileSync'.",
+      "hint": "Cannot find name 'readFileSync'.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "readFileSync",
+      "location": {
+        "start": 63,
+        "length": 12,
+        "line": 1,
+        "character": 9
+      }
+    },
+    {
+      "file": "second.ts",
+      "code": 2304,
+      "category": "Error",
+      "message": "Cannot find name 'doesNotExist'.",
+      "hint": "Cannot find name 'doesNotExist'.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "doesNotExist",
+      "location": {
+        "start": 339,
+        "length": 12,
+        "line": 12,
+        "character": 21
+      }
+    },
+    {
+      "file": "second.ts",
+      "code": 2304,
+      "category": "Error",
+      "message": "Cannot find name 'doesNotExist'.",
+      "hint": "Cannot find name 'doesNotExist'.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "doesNotExist",
+      "location": {
+        "start": 538,
+        "length": 12,
+        "line": 20,
+        "character": 6
+      }
+    },
+    {
+      "file": "second.ts",
+      "code": 2304,
+      "category": "Error",
+      "message": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",
+      "hint": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",
+      "fixed": false,
+      "nodeKind": "Identifier",
+      "nodeText": "doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString",
+      "location": {
+        "start": 631,
+        "length": 92,
+        "line": 22,
+        "character": 6
+      }
+    }
+  ]
+}

--- a/packages/migration/test/fixtures/migrate/.rehearsal-report.output.md
+++ b/packages/migration/test/fixtures/migrate/.rehearsal-report.output.md
@@ -1,0 +1,67 @@
+### Summary:
+Typescript Version: 4.5.5
+Files Tested: 3
+
+### Results:
+
+#### File: /first.ts, issues: 9:
+
+**Error TS6133**: FIXED
+The declaration 'fs' is never read or used. Remove the declaration or use it.
+Code: `import fs from 'fs';`
+
+**Error TS6133**: FIXED
+The declaration 'parse' is never read or used. Remove the declaration or use it.
+Code: `parse`
+
+**Error TS2307**: NEED TO BE FIXED MANUALLY
+Cannot find module 'path' or its corresponding type declarations.
+Code: `'path'`
+
+**Error TS6133**: NEED TO BE FIXED MANUALLY
+The declaration 'sleep' is never read or used. Remove the declaration or use it.
+Code: `sleep`
+
+**Error TS6133**: NEED TO BE FIXED MANUALLY
+The declaration 'inSeconds' is never read or used. Remove the declaration or use it.
+Code: `inSeconds`
+
+**Error TS6133**: NEED TO BE FIXED MANUALLY
+The declaration 'timestamp' is never read or used. Remove the declaration or use it.
+Code: `timestamp`
+
+**Error TS6133**: FIXED
+The declaration 'b' is never read or used. Remove the declaration or use it.
+Code: `b`
+
+**Error TS6133**: NEED TO BE FIXED MANUALLY
+The declaration 'b' is never read or used. Remove the declaration or use it.
+Code: `b`
+
+**Error TS2322**: NEED TO BE FIXED MANUALLY
+Type 'string' is not assignable to type 'void'.
+Code: `return a;`
+
+#### File: /react.tsx, issues: 1:
+
+**Error TS2304**: NEED TO BE FIXED MANUALLY
+Cannot find name 'DoesNotExist'.
+Code: `DoesNotExist`
+
+#### File: /second.ts, issues: 4:
+
+**Error TS2304**: NEED TO BE FIXED MANUALLY
+Cannot find name 'readFileSync'.
+Code: `readFileSync`
+
+**Error TS2304**: NEED TO BE FIXED MANUALLY
+Cannot find name 'doesNotExist'.
+Code: `doesNotExist`
+
+**Error TS2304**: NEED TO BE FIXED MANUALLY
+Cannot find name 'doesNotExist'.
+Code: `doesNotExist`
+
+**Error TS2304**: NEED TO BE FIXED MANUALLY
+Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.
+Code: `doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString`

--- a/packages/migration/test/migrate.test.ts
+++ b/packages/migration/test/migrate.test.ts
@@ -1,12 +1,16 @@
 import fs from 'fs';
+import ts from 'typescript';
 import winston from 'winston';
 
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
 import { resolve } from 'path';
 
 import migrate from '../src/migrate';
 
-import { assert } from 'chai';
-import { describe, it } from 'mocha';
+import { Report } from '../src/reporter/types';
+import Reporter from '../src/reporter/reporter';
+import pullRequestMd from '../src/reporter/formatters/pull-request-md';
 
 const basePath = resolve(__dirname, 'fixtures', 'migrate');
 const filesNames = ['first.ts', 'react.tsx', 'second.ts'];
@@ -18,11 +22,13 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console({ format: winston.format.cli(), level: 'debug' })],
 });
 
+const reporter = new Reporter('@rehearsal/test', basePath, logger);
+
 describe('Test migration', function () {
   it('run with correct params', async () => {
     createTsFilesFromInputs(files);
 
-    const result = await migrate({ basePath, logger });
+    const result = await migrate({ basePath, logger, reporter });
 
     assert.exists(result);
 
@@ -31,9 +37,48 @@ describe('Test migration', function () {
       assert.equal(fs.readFileSync(`${file}.output`).toString(), fs.readFileSync(file).toString());
     }
 
+    // Test the json report
+    assert.isTrue(fs.existsSync(result.reportFile));
+
+    const report = JSON.parse(fs.readFileSync(result.reportFile).toString());
+
+    assert.isNotEmpty(report.summary.basePath);
+    assert.isNotEmpty(report.summary.timestamp);
+    assert.deepEqual(report, expectedReport(report.summary.basePath, report.summary.timestamp));
+
+    fs.rmSync(result.reportFile);
+
+    // Test the pull-request-md report
+    // TODO: Move to @rehearsal/report
+    const mdReport = resolve(basePath, '.rehearsal-report.md');
+    reporter.print(mdReport, pullRequestMd);
+
+    assert.equal(
+      fs.readFileSync(resolve(basePath, '.rehearsal-report.output.md')).toString(),
+      fs.readFileSync(mdReport).toString()
+    );
+
+    fs.rmSync(mdReport);
+
     cleanupTsFiles(files);
   });
 });
+
+/**
+ * Prepares the report to compare with.
+ */
+function expectedReport(basePath: string, timestamp: string): Report {
+  const content = fs.readFileSync(resolve(basePath, '.rehearsal-report.output.json')).toString();
+
+  const report = JSON.parse(content) as Report;
+
+  report.summary.basePath = basePath;
+  report.summary.timestamp = timestamp;
+  report.summary.tsVersion = ts.version;
+  report.items.map((v) => (v.file = resolve(basePath, v.file)));
+
+  return report;
+}
 
 /**
  * Creates .ts files from .ts.input files


### PR DESCRIPTION
Add reporter to the `migrate` command.

Reporter keeps all items in memory and allows to print reports in different formats.
Currently has plain json output and md format for PR (see tests).

Will be migrated to @rehearsal/reporter in one of the following PRs 