### PR TITLE
chore: Refactor Reporter: better naming and no default exports

### DIFF
--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -8,7 +8,7 @@ import { resolve } from 'path';
 
 import migrate from '../src/migrate';
 
-import Reporter, { Report, pullRequestMd } from '@rehearsal/reporter';
+import Reporter, { Report, mdFormatter } from '@rehearsal/reporter';
 
 const basePath = resolve(__dirname, 'fixtures', 'migrate');
 
@@ -48,7 +48,7 @@ describe('Test migration', function () {
 
     // Test the pull-request-md report
     const mdReport = resolve(basePath, '.rehearsal-report.md');
-    reporter.print(mdReport, pullRequestMd);
+    reporter.print(mdReport, mdFormatter);
 
     assert.equal(
       fs.readFileSync(mdReport).toString(),

--- a/packages/reporter/src/formatters/json-formatter.ts
+++ b/packages/reporter/src/formatters/json-formatter.ts
@@ -1,5 +1,5 @@
 import { Report } from '../types';
 
-export function json(report: Report): string {
+export function jsonFormatter(report: Report): string {
   return JSON.stringify(report, null, 2);
 }

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -1,6 +1,6 @@
 import { Report } from '../types';
 
-export function pullRequestMd(report: Report): string {
+export function mdFormatter(report: Report): string {
   const fileNames = [...new Set(report.items.map((item) => item.file))];
 
   let text = ``;

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -1,6 +1,7 @@
-export { default } from './reporter';
+export { Reporter as default } from './reporter';
 
-export { json } from './formatters/json';
-export { pullRequestMd } from './formatters/pull-request-md';
+export { Reporter } from './reporter';
+export { jsonFormatter } from './formatters/json-formatter';
+export { mdFormatter } from './formatters/md-formatter';
 
 export type { Report, ReportItem, ReportSummary } from './types';

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 import ts from 'typescript';
 import winston from 'winston';
-import { Report, ReportItem } from './types';
+
+import { type Report, type ReportItem } from './types';
 
 /**
  * Representation of diagnostic and migration report.
  */
-export default class Reporter {
+export class Reporter {
   readonly basePath: string;
 
   private report: Report;

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -4,9 +4,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import { resolve } from 'path';
 
-import Reporter from '../src/reporter';
-
-import { Report } from '../src';
+import { Reporter, Report } from '../src';
 
 const basePath = resolve(__dirname, 'fixtures');
 


### PR DESCRIPTION
Remove default export
Rename pullRequestMd to mdFormatter, because it just an example of md formatter (not specifically for PRs) 