### PR TITLE
Fix compilation process to include all modules

### DIFF
--- a/packages/migrate/src/rehearsal-service.ts
+++ b/packages/migrate/src/rehearsal-service.ts
@@ -56,6 +56,11 @@ export class RehearsalServiceHost implements ts.LanguageServiceHost {
   fileExists = ts.sys.fileExists;
   readFile = ts.sys.readFile;
   writeFile = ts.sys.writeFile;
+
+  directoryExists = ts.sys.directoryExists;
+  getDirectories = ts.sys.getDirectories;
+  readDirectory = ts.sys.readDirectory;
+  realpath = ts.sys.realpath;
 }
 
 /**

--- a/packages/migrate/test/fixtures/migrate/tsconfig.json
+++ b/packages/migrate/test/fixtures/migrate/tsconfig.json
@@ -15,6 +15,5 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2017",
-    "types": ["node"],
   },
 }


### PR DESCRIPTION
During the applying a hack I found a, probably, proper solution for the compilation of global types.

These functions are optional by default, but they are used to find typeRoots in the TypeScript compiler. 
![image](https://user-images.githubusercontent.com/1502496/181072923-fd19ec73-9e19-4a8c-a65d-0b073cb7fa13.png)
