### PR TITLE
feat: Fix typescript error 2790 [PPTF-4317]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
   ],
   rules: {
+    'curly': 'error',
     'sort-imports': 'off',
     'import/order': 'off',
     'import/no-extraneous-dependencies': 'error',

--- a/packages/migrate/src/helpers/transform-utils.ts
+++ b/packages/migrate/src/helpers/transform-utils.ts
@@ -1,0 +1,66 @@
+import ts from 'typescript';
+
+import type RehearsalService from '../rehearsal-service';
+
+export function getInterfaceByName(
+  sourceFile: ts.SourceFile,
+  typeName: string
+): ts.InterfaceDeclaration | undefined {
+  const matched = sourceFile.statements.find(
+    (s) => ts.isInterfaceDeclaration(s) && s.name.getFullText().trim() === typeName
+  );
+  return matched as ts.InterfaceDeclaration;
+}
+
+export function getImportByName(
+  sourceFile: ts.SourceFile,
+  typeName: string
+): ts.ImportDeclaration | undefined {
+  const matched = sourceFile.statements.find(
+    (s) =>
+      ts.isImportDeclaration(s) &&
+      (s.importClause?.namedBindings as ts.NamedImports).elements.find(
+        (e) => e.name.getFullText().trim() === typeName
+      )
+  );
+  return matched as ts.ImportDeclaration;
+}
+
+export function getClassByName(
+  sourceFile: ts.SourceFile,
+  className: string
+): ts.ClassDeclaration | undefined {
+  const matched = sourceFile.statements.find(
+    (s) => ts.isClassDeclaration(s) && s.name?.getFullText().trim() === className
+  );
+  return matched as ts.ClassDeclaration;
+}
+
+export function getSourceFileFromImport(
+  declaration: ts.ImportDeclaration,
+  importingFile: string,
+  service: RehearsalService
+): ts.SourceFile | undefined {
+  const module = declaration.moduleSpecifier.getFullText().trim().replace(/^'|'$/g, '');
+  const fileName = service.resolveModuleName(module, importingFile);
+  if (fileName) {
+    const sourceFile = service.getSourceFile(fileName);
+    return sourceFile;
+  }
+}
+
+export function getInterfaceMemberByName(
+  declaration: ts.InterfaceDeclaration,
+  typeMemberName: string
+): ts.TypeElement | undefined {
+  return declaration.members.find((member) => member.name?.getFullText().trim() === typeMemberName);
+}
+
+export function getClassMemberByName(
+  declaration: ts.ClassDeclaration,
+  classMemberName: string
+): ts.ClassElement | undefined {
+  return declaration.members.find(
+    (member) => member.name?.getFullText().trim() === classMemberName
+  );
+}

--- a/packages/migrate/src/helpers/typescript-ast.ts
+++ b/packages/migrate/src/helpers/typescript-ast.ts
@@ -106,3 +106,8 @@ export function isJsxTextNode(node: ts.Node): boolean {
 
   return visit(node);
 }
+
+export function insertIntoText(text: string, insertAt: number, strToInsert: string): string {
+  const newText = `${text.substring(0, insertAt)}${strToInsert}${text.substring(insertAt)}`;
+  return newText;
+}

--- a/packages/migrate/src/interfaces/fix-transform.ts
+++ b/packages/migrate/src/interfaces/fix-transform.ts
@@ -1,17 +1,19 @@
 import ts from 'typescript';
+import type RehearsalService from '../rehearsal-service';
 
 export interface FixedFile {
   fileName: string;
   text: string;
 }
+
 export default class FixTransform {
   /** Engineer friendly message describes steps needs to be done to fix the related issue */
   hint?: string;
 
   /** Function to fix the diagnostic issue */
-  fix?: (diagnostic: ts.DiagnosticWithLocation, service: ts.LanguageService) => FixedFile[];
+  fix?: (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService) => FixedFile[];
 
-  run(diagnostic: ts.DiagnosticWithLocation, service: ts.LanguageService): FixedFile[] {
+  run(diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixedFile[] {
     return this.fix ? this.fix(diagnostic, service) : [];
   }
 }

--- a/packages/migrate/src/rehearsal-service.ts
+++ b/packages/migrate/src/rehearsal-service.ts
@@ -118,4 +118,17 @@ export default class RehearsalService {
 
     return this.service.getSemanticDiagnostics(fileName).filter(withLocation);
   }
+
+  /**
+   * Provides a path to a module file by its name
+   */
+  resolveModuleName(moduleName: string, containingFile: string): string | undefined {
+    const result = ts.resolveModuleName(
+      moduleName,
+      containingFile,
+      this.host.getCompilationSettings(),
+      ts.sys
+    );
+    return result?.resolvedModule?.resolvedFileName;
+  }
 }

--- a/packages/migrate/src/transforms/2790-fix-transform.ts
+++ b/packages/migrate/src/transforms/2790-fix-transform.ts
@@ -1,0 +1,137 @@
+import ts from 'typescript';
+
+import FixTransform, { FixedFile } from '../interfaces/fix-transform';
+import { findNodeAtPosition, insertIntoText } from '../helpers/typescript-ast';
+import {
+  getClassByName,
+  getInterfaceByName,
+  getImportByName,
+  getSourceFileFromImport,
+  getClassMemberByName,
+  getInterfaceMemberByName,
+} from '../helpers/transform-utils';
+import type RehearsalService from '../rehearsal-service';
+
+const OPTIONAL_TOKEN = '?';
+
+export default class FixTransform2790 extends FixTransform {
+  hint = `The operand of a 'delete' operator must be optional.`;
+
+  fix = (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixedFile[] => {
+    const errorNode = findNodeAtPosition(diagnostic.file, diagnostic.start, diagnostic.length);
+    if (
+      !errorNode ||
+      !ts.isPropertyAccessExpression(errorNode) ||
+      !ts.isDeleteExpression(errorNode.parent)
+    ) {
+      return [];
+    }
+
+    const program = service.getLanguageService().getProgram()!;
+    const checker = program.getTypeChecker();
+
+    const type = checker.getTypeAtLocation(errorNode.expression);
+    const typeMemberName = errorNode.name.getFullText(); //'name' as in 'delete person.name' or 'make' as in 'delete car.make';
+    const typeName = type.getSymbol()?.getName().trim(); // 'Person' as in "interface Person" or 'Car' as in 'class Car'
+
+    if (!typeMemberName || !typeName || !type.isClassOrInterface()) {
+      return [];
+    }
+
+    if (type.isClass()) {
+      return updateTextWithOptionalClassMember(diagnostic.file, service, typeMemberName, typeName);
+    }
+    return updateTextWithOptionalTypeMember(diagnostic.file, service, typeMemberName, typeName);
+  };
+}
+
+function optionalTypeMember(
+  sourceFile: ts.SourceFile,
+  declaration: ts.InterfaceDeclaration,
+  typeMemberName: string
+): FixedFile[] {
+  const matchedMember = getInterfaceMemberByName(declaration, typeMemberName);
+
+  if (!matchedMember) {
+    return [];
+  }
+
+  const nameEnd = (matchedMember as ts.PropertySignature).name.getEnd();
+  const updatedText = insertIntoText(sourceFile.getFullText(), nameEnd, OPTIONAL_TOKEN);
+  return [
+    {
+      fileName: sourceFile.fileName,
+      text: updatedText,
+    },
+  ];
+}
+
+function updateTextWithOptionalTypeMember(
+  sourceFile: ts.SourceFile,
+  service: RehearsalService,
+  typeMemberName: string,
+  typeName: string
+): FixedFile[] {
+  const matchedInterface: ts.InterfaceDeclaration | undefined = getInterfaceByName(
+    sourceFile,
+    typeName
+  );
+  const matchedImport: ts.ImportDeclaration | undefined = getImportByName(sourceFile, typeName);
+
+  if (matchedInterface) {
+    return optionalTypeMember(sourceFile, matchedInterface, typeMemberName);
+  } else if (matchedImport) {
+    const importedSourceFile = getSourceFileFromImport(matchedImport, sourceFile.fileName, service);
+
+    if (!importedSourceFile || !ts.isSourceFile(importedSourceFile)) {
+      return [];
+    }
+
+    return updateTextWithOptionalTypeMember(importedSourceFile, service, typeMemberName, typeName);
+  } else {
+    return [];
+  }
+}
+
+function optionalClassMember(
+  sourceFile: ts.SourceFile,
+  matchedClass: ts.ClassDeclaration,
+  typeMemberName: string
+): FixedFile[] {
+  const matchedMember = getClassMemberByName(matchedClass, typeMemberName);
+  if (!matchedMember) {
+    return [];
+  }
+
+  const nameEnd = (matchedMember as ts.PropertyDeclaration).name.getEnd();
+  const updatedText = insertIntoText(sourceFile.getFullText(), nameEnd, OPTIONAL_TOKEN);
+  return [
+    {
+      fileName: sourceFile.fileName,
+      text: updatedText,
+    },
+  ];
+}
+
+function updateTextWithOptionalClassMember(
+  sourceFile: ts.SourceFile,
+  service: RehearsalService,
+  memberName: string,
+  typeName: string
+): FixedFile[] {
+  const matchedClass: ts.ClassDeclaration | undefined = getClassByName(sourceFile, typeName);
+  const matchedImport: ts.ImportDeclaration | undefined = getImportByName(sourceFile, typeName);
+
+  if (matchedClass) {
+    return optionalClassMember(sourceFile, matchedClass, memberName);
+  } else if (matchedImport) {
+    const importedSourceFile = getSourceFileFromImport(matchedImport, sourceFile.fileName, service);
+
+    if (!importedSourceFile || !ts.isSourceFile(importedSourceFile)) {
+      return [];
+    }
+    return updateTextWithOptionalClassMember(importedSourceFile, service, memberName, typeName);
+  } else {
+    return [];
+  }
+}

--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
@@ -55,6 +55,86 @@
       }
     },
     {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "animal.weight",
+      "location": {
+        "start": 180,
+        "length": 13,
+        "line": 8,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "car.color",
+      "location": {
+        "start": 296,
+        "length": 9,
+        "line": 16,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "employee.badgeNumber",
+      "location": {
+        "start": 398,
+        "length": 20,
+        "line": 19,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "person.address",
+      "location": {
+        "start": 621,
+        "length": 14,
+        "line": 33,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "student.gender",
+      "location": {
+        "start": 971,
+        "length": 14,
+        "line": 47,
+        "character": 7
+      }
+    },
+    {
       "file": "6133.ts",
       "code": 6133,
       "category": "Error",

--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
@@ -1,6 +1,6 @@
 ### Summary:
 Typescript Version: 4.5.5
-Files Tested: 5
+Files Tested: 6
 
 ### Results:
 
@@ -17,6 +17,28 @@ Code: `dummy_var`
 **Error TS2322**: NEED TO BE FIXED MANUALLY
 The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type.
 Code: `return 'dummy-string';`
+
+#### File: /2790.ts, issues: 5:
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `animal.weight`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `car.color`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `employee.badgeNumber`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `person.address`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `student.gender`
 
 #### File: /6133.ts, issues: 6:
 

--- a/packages/migrate/test/fixtures/migrate/2790-import-1.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790-import-1.ts.input
@@ -1,0 +1,10 @@
+export interface Animal {
+  species: string;
+  weight: number;
+}
+
+export interface Car {
+  make: string;
+  model: string;
+  color: string;
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-1.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790-import-1.ts.output
@@ -1,0 +1,10 @@
+export interface Animal {
+  species: string;
+  weight?: number;
+}
+
+export interface Car {
+  make: string;
+  model: string;
+  color?: string;
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-2.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790-import-2.ts.input
@@ -1,0 +1,9 @@
+export class Employee {
+  name: string;
+  badgeNumber: string;
+
+  constructor({name, badgeNumber} : { name: string; badgeNumber: string }) {
+    this.name = name;
+    this.badgeNumber = badgeNumber;
+  }
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-2.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790-import-2.ts.output
@@ -1,0 +1,9 @@
+export class Employee {
+  name: string;
+  badgeNumber?: string;
+
+  constructor({ name, badgeNumber }: { name: string; badgeNumber: string }) {
+    this.name = name;
+    this.badgeNumber = badgeNumber;
+  }
+}

--- a/packages/migrate/test/fixtures/migrate/2790.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790.ts.input
@@ -1,0 +1,48 @@
+import { Animal, Car } from './2790-import-1';
+import { Employee } from './2790-import-2';
+
+const animal: Animal = {
+    species: 'dog',
+    weight: 90,
+};
+
+delete animal.weight;
+
+const car: Car = {
+    make: 'Ford',
+    model: 'Focus',
+    color: 'red',
+};
+
+delete car.color;
+
+const employee = new Employee({name: 'Victor', badgeNumber: '12345'});
+delete employee.badgeNumber;
+
+interface Person {
+    name: string;
+    age?: number;
+    address: string | null;
+}
+
+const person:Person = {
+    name: 'Jane',
+    age: 10,
+    address: '123 Happy St'
+};
+
+delete person.address;
+
+class Student{
+    name: string;
+    grade: number;
+    gender: string;
+
+    constructor({name, grade, gender}: { name: string; grade: number; gender: string }) {
+        this.name = name;
+        this.grade = grade;
+        this.gender = gender;
+    }
+}
+const student = new Student({name: '', grade: 3, gender: 'male'});
+delete student.gender;

--- a/packages/migrate/test/fixtures/migrate/2790.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790.ts.output
@@ -1,0 +1,48 @@
+import { Animal, Car } from './2790-import-1';
+import { Employee } from './2790-import-2';
+
+const animal: Animal = {
+  species: 'dog',
+  weight: 90,
+};
+
+delete animal.weight;
+
+const car: Car = {
+  make: 'Ford',
+  model: 'Focus',
+  color: 'red',
+};
+
+delete car.color;
+
+const employee = new Employee({ name: 'Victor', badgeNumber: '12345' });
+delete employee.badgeNumber;
+
+interface Person {
+  name: string;
+  age?: number;
+  address?: string | null;
+}
+
+const person: Person = {
+  name: 'Jane',
+  age: 10,
+  address: '123 Happy St',
+};
+
+delete person.address;
+
+class Student {
+  name: string;
+  grade: number;
+  gender?: string;
+
+  constructor({ name, grade, gender }: { name: string; grade: number; gender: string }) {
+    this.name = name;
+    this.grade = grade;
+    this.gender = gender;
+  }
+}
+const student = new Student({ name: '', grade: 3, gender: 'male' });
+delete student.gender;

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -11,7 +11,16 @@ import migrate from '../src/migrate';
 import Reporter, { Report, pullRequestMd } from '@rehearsal/reporter';
 
 const basePath = resolve(__dirname, 'fixtures', 'migrate');
-const filesNames = ['first.ts', 'react.tsx', 'second.ts', '2322.ts', '6133.ts'];
+const filesNames = [
+  'first.ts',
+  'react.tsx',
+  'second.ts',
+  '2322.ts',
+  '6133.ts',
+  '2790.ts',
+  '2790-import-1.ts',
+  '2790-import-2.ts',
+];
 
 // Append basePath to file names
 const files = filesNames.map((file) => resolve(basePath, file));


### PR DESCRIPTION
Error 2790 is the error we receive when we delete a property on a type or class that's required. The auto fix adopted in this PR is to make the property optional in the type definition or class definition. This PR handles when the type or class is local to the file where the error happens, or when the type or class is imported from a different file. 