### PR TITLE
chore:increase mocha reporter maxDiffSize

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -6,5 +6,6 @@
   "require": "ts-node/register",
   "spec": "test/**/*.test.ts",
   "timeout": 10000,
-  "watch-files": ["test/**/*.test.ts"]
+  "watch-files": ["test/**/*.test.ts"],
+  "reporter-option": ["maxDiffSize=0"]
 }


### PR DESCRIPTION
As we add more test files, we frequently run into this issue: 'output truncated to 8192 characters, see "maxDiffSize" reporter-option' locally and on github. 