### PR TITLE
chore: Move Rehearsal Service out of @rehearsal/migrate

### DIFF
--- a/packages/migrate/src/interfaces/fix-transform.ts
+++ b/packages/migrate/src/interfaces/fix-transform.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type RehearsalService from '../rehearsal-service';
+import type RehearsalService from '@rehearsal/service';
 
 export interface FixedFile {
   fileName: string;

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,9 +1,10 @@
 import ts from 'typescript';
 import winston from 'winston';
 import { dirname, resolve } from 'path';
-import Reporter from '@rehearsal/reporter';
 
-import RehearsalService from './rehearsal-service';
+import Reporter from '@rehearsal/reporter';
+import RehearsalService from '@rehearsal/service';
+
 import {
   DiagnosticAutofixPlugin,
   EmptyLinesPreservePlugin,

--- a/packages/migrate/src/plugins/diagnostics-autofix.plugin.ts
+++ b/packages/migrate/src/plugins/diagnostics-autofix.plugin.ts
@@ -1,5 +1,7 @@
 import ts from 'typescript';
 
+import { Plugin, type PluginParams, type PluginResult } from '@rehearsal/service';
+
 import FixTransform from '../interfaces/fix-transform';
 
 // TODO: Use dynamic import inside getFixForDiagnostic function
@@ -12,7 +14,6 @@ import {
   FixTransform4082,
 } from '../transforms';
 
-import Plugin, { type PluginParams, type PluginResult } from '../interfaces/plugin';
 import { findNodeAtPosition, isJsxTextNode } from '../helpers/typescript-ast';
 
 /**

--- a/packages/migrate/src/plugins/empty-lines-preserve.plugin.ts
+++ b/packages/migrate/src/plugins/empty-lines-preserve.plugin.ts
@@ -1,4 +1,4 @@
-import Plugin, { type PluginParams, type PluginResult } from '../interfaces/plugin';
+import { Plugin, type PluginParams, type PluginResult } from '@rehearsal/service';
 /**
  * Preserves empty line in a multiline string to restore them in EmptyLinesRestorePlugin
  * by using comments with placeholders (:line: comments)

--- a/packages/migrate/src/plugins/empty-lines-restore.plugin.ts
+++ b/packages/migrate/src/plugins/empty-lines-restore.plugin.ts
@@ -1,4 +1,4 @@
-import Plugin, { type PluginParams, type PluginResult } from '../interfaces/plugin';
+import { Plugin, type PluginParams, type PluginResult } from '@rehearsal/service';
 
 /**
  * Replaces empty line placeholders set by EmptyLinesPreservePlugin with real empty lines

--- a/packages/migrate/src/plugins/lint.plugin.ts
+++ b/packages/migrate/src/plugins/lint.plugin.ts
@@ -1,6 +1,6 @@
 import { ESLint } from 'eslint';
 
-import Plugin, { type PluginParams, type PluginResult } from '../interfaces/plugin';
+import { Plugin, type PluginParams, type PluginResult } from '@rehearsal/service';
 
 /**
  * Lint the text

--- a/packages/migrate/src/transforms/2345-fix-transform.ts
+++ b/packages/migrate/src/transforms/2345-fix-transform.ts
@@ -1,10 +1,10 @@
 import ts from 'typescript';
 
+import type RehearsalService from '@rehearsal/service';
 import { getTypeNameFromVariable } from '@rehearsal/utils';
 
 import FixTransform, { type FixedFile } from '../interfaces/fix-transform';
 import { findNodeAtPosition } from '../helpers/typescript-ast';
-import type RehearsalService from '../rehearsal-service';
 
 export default class FixTransform2345 extends FixTransform {
   hint = `Argument of type '{0}' is not assignable to parameter of type '{1}'.`;

--- a/packages/migrate/src/transforms/2571-fix-transform.ts
+++ b/packages/migrate/src/transforms/2571-fix-transform.ts
@@ -1,5 +1,7 @@
-import FixTransform, { FixedFile } from '../interfaces/fix-transform';
 import ts from 'typescript';
+
+import FixTransform, { type FixedFile } from '../interfaces/fix-transform';
+
 import { isVariableOfCatchClause, transformDiagnosedNode } from '../helpers/typescript-ast';
 import { isSourceCodeChanged } from '../helpers/strings';
 

--- a/packages/migrate/src/transforms/2790-fix-transform.ts
+++ b/packages/migrate/src/transforms/2790-fix-transform.ts
@@ -1,5 +1,9 @@
 import ts from 'typescript';
 
+import type RehearsalService from '@rehearsal/service';
+
+import FixTransform, { type FixedFile } from '../interfaces/fix-transform';
+
 import {
   getClassByName,
   getInterfaceByName,
@@ -11,9 +15,7 @@ import {
   getTypeDeclarationFromTypeSymbol,
 } from '@rehearsal/utils';
 
-import FixTransform, { FixedFile } from '../interfaces/fix-transform';
 import { findNodeAtPosition, insertIntoText } from '../helpers/typescript-ast';
-import type RehearsalService from '../rehearsal-service';
 
 const OPTIONAL_TOKEN = '?';
 

--- a/packages/migrate/src/transforms/4082-fix-transform.ts
+++ b/packages/migrate/src/transforms/4082-fix-transform.ts
@@ -1,10 +1,10 @@
 import ts from 'typescript';
 
+import type RehearsalService from '@rehearsal/service';
 import { isSubtypeOf, getTypeDeclarationFromTypeSymbol, isTypeMatched } from '@rehearsal/utils';
 
-import FixTransform, { FixedFile } from '../interfaces/fix-transform';
+import FixTransform, { type FixedFile } from '../interfaces/fix-transform';
 import { findNodeAtPosition, insertIntoText } from '../helpers/typescript-ast';
-import type RehearsalService from '../rehearsal-service';
 
 const EXPORT_KEYWORD = 'export';
 export default class FixTransform4082 extends FixTransform {

--- a/packages/migrate/src/transforms/6133-fix-transform.ts
+++ b/packages/migrate/src/transforms/6133-fix-transform.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 
-import FixTransform, { FixedFile } from '../interfaces/fix-transform';
+import FixTransform, { type FixedFile } from '../interfaces/fix-transform';
+
 import { isSourceCodeChanged } from '../helpers/strings';
 import { transformDiagnosedNode } from '../helpers/typescript-ast';
 

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -1,0 +1,3 @@
+# @rehearsal/service
+
+Rehearsal Service provides access to project's files and helps to run plugins to transform their source code.

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@rehearsal/migrate",
+  "name": "@rehearsal/service",
   "version": "0.0.27",
-  "description": "Rehearsal Migration Tool",
+  "description": "Rehearsal Service",
   "keywords": [
-    "migrate",
-    "migration",
     "rehearsal",
+    "service",
+    "ast",
+    "transforms",
     "typescript"
   ],
   "repository": {
@@ -21,7 +22,7 @@
   ],
   "scripts": {
     "build": "yarn tsc -b",
-    "lint": "npm-run-all lint:*",
+    "lint": "yarn npm-run-all lint:*",
     "lint:eslint": "yarn eslint --fix . --ext .ts",
     "lint:tsc-src": "yarn tsc --noEmit",
     "prepare": "yarn build",
@@ -29,9 +30,6 @@
   },
   "dependencies": {
     "@rehearsal/reporter": "^0.0.27",
-    "@rehearsal/service": "^0.0.27",
-    "@rehearsal/utils": "^0.0.27",
-    "eslint": "^8.11.0",
     "winston": "^3.6.0"
   },
   "devDependencies": {
@@ -39,7 +37,7 @@
     "@types/eslint": "^8.4.1",
     "@types/mocha": "^9.1.0",
     "@types/node": "^18.0.3",
-    "@types/react": "^18.0.9",
+    "eslint": "^8.11.0",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0"

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,0 +1,7 @@
+export { RehearsalService as default } from './rehearsal-service';
+
+export { Plugin } from './plugin';
+export { RehearsalService } from './rehearsal-service';
+export { RehearsalServiceHost } from './rehearsal-service-host';
+
+export type { PluginOptions, PluginParams, PluginResult } from './plugin';

--- a/packages/service/src/plugin.ts
+++ b/packages/service/src/plugin.ts
@@ -1,17 +1,9 @@
 import winston from 'winston';
 import Reporter from '@rehearsal/reporter';
-import RehearsalService from '../rehearsal-service';
 
-export type PluginOptions = Record<string, unknown> | undefined;
+import { RehearsalService } from './rehearsal-service';
 
-export type PluginParams<PluginOptions> = {
-  fileName: string;
-  options?: PluginOptions;
-};
-
-export type PluginResult = Promise<string[]>;
-
-export default class Plugin {
+export class Plugin {
   protected readonly logger?: winston.Logger;
   protected readonly reporter?: Reporter;
   protected readonly service: RehearsalService;
@@ -26,3 +18,12 @@ export default class Plugin {
     return [params.fileName];
   }
 }
+
+export type PluginOptions = Record<string, unknown> | undefined;
+
+export type PluginParams<PluginOptions> = {
+  fileName: string;
+  options?: PluginOptions;
+};
+
+export type PluginResult = Promise<string[]>;

--- a/packages/service/src/rehearsal-service-host.ts
+++ b/packages/service/src/rehearsal-service-host.ts
@@ -1,0 +1,64 @@
+import ts from 'typescript';
+
+/**
+ * ServiceHost represents the layer between the LanguageServer and the permanent storage.
+ *
+ * The host provides access to versioned snapshot of source file - the state of file
+ * in the current moment of time.
+ *
+ * The host keeps snapshots in memory and saves them to filesystem calling saveFile().
+ */
+export class RehearsalServiceHost implements ts.LanguageServiceHost {
+  private readonly compilerOptions: ts.CompilerOptions;
+  private readonly currentDirectory: string;
+  private readonly fileNames: string[];
+  private readonly files: ts.MapLike<{ snapshot: ts.IScriptSnapshot; version: number }> = {};
+
+  constructor(compilerOptions: ts.CompilerOptions, fileNames: string[]) {
+    this.compilerOptions = compilerOptions;
+    this.currentDirectory = process.cwd();
+    this.fileNames = fileNames;
+  }
+
+  /**
+   * Updates a snapshot state in memory and increases its version.
+   */
+  setScriptSnapshot(fileName: string, snapshot: ts.IScriptSnapshot): ts.IScriptSnapshot {
+    this.files[fileName] = {
+      snapshot: snapshot,
+      version: this.files[fileName]?.version + 1 || 0,
+    };
+
+    return this.files[fileName].snapshot;
+  }
+
+  /**
+   * Gets the latest snapshot
+   * If a snapshot doesn't exist yet - reads its content from file as the first version
+   */
+  getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
+    if (!(fileName in this.files) && this.fileExists(fileName)) {
+      const text = this.readFile(fileName);
+      if (text !== undefined) {
+        this.setScriptSnapshot(fileName, ts.ScriptSnapshot.fromString(text));
+      }
+    }
+
+    return this.files[fileName].snapshot;
+  }
+
+  getCompilationSettings = (): ts.CompilerOptions => this.compilerOptions;
+  getCurrentDirectory = (): string => this.currentDirectory;
+  getDefaultLibFileName = (o: ts.CompilerOptions): string => ts.getDefaultLibFilePath(o);
+  getScriptFileNames = (): string[] => this.fileNames;
+  getScriptVersion = (fileName: string): string => this.files[fileName]?.version.toString() || '0';
+
+  fileExists = ts.sys.fileExists;
+  readFile = ts.sys.readFile;
+  writeFile = ts.sys.writeFile;
+
+  directoryExists = ts.sys.directoryExists;
+  getDirectories = ts.sys.getDirectories;
+  readDirectory = ts.sys.readDirectory;
+  realpath = ts.sys.realpath;
+}

--- a/packages/service/src/rehearsal-service.ts
+++ b/packages/service/src/rehearsal-service.ts
@@ -1,73 +1,12 @@
 import ts from 'typescript';
 
-/**
- * ServiceHost represents the layer between the LanguageServer and the permanent storage.
- *
- * The host provides access to versioned snapshot of source file - the state of file
- * in the current moment of time.
- *
- * The host keeps snapshots in memory and saves them to filesystem calling saveFile().
- */
-export class RehearsalServiceHost implements ts.LanguageServiceHost {
-  private readonly compilerOptions: ts.CompilerOptions;
-  private readonly currentDirectory: string;
-  private readonly fileNames: string[];
-  private readonly files: ts.MapLike<{ snapshot: ts.IScriptSnapshot; version: number }> = {};
-
-  constructor(compilerOptions: ts.CompilerOptions, fileNames: string[]) {
-    this.compilerOptions = compilerOptions;
-    this.currentDirectory = process.cwd();
-    this.fileNames = fileNames;
-  }
-
-  /**
-   * Updates a snapshot state in memory and increases its version.
-   */
-  setScriptSnapshot(fileName: string, snapshot: ts.IScriptSnapshot): ts.IScriptSnapshot {
-    this.files[fileName] = {
-      snapshot: snapshot,
-      version: this.files[fileName]?.version + 1 || 0,
-    };
-
-    return this.files[fileName].snapshot;
-  }
-
-  /**
-   * Gets the latest snapshot
-   * If a snapshot doesn't exist yet - reads its content from file as the first version
-   */
-  getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
-    if (!(fileName in this.files) && this.fileExists(fileName)) {
-      const text = this.readFile(fileName);
-      if (text !== undefined) {
-        this.setScriptSnapshot(fileName, ts.ScriptSnapshot.fromString(text));
-      }
-    }
-
-    return this.files[fileName].snapshot;
-  }
-
-  getCompilationSettings = (): ts.CompilerOptions => this.compilerOptions;
-  getCurrentDirectory = (): string => this.currentDirectory;
-  getDefaultLibFileName = (o: ts.CompilerOptions): string => ts.getDefaultLibFilePath(o);
-  getScriptFileNames = (): string[] => this.fileNames;
-  getScriptVersion = (fileName: string): string => this.files[fileName]?.version.toString() || '0';
-
-  fileExists = ts.sys.fileExists;
-  readFile = ts.sys.readFile;
-  writeFile = ts.sys.writeFile;
-
-  directoryExists = ts.sys.directoryExists;
-  getDirectories = ts.sys.getDirectories;
-  readDirectory = ts.sys.readDirectory;
-  realpath = ts.sys.realpath;
-}
+import { RehearsalServiceHost } from './rehearsal-service-host';
 
 /**
  * Service represents the list of helper functions wrapped over compiled program context.
  * Service helps to get diagnostics and work with source files content (through ServiceHost).
  */
-export default class RehearsalService {
+export class RehearsalService {
   protected readonly host: RehearsalServiceHost;
   protected readonly service: ts.LanguageService;
 

--- a/packages/service/test/fixtures/dummy.ts
+++ b/packages/service/test/fixtures/dummy.ts
@@ -1,0 +1,3 @@
+class Dummy {
+  
+}

--- a/packages/service/test/rehearsal-service.test.ts
+++ b/packages/service/test/rehearsal-service.test.ts
@@ -1,0 +1,94 @@
+import ts from 'typescript';
+import fs from 'fs';
+
+import { assert, expect } from 'chai';
+import { describe, it } from 'mocha';
+import { resolve } from 'path';
+
+import { RehearsalService } from '../src';
+
+const basePath = resolve(__dirname, 'fixtures');
+const fileName = resolve(basePath, 'dummy.ts');
+const fileNames = [fileName];
+const originalFileContent = fs.readFileSync(fileName).toString();
+
+const options: ts.CompilerOptions = {};
+
+describe('Test service', function () {
+  it('construct', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    assert.exists(service);
+    assert.exists(service.getLanguageService());
+  });
+
+  it('getFileText', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    expect(function () {
+      service.getFileText('oops.ts');
+    }).to.throw("Cannot read properties of undefined (reading 'snapshot')");
+
+    assert.equal(service.getFileText(fileName), originalFileContent);
+  });
+
+  it('setFileText', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    service.setFileText(fileName, 'class Real {\n  \n}\n');
+
+    assert.equal(service.getFileText(fileName), 'class Real {\n  \n}\n');
+  });
+
+  it('setFileText', async () => {
+    const service = new RehearsalService(options, fileNames);
+    const originalContent = fs.readFileSync(fileName).toString();
+
+    service.setFileText(fileName, 'class Real {\n  \n}\n');
+
+    assert.equal(fs.readFileSync(fileName).toString(), originalFileContent);
+
+    service.saveFile(fileName);
+
+    assert.equal(fs.readFileSync(fileName).toString(), 'class Real {\n  \n}\n');
+
+    fs.writeFileSync(fileName, originalContent);
+
+    assert.equal(fs.readFileSync(fileName).toString(), originalFileContent);
+  });
+
+  it('getSourceFile', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    assert.equal(service.getSourceFile('oops'), undefined);
+
+    assert.exists(service.getSourceFile(fileName));
+    assert.equal(service.getSourceFile(fileName).text, originalFileContent);
+  });
+
+  it('getSemanticDiagnosticsWithLocation', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    let diagnostics: ts.DiagnosticWithLocation[];
+
+    diagnostics = service.getSemanticDiagnosticsWithLocation(fileName);
+
+    assert.equal(diagnostics.length, 0);
+
+    // Add error to the file content
+    service.setFileText(fileName, 'class Dummy {\n  \n}\n oops();\n');
+    diagnostics = service.getSemanticDiagnosticsWithLocation(fileName);
+
+    assert.equal(diagnostics.length, 1);
+    assert.equal(diagnostics[0].code, 2304);
+    assert.equal(diagnostics[0].messageText, `Cannot find name 'oops'.`);
+  });
+
+  it('resolveModuleName', async () => {
+    const service = new RehearsalService(options, fileNames);
+
+    const path = service.resolveModuleName('path', fileName);
+
+    assert.equal(path, undefined);
+  });
+});

--- a/packages/service/test/tsconfig.json
+++ b/packages/service/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../",
+    "outDir": "../dist/test/"
+  },
+  "include": [
+    "./", "../src"]
+}

--- a/packages/service/tsconfig.json
+++ b/packages/service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Make service available to use outside of migrate.
Will make Service to be responsible of running plugins later.