### PR TITLE
fix: clean up the second report generation logic

### DIFF
--- a/packages/cli/src/commands/ts.ts
+++ b/packages/cli/src/commands/ts.ts
@@ -225,7 +225,6 @@ export default class TS extends Command {
             const result = await migrate({
               basePath: resolvedSrcDir,
               configName: 'tsconfig.json', // TODO: Add to command options
-              reportName: '.rehearsal.json', // TODO: Add to command options
               reporter: reporter,
               logger: logger,
             });

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import winston from 'winston';
 
-import { parse, resolve } from 'path';
+import { resolve } from 'path';
 
 import RehearsalService from './rehearsal-service';
 
@@ -14,7 +14,6 @@ import Reporter from '@rehearsal/reporter';
 export type MigrateInput = {
   basePath: string;
   configName?: string;
-  reportName?: string;
   reporter?: Reporter;
   logger?: winston.Logger;
 };
@@ -22,7 +21,6 @@ export type MigrateInput = {
 export type MigrateOutput = {
   basePath: string;
   configFile: string;
-  reportFile: string;
   sourceFiles: string[];
 };
 
@@ -32,7 +30,6 @@ export type MigrateOutput = {
 export default async function migrate(input: MigrateInput): Promise<MigrateOutput> {
   const basePath = resolve(input.basePath);
   const configName = input.configName || 'tsconfig.json';
-  const reportName = input.reportName || '.rehearsal-report.json';
   const reporter = input.reporter;
   const logger = input.logger;
 
@@ -77,14 +74,9 @@ export default async function migrate(input: MigrateInput): Promise<MigrateOutpu
 
   logger?.info(`Migration finished.`);
 
-  const reportFile = resolve(parse(configFile).dir, reportName);
-  reporter?.save(reportFile);
-  logger?.info(`Report saved to ${reportFile}`);
-
   return {
     basePath,
     configFile,
-    reportFile,
     sourceFiles: fileNames,
   };
 }

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -35,19 +35,20 @@ describe('Test migration', function () {
       assert.equal(fs.readFileSync(`${file}.output`).toString(), fs.readFileSync(file).toString());
     }
 
+    // TODO: Move to @rehearsal/report
     // Test the json report
-    assert.isTrue(fs.existsSync(result.reportFile));
+    const jsonReport = resolve(basePath, '.rehearsal-report.json');
+    reporter.save(jsonReport);
 
-    const report = JSON.parse(fs.readFileSync(result.reportFile).toString());
+    const report = JSON.parse(fs.readFileSync(jsonReport).toString());
 
     assert.isNotEmpty(report.summary.basePath);
     assert.isNotEmpty(report.summary.timestamp);
     assert.deepEqual(report, expectedReport(report.summary.basePath, report.summary.timestamp));
 
-    fs.rmSync(result.reportFile);
+    fs.rmSync(jsonReport);
 
     // Test the pull-request-md report
-    // TODO: Move to @rehearsal/report
     const mdReport = resolve(basePath, '.rehearsal-report.md');
     reporter.print(mdReport, pullRequestMd);
 


### PR DESCRIPTION
CLI saves a report in specified format. 
Migrate is not responsible for saving report in any format, just to fill it up.