### PR TITLE
fix: correct the way to check if source code been fixed

### DIFF
--- a/packages/cli/test/commands/ts.test.ts
+++ b/packages/cli/test/commands/ts.test.ts
@@ -56,7 +56,7 @@ describe('ts:command against fixture', async () => {
 
     assert.equal(report.summary.projectName, '@rehearsal/cli');
     assert.equal(report.summary.tsVersion, latestPublishedTSVersion);
-    assert.equal(report.summary.cumulativeErrors, 26);
+    assert.equal(report.summary.cumulativeErrors, 25);
     assert.equal(report.summary.uniqueErrors, 2);
     assert.deepEqual(report.summary.uniqueErrorsList, [6133, 2322]);
     assert.equal(report.summary.autofixedErrors, 1);
@@ -68,7 +68,7 @@ describe('ts:command against fixture', async () => {
       '/foo_2/foo_2b.ts',
     ]);
 
-    assert.equal(report.items.length, 26);
+    assert.equal(report.items.length, 25);
 
     const firstFileReportError = report.items[0];
 

--- a/packages/migrate/src/plugins/diagnostics-autofix.plugin.ts
+++ b/packages/migrate/src/plugins/diagnostics-autofix.plugin.ts
@@ -25,8 +25,8 @@ export default class DiagnosticAutofixPlugin extends Plugin {
 
       let text = fix.run(diagnostic, this.service.getLanguageService());
 
+      const fixed = this.isSourceCodeChanged(diagnostic.file.getFullText(), text);
       const hint = this.prepareHint(diagnostic.messageText, fix?.hint);
-      const fixed = diagnostic.file.getFullText() !== text;
 
       if (fixed) {
         this.logger?.debug(` - TS${diagnostic.code} at ${diagnostic.start}:\t fix applied`);
@@ -45,6 +45,14 @@ export default class DiagnosticAutofixPlugin extends Plugin {
     }
 
     return this.service.getFileText(params.fileName);
+  }
+
+  /**
+   * Determines if update source code is different from original one
+   */
+  isSourceCodeChanged(originalText: string, updateText: string): boolean {
+    // Compares source codes without spaces.
+    return originalText.replace(/\s+/g, ' ') !== updateText.replace(/\s+/g, ' ');
   }
 
   /**

--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
@@ -284,7 +284,7 @@
       "category": "Error",
       "message": "'timestamp' is declared but its value is never read.",
       "hint": "The function 'timestamp' is never called. Remove the function or use it.",
-      "fixed": true,
+      "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "timestamp",
       "location": {
@@ -298,45 +298,13 @@
       "file": "first.ts",
       "code": 6133,
       "category": "Error",
-      "message": "'timestamp' is declared but its value is never read.",
-      "hint": "The function 'timestamp' is never called. Remove the function or use it.",
-      "fixed": false,
-      "nodeKind": "Identifier",
-      "nodeText": "timestamp",
-      "location": {
-        "start": 1005,
-        "length": 9,
-        "line": 20,
-        "character": 13
-      }
-    },
-    {
-      "file": "first.ts",
-      "code": 6133,
-      "category": "Error",
-      "message": "'b' is declared but its value is never read.",
-      "hint": "The variable 'b' is never read or used. Remove the variable or use it.",
-      "fixed": true,
-      "nodeKind": "Identifier",
-      "nodeText": "b",
-      "location": {
-        "start": 1170,
-        "length": 1,
-        "line": 22,
-        "character": 14
-      }
-    },
-    {
-      "file": "first.ts",
-      "code": 6133,
-      "category": "Error",
       "message": "'b' is declared but its value is never read.",
       "hint": "The variable 'b' is never read or used. Remove the variable or use it.",
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "b",
       "location": {
-        "start": 1174,
+        "start": 1166,
         "length": 1,
         "line": 22,
         "character": 14
@@ -352,7 +320,7 @@
       "nodeKind": "ReturnStatement",
       "nodeText": "return 'a';",
       "location": {
-        "start": 1304,
+        "start": 1296,
         "length": 11,
         "line": 24,
         "character": 8

--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
@@ -48,7 +48,7 @@ Code: `defined_function`
 The parameter 'defined_param' is never used. Remove the parameter from function definition or use it.
 Code: `defined_param`
 
-#### File: /first.ts, issues: 12:
+#### File: /first.ts, issues: 10:
 
 **Error TS6133**: FIXED
 The declaration 'fs' is never read or used. Remove the declaration or use it.
@@ -78,17 +78,9 @@ Code: `inSeconds`
 The variable 'foo' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.
 Code: `foo`
 
-**Error TS6133**: FIXED
-The function 'timestamp' is never called. Remove the function or use it.
-Code: `timestamp`
-
 **Error TS6133**: NEED TO BE FIXED MANUALLY
 The function 'timestamp' is never called. Remove the function or use it.
 Code: `timestamp`
-
-**Error TS6133**: FIXED
-The variable 'b' is never read or used. Remove the variable or use it.
-Code: `b`
 
 **Error TS6133**: NEED TO BE FIXED MANUALLY
 The variable 'b' is never read or used. Remove the variable or use it.


### PR DESCRIPTION
Updated the way to compare original and updated source codes.

Decided do not use `diff` to improve performance, but we always can update the isSourceCodeChanged implementation