### PR TITLE
Chore: enable lint autofix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "build": "yarn tsc -b",
     "docs": "yarn api-extractor run --typescript-compiler-folder ./node_modules/typescript && yarn api-documenter markdown -i ./temp -o ./docs",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "yarn eslint . --ext .ts",
+    "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "oclif:manifest": "yarn oclif-dev manifest",
     "oclif:readme": "yarn oclif-dev readme",

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "yarn tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "yarn eslint . --ext .ts",
+    "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "prepare": "yarn build",
     "test": "yarn nyc mocha"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "yarn tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "yarn eslint . --ext .ts",
+    "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "prepare": "yarn build",
     "test": "yarn nyc mocha"

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "yarn tsc -b",
     "lint": "yarn npm-run-all lint:*",
-    "lint:eslint": "yarn eslint . --ext .ts",
+    "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "prepare": "yarn build",
     "test": "yarn nyc mocha"

--- a/packages/tsc-transforms/package.json
+++ b/packages/tsc-transforms/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "yarn tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "yarn eslint . --ext .ts",
+    "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "prepare": "yarn build",
     "test": "yarn lint && yarn nyc mocha"


### PR DESCRIPTION
This PR enables eslint autofix. By running 'yarn lint', autofixable lint errors will be fixed, saving devs the time to manually reformatting the code. 