### PR TITLE
fix: Add more use cases for TS2790

### DIFF
--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.json
@@ -112,9 +112,9 @@
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "animal.weight",
       "location": {
-        "start": 180,
+        "start": 265,
         "length": 13,
-        "line": 8,
+        "line": 10,
         "character": 7
       }
     },
@@ -128,9 +128,9 @@
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "car.color",
       "location": {
-        "start": 296,
+        "start": 381,
         "length": 9,
-        "line": 16,
+        "line": 18,
         "character": 7
       }
     },
@@ -144,9 +144,41 @@
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "employee.badgeNumber",
       "location": {
-        "start": 398,
+        "start": 483,
         "length": 20,
-        "line": 19,
+        "line": 21,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "human.height",
+      "location": {
+        "start": 579,
+        "length": 12,
+        "line": 27,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "rabbit.color",
+      "location": {
+        "start": 718,
+        "length": 12,
+        "line": 34,
         "character": 7
       }
     },
@@ -160,9 +192,9 @@
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "person.address",
       "location": {
-        "start": 621,
+        "start": 933,
         "length": 14,
-        "line": 33,
+        "line": 48,
         "character": 7
       }
     },
@@ -176,9 +208,25 @@
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "student.gender",
       "location": {
-        "start": 971,
+        "start": 1283,
         "length": 14,
-        "line": 47,
+        "line": 62,
+        "character": 7
+      }
+    },
+    {
+      "file": "2790.ts",
+      "code": 2790,
+      "category": "Error",
+      "message": "The operand of a 'delete' operator must be optional.",
+      "hint": "The operand of a 'delete' operator must be optional.",
+      "fixed": true,
+      "nodeKind": "PropertyAccessExpression",
+      "nodeText": "oak.height",
+      "location": {
+        "start": 1465,
+        "length": 10,
+        "line": 75,
         "character": 7
       }
     },

--- a/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
+++ b/packages/migrate/test/fixtures/migrate/.rehearsal-report.output.md
@@ -32,7 +32,7 @@ Code: `e`
 Object is of type 'unknown'. Specify a type of dummy, use type assertion: `(dummy as DesiredType)` or type guard: `if (dummy instanceof DesiredType) { ... }`
 Code: `dummy`
 
-#### File: /2790.ts, issues: 5:
+#### File: /2790.ts, issues: 8:
 
 **Error TS2790**: FIXED
 The operand of a 'delete' operator must be optional.
@@ -48,11 +48,23 @@ Code: `employee.badgeNumber`
 
 **Error TS2790**: FIXED
 The operand of a 'delete' operator must be optional.
+Code: `human.height`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `rabbit.color`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
 Code: `person.address`
 
 **Error TS2790**: FIXED
 The operand of a 'delete' operator must be optional.
 Code: `student.gender`
+
+**Error TS2790**: FIXED
+The operand of a 'delete' operator must be optional.
+Code: `oak.height`
 
 #### File: /6133.ts, issues: 6:
 

--- a/packages/migrate/test/fixtures/migrate/2790-import-3.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790-import-3.ts.input
@@ -1,0 +1,9 @@
+export interface Rabbit {
+    color: string;
+    species: string;
+    name: string;
+}
+
+export function feedRabbit(rabbit: Rabbit) {
+    console.log(`Rabbit ${rabbit.name} loves to eat fruit, not hay.`);
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-3.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790-import-3.ts.output
@@ -1,0 +1,9 @@
+export interface Rabbit {
+  color?: string;
+  species: string;
+  name: string;
+}
+
+export function feedRabbit(rabbit: Rabbit) {
+  console.log(`Rabbit ${rabbit.name} loves to eat fruit, not hay.`);
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-4.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790-import-4.ts.input
@@ -1,0 +1,4 @@
+export default interface Human {
+  height: number;
+  weight: number;
+}

--- a/packages/migrate/test/fixtures/migrate/2790-import-4.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790-import-4.ts.output
@@ -1,0 +1,4 @@
+export default interface Human {
+  height?: number;
+  weight: number;
+}

--- a/packages/migrate/test/fixtures/migrate/2790.ts.input
+++ b/packages/migrate/test/fixtures/migrate/2790.ts.input
@@ -1,5 +1,7 @@
 import { Animal, Car } from './2790-import-1';
 import { Employee } from './2790-import-2';
+import * as RabbitStuff from './2790-import-3';
+import Human from './2790-import-4';
 
 const animal: Animal = {
     species: 'dog',
@@ -18,6 +20,19 @@ delete car.color;
 
 const employee = new Employee({name: 'Victor', badgeNumber: '12345'});
 delete employee.badgeNumber;
+
+const human: Human = {
+  weight: 200,
+  height: 180,
+};
+delete human.height;
+
+const rabbit: RabbitStuff.Rabbit = {
+  color: 'butterscotch',
+  species: 'Holland Lop',
+  name: 'Poca',
+};
+delete rabbit.color;
 
 interface Person {
     name: string;
@@ -46,3 +61,16 @@ class Student{
 }
 const student = new Student({name: '', grade: 3, gender: 'male'});
 delete student.gender;
+
+type Tree = {
+  species: string;
+  age: number;
+  height: number;
+}
+
+const oak: Tree = {
+  species: 'oak',
+  age: 150,
+  height: 40,
+};
+delete oak.height;

--- a/packages/migrate/test/fixtures/migrate/2790.ts.output
+++ b/packages/migrate/test/fixtures/migrate/2790.ts.output
@@ -1,5 +1,7 @@
 import { Animal, Car } from './2790-import-1';
 import { Employee } from './2790-import-2';
+import * as RabbitStuff from './2790-import-3';
+import Human from './2790-import-4';
 
 const animal: Animal = {
   species: 'dog',
@@ -18,6 +20,19 @@ delete car.color;
 
 const employee = new Employee({ name: 'Victor', badgeNumber: '12345' });
 delete employee.badgeNumber;
+
+const human: Human = {
+  weight: 200,
+  height: 180,
+};
+delete human.height;
+
+const rabbit: RabbitStuff.Rabbit = {
+  color: 'butterscotch',
+  species: 'Holland Lop',
+  name: 'Poca',
+};
+delete rabbit.color;
 
 interface Person {
   name: string;
@@ -46,3 +61,16 @@ class Student {
 }
 const student = new Student({ name: '', grade: 3, gender: 'male' });
 delete student.gender;
+
+type Tree = {
+  species: string;
+  age: number;
+  height?: number;
+};
+
+const oak: Tree = {
+  species: 'oak',
+  age: 150,
+  height: 40,
+};
+delete oak.height;


### PR DESCRIPTION
This PR adds three use cases for TS2790:
1. ```import XXX from './xxx';```,
2. ```import * as XXX from './xxx';```,
3. ```type XXX = {...};```.

Another change is now we detect if a type is imported by looking at the fully qualified name of the type, and then retrieve the source file from which the type is imported. This way, we avoid the previous recursion where we parse the import declaration and then go to the file from which the type is imported.