### PR TITLE
refactor: Add counter of errors tp the report

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -7,21 +7,31 @@ export function reportFormatter(report: Report): string {
   const fileNames = [
     ...new Set(report.items.map((item) => item.file.replace(report.summary.basePath, ''))),
   ];
-  const uniqueErrors = [...new Set(report.items.map((item) => item.code))];
-  const autofixedErrors = [
-    ...new Set(report.items.map((item) => (item.fixed ? item.code : undefined)).filter(Boolean)),
-  ];
+
+  const fixedErrors: { [key: string]: number } = {};
+  let fixedErrorsCounter = 0;
+
+  const totalErrors: { [key: string]: number } = {};
+  let totalErrorsCounter = 0;
+
+  report.items.forEach((item) => {
+    const fixed = item.fixed ? 1 : 0;
+    fixedErrors[item.code] = (fixedErrors[item.code] || 0) + fixed;
+    fixedErrorsCounter += fixed;
+    totalErrors[item.code] = (totalErrors[item.code] || 0) + 1;
+    totalErrorsCounter += 1;
+  });
 
   // Add statistic info to summary
   report.summary = {
     ...report.summary,
     ...{
       timestamp: new Date().toISOString(),
-      cumulativeErrors: report.items.length,
-      uniqueErrors: uniqueErrors.length,
-      uniqueErrorsList: uniqueErrors,
-      autofixedErrors: autofixedErrors.length,
-      autofixedErrorsList: autofixedErrors,
+      uniqueErrors: Object.keys(totalErrors).length,
+      totalErrors: totalErrorsCounter,
+      totalErrorsList: totalErrors,
+      fixedErrors: fixedErrorsCounter,
+      fixedErrorsList: fixedErrors,
       files: fileNames.length,
       filesList: fileNames,
     },

--- a/packages/cli/test/commands/ts.test.ts
+++ b/packages/cli/test/commands/ts.test.ts
@@ -56,11 +56,17 @@ describe('ts:command against fixture', async () => {
 
     assert.equal(report.summary.projectName, '@rehearsal/cli');
     assert.equal(report.summary.tsVersion, latestPublishedTSVersion);
-    assert.equal(report.summary.cumulativeErrors, 25);
     assert.equal(report.summary.uniqueErrors, 2);
-    assert.deepEqual(report.summary.uniqueErrorsList, [6133, 2322]);
-    assert.equal(report.summary.autofixedErrors, 1);
-    assert.deepEqual(report.summary.autofixedErrorsList, [6133]);
+    assert.equal(report.summary.totalErrors, 25);
+    assert.deepEqual(report.summary.totalErrorsList, {
+      '2322': 1,
+      '6133': 24,
+    });
+    assert.equal(report.summary.fixedErrors, 3);
+    assert.deepEqual(report.summary.fixedErrorsList, {
+      '2322': 0,
+      '6133': 3,
+    });
     assert.equal(report.summary.files, 3);
     assert.deepEqual(report.summary.filesList, [
       '/foo/foo.ts',
@@ -96,7 +102,7 @@ describe('ts:command against fixture', async () => {
 
     expect(ctx.stdout).to.contain(`Autofix successful: ts-expect-error comments added`);
   });
-}).afterEach(afterEachCleanup);
+});
 
 describe('ts:command tsc version check', async () => {
   test.stderr().it(`on typescript invalid tsc_version`, async () => {


### PR DESCRIPTION
Count how many times error was detected:

```
"uniqueErrors": 2,
"totalErrors": 20,
"totalErrorsList": {
  "1016": 15,
  "1192": 5
 } ,
"fixedErrors": 5,
"fixedErrorsList": {
  "1016": 5,
  "1192": 0
 } ,
```