### PR TITLE
refactor: expose more transform data for sarif reporting

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -5,7 +5,7 @@ import { Report } from '@rehearsal/reporter';
  */
 export function reportFormatter(report: Report): string {
   const fileNames = [
-    ...new Set(report.items.map((item) => item.file.replace(report.summary.basePath, ''))),
+    ...new Set(report.items.map((item) => item.analysisTarget.replace(report.summary.basePath, ''))),
   ];
 
   const fixedErrors: { [key: string]: number } = {};

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -1,7 +1,7 @@
 import { Report } from '../types';
 
 export function mdFormatter(report: Report): string {
-  const fileNames = [...new Set(report.items.map((item) => item.file))];
+  const fileNames = [...new Set(report.items.map((item) => item.analysisTarget))];
 
   let text = ``;
 
@@ -12,7 +12,7 @@ export function mdFormatter(report: Report): string {
   text += `### Results:\n`;
 
   for (const fileName of fileNames) {
-    const items = report.items.filter((item) => item.file === fileName);
+    const items = report.items.filter((item) => item.analysisTarget === fileName);
     const relativeFileName = fileName.replace(report.summary.basePath, '');
 
     text += `\n`;

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -6,7 +6,9 @@ export type ReportSummary = Record<string, unknown> & {
 };
 
 export type ReportItem = {
-  file: string;
+  analysisTarget: string;
+  fixedFiles: FixedFile[];
+  commentedFiles: FixedFile[];
   code: number;
   category: string;
   message: string;
@@ -14,7 +16,7 @@ export type ReportItem = {
   fixed?: boolean;
   nodeKind?: string;
   nodeText?: string;
-  location: {
+  nodeLocation: {
     start: number;
     length: number;
     line: number;
@@ -26,3 +28,17 @@ export type Report = {
   summary: ReportSummary;
   items: ReportItem[];
 };
+
+interface FixedFile {
+  fileName: string;
+  updatedText?: string;
+  location: {
+    line: number;
+    character: number;
+  };
+}
+
+export interface FixResult {
+  fixedFiles: FixedFile[];
+  commentedFiles: FixedFile[];
+}

--- a/packages/reporter/test/fixtures/.rehearsal-report.input.json
+++ b/packages/reporter/test/fixtures/.rehearsal-report.input.json
@@ -7,36 +7,56 @@
   },
   "items": [
     {
-      "file": "first.ts",
-      "code": 6133,
       "category": "Error",
-      "message": "'fs' is declared but its value is never read.",
-      "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
+      "fixedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
+      "code": 6133,
+      "analysisTarget": "first.ts",
       "fixed": true,
-      "nodeKind": "ImportDeclaration",
-      "nodeText": "import fs from 'fs';",
-      "location": {
-        "start": 0,
+      "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
+      "nodeLocation": {
+        "character": 0,
         "length": 20,
         "line": 0,
-        "character": 0
-      }
+        "start": 0
+      },
+      "message": "'fs' is declared but its value is never read.",
+      "nodeKind": "ImportDeclaration",
+      "nodeText": "import fs from 'fs';"
     },
     {
-      "file": "second.ts",
-      "code": 6133,
       "category": "Error",
-      "message": "'parse' is declared but its value is never read.",
-      "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
+      "fixedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
+      "code": 6133,
+      "analysisTarget": "second.ts",
       "fixed": true,
-      "nodeKind": "ImportSpecifier",
-      "nodeText": "parse",
-      "location": {
-        "start": 18,
+      "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
+      "nodeLocation": {
+        "character": 18,
         "length": 5,
         "line": 0,
-        "character": 18
-      }
+        "start": 18
+      },
+      "message": "'parse' is declared but its value is never read.",
+      "nodeKind": "ImportSpecifier",
+      "nodeText": "parse"
     }
   ]
 }

--- a/packages/reporter/test/fixtures/.rehearsal-report.output.json
+++ b/packages/reporter/test/fixtures/.rehearsal-report.output.json
@@ -7,36 +7,56 @@
   },
   "items": [
     {
-      "file": "first.ts",
-      "code": 6133,
       "category": "Error",
-      "message": "'fs' is declared but its value is never read.",
-      "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
+      "fixedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
+      "code": 6133,
+      "analysisTarget": "first.ts",
       "fixed": true,
-      "nodeKind": "ImportDeclaration",
-      "nodeText": "import fs from 'fs';",
-      "location": {
-        "start": 0,
+      "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
+      "nodeLocation": {
+        "character": 0,
         "length": 20,
         "line": 0,
-        "character": 0
-      }
+        "start": 0
+      },
+      "message": "'fs' is declared but its value is never read.",
+      "nodeKind": "ImportDeclaration",
+      "nodeText": "import fs from 'fs';"
     },
     {
-      "file": "second.ts",
-      "code": 6133,
       "category": "Error",
-      "message": "'parse' is declared but its value is never read.",
-      "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
+      "fixedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
+      "code": 6133,
+      "analysisTarget": "second.ts",
       "fixed": true,
-      "nodeKind": "ImportSpecifier",
-      "nodeText": "parse",
-      "location": {
-        "start": 18,
+      "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
+      "nodeLocation": {
+        "character": 18,
         "length": 5,
         "line": 0,
-        "character": 18
-      }
+        "start": 18
+      },
+      "message": "'parse' is declared but its value is never read.",
+      "nodeKind": "ImportSpecifier",
+      "nodeText": "parse"
     }
   ]
 }

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -50,14 +50,24 @@ describe('Test reporter', function () {
       resolve(basePath, '.rehearsal-report.input.json')
     );
 
-    assert.deepEqual(reporter.getItemsByFile('first.ts'), [
+    assert.deepEqual(reporter.getItemsByAnalysisTarget('first.ts'), [
       {
         category: 'Error',
+        fixedFiles: [
+          {
+            fileName: 'first.ts',
+            location: {
+              line: 0,
+              character: 0,
+            },
+          },
+        ],
+        commentedFiles: [],
         code: 6133,
-        file: 'first.ts',
+        analysisTarget: 'first.ts',
         fixed: true,
         hint: "The declaration 'fs' is never read or used. Remove the declaration or use it.",
-        location: {
+        nodeLocation: {
           character: 0,
           length: 20,
           line: 0,
@@ -69,14 +79,24 @@ describe('Test reporter', function () {
       },
     ]);
 
-    assert.deepEqual(reporter.getItemsByFile('second.ts'), [
+    assert.deepEqual(reporter.getItemsByAnalysisTarget('second.ts'), [
       {
         category: 'Error',
+        fixedFiles: [
+          {
+            fileName: 'second.ts',
+            location: {
+              line: 0,
+              character: 0,
+            },
+          },
+        ],
+        commentedFiles: [],
         code: 6133,
-        file: 'second.ts',
+        analysisTarget: 'second.ts',
         fixed: true,
         hint: "The declaration 'parse' is never read or used. Remove the declaration or use it.",
-        location: {
+        nodeLocation: {
           character: 18,
           length: 5,
           line: 0,

--- a/packages/upgrade/src/helpers/transform-utils.ts
+++ b/packages/upgrade/src/helpers/transform-utils.ts
@@ -1,0 +1,40 @@
+import ts from 'typescript';
+import { type FixResult } from '../interfaces/fix-transform';
+
+export function getCommentsOnlyResult(diagnostic: ts.DiagnosticWithLocation): FixResult {
+  const { file, start } = diagnostic;
+  const { line, character } = ts.getLineAndCharacterOfPosition(file, start);
+  return {
+    fixedFiles: [],
+    commentedFiles: [
+      {
+        fileName: file.fileName,
+        location: {
+          line,
+          character,
+        },
+      },
+    ],
+  };
+}
+
+export function getCodemodResult(
+  modifiedSourceFile: ts.SourceFile,
+  updatedText: string,
+  insertionPos: number
+): FixResult {
+  const { line, character } = ts.getLineAndCharacterOfPosition(modifiedSourceFile, insertionPos);
+  return {
+    fixedFiles: [
+      {
+        fileName: modifiedSourceFile.fileName,
+        updatedText,
+        location: {
+          line,
+          character,
+        },
+      },
+    ],
+    commentedFiles: [],
+  };
+}

--- a/packages/upgrade/src/interfaces/fix-transform.ts
+++ b/packages/upgrade/src/interfaces/fix-transform.ts
@@ -1,9 +1,19 @@
 import ts from 'typescript';
 import { type RehearsalService } from '@rehearsal/service';
+import { getCommentsOnlyResult } from '../helpers/transform-utils';
 
 export interface FixedFile {
   fileName: string;
-  text: string;
+  updatedText?: string;
+  location: {
+    line: number;
+    character: number;
+  };
+}
+
+export interface FixResult {
+  fixedFiles: FixedFile[];
+  commentedFiles: FixedFile[];
 }
 
 export class FixTransform {
@@ -11,9 +21,9 @@ export class FixTransform {
   hint?: string;
 
   /** Function to fix the diagnostic issue */
-  fix?: (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService) => FixedFile[];
+  fix?: (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService) => FixResult;
 
-  run(diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixedFile[] {
-    return this.fix ? this.fix(diagnostic, service) : [];
+  run(diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixResult {
+    return this.fix ? this.fix(diagnostic, service) : getCommentsOnlyResult(diagnostic);
   }
 }

--- a/packages/upgrade/src/transforms/2322-fix-transform.ts
+++ b/packages/upgrade/src/transforms/2322-fix-transform.ts
@@ -1,13 +1,14 @@
 import ts from 'typescript';
 
-import { FixTransform, type FixedFile } from '../interfaces/fix-transform';
+import { FixTransform, type FixResult } from '../interfaces/fix-transform';
+import { getCommentsOnlyResult } from '../helpers/transform-utils';
 
 import { transformDiagnosedNode } from '../helpers/typescript-ast';
 
 export class FixTransform2322 extends FixTransform {
   hint = `Type '{0}' is being returned or assigned, but type '{1}' is expected. Please convert type '{0}' to type '{1}', or return or assign a variable of type '{1}'`;
 
-  fix = (diagnostic: ts.DiagnosticWithLocation): FixedFile[] => {
+  fix = (diagnostic: ts.DiagnosticWithLocation): FixResult => {
     transformDiagnosedNode(diagnostic, (node: ts.Node) => {
       if (ts.isReturnStatement(node)) {
         this.hint = `The function expects to return '{1}', but '{0}' is returned. Please convert '{0}' value to '{1}' or update the function's return type.`;
@@ -16,7 +17,6 @@ export class FixTransform2322 extends FixTransform {
       }
       return node;
     });
-
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   };
 }

--- a/packages/upgrade/src/transforms/2345-fix-transform.ts
+++ b/packages/upgrade/src/transforms/2345-fix-transform.ts
@@ -3,16 +3,17 @@ import ts from 'typescript';
 import { type RehearsalService } from '@rehearsal/service';
 import { getTypeNameFromVariable } from '@rehearsal/utils';
 
-import { FixTransform, type FixedFile } from '../interfaces/fix-transform';
+import { FixTransform, type FixResult } from '../interfaces/fix-transform';
+import { getCommentsOnlyResult } from '../helpers/transform-utils';
 import { findNodeAtPosition } from '../helpers/typescript-ast';
 
 export class FixTransform2345 extends FixTransform {
   hint = `Argument of type '{0}' is not assignable to parameter of type '{1}'.`;
 
-  fix = (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixedFile[] => {
+  fix = (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixResult => {
     const errorNode = findNodeAtPosition(diagnostic.file, diagnostic.start, diagnostic.length);
     if (!errorNode || !ts.isIdentifier(errorNode)) {
-      return [];
+      return getCommentsOnlyResult(diagnostic);
     }
     const variableName = errorNode.getFullText();
 
@@ -30,6 +31,6 @@ export class FixTransform2345 extends FixTransform {
         ` Consider verifying both types, using type assertion: '(${variableName} as string)', or using type guard: 'if (${variableName} instanceof string) { ... }'.`;
     }
 
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   };
 }

--- a/packages/upgrade/src/transforms/2571-fix-transform.ts
+++ b/packages/upgrade/src/transforms/2571-fix-transform.ts
@@ -1,14 +1,15 @@
 import ts from 'typescript';
 
-import { FixTransform, type FixedFile } from '../interfaces/fix-transform';
+import { FixTransform, type FixResult } from '../interfaces/fix-transform';
 
 import { isVariableOfCatchClause, transformDiagnosedNode } from '../helpers/typescript-ast';
 import { isSourceCodeChanged } from '../helpers/strings';
+import { getCommentsOnlyResult, getCodemodResult } from '../helpers/transform-utils';
 
 export class FixTransform2571 extends FixTransform {
   hint = `Object is of type '{0}'. Specify a type of variable, use type assertion: \`(variable as DesiredType)\` or type guard: \`if (variable instanceof DesiredType) { ... }\``;
 
-  fix = (diagnostic: ts.DiagnosticWithLocation): FixedFile[] => {
+  fix = (diagnostic: ts.DiagnosticWithLocation): FixResult => {
     const text = transformDiagnosedNode(diagnostic, (node: ts.Node) => {
       if (ts.isIdentifier(node) && isVariableOfCatchClause(node)) {
         if (isPropertyOfErrorInterface(node.parent)) {
@@ -24,8 +25,10 @@ export class FixTransform2571 extends FixTransform {
     });
 
     const hasChanged = isSourceCodeChanged(diagnostic.file.getFullText(), text);
-
-    return hasChanged ? [{ fileName: diagnostic.file.fileName, text }] : [];
+    if (hasChanged) {
+      return getCodemodResult(diagnostic.file, text, diagnostic.start);
+    }
+    return getCommentsOnlyResult(diagnostic);
   };
 }
 

--- a/packages/upgrade/src/transforms/2790-fix-transform.ts
+++ b/packages/upgrade/src/transforms/2790-fix-transform.ts
@@ -2,7 +2,8 @@ import ts from 'typescript';
 
 import { type RehearsalService } from '@rehearsal/service';
 
-import { FixTransform, type FixedFile } from '../interfaces/fix-transform';
+import { FixTransform, type FixResult } from '../interfaces/fix-transform';
+import { getCommentsOnlyResult, getCodemodResult } from '../helpers/transform-utils';
 
 import {
   getClassByName,
@@ -22,14 +23,14 @@ const OPTIONAL_TOKEN = '?';
 export class FixTransform2790 extends FixTransform {
   hint = `The operand of a 'delete' operator must be optional.`;
 
-  fix = (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixedFile[] => {
+  fix = (diagnostic: ts.DiagnosticWithLocation, service: RehearsalService): FixResult => {
     const errorNode = findNodeAtPosition(diagnostic.file, diagnostic.start, diagnostic.length);
     if (
       !errorNode ||
       !ts.isPropertyAccessExpression(errorNode) ||
       !ts.isDeleteExpression(errorNode.parent)
     ) {
-      return [];
+      return getCommentsOnlyResult(diagnostic);
     }
 
     const program = service.getLanguageService().getProgram()!;
@@ -39,7 +40,7 @@ export class FixTransform2790 extends FixTransform {
 
     const typeDeclaration = getTypeDeclarationFromTypeSymbol(type);
     if (!typeDeclaration) {
-      return [];
+      return getCommentsOnlyResult(diagnostic);
     }
 
     const sourceFile = typeDeclaration.getSourceFile();
@@ -48,21 +49,22 @@ export class FixTransform2790 extends FixTransform {
     const typeMemberName = errorNode.name.getFullText(); //'name' as in 'delete person.name' or 'make' as in 'delete car.make';
 
     if (!typeMemberName || !typeName || !sourceFile) {
-      return [];
+      return getCommentsOnlyResult(diagnostic);
     }
 
     if (type.isClass()) {
-      return updateTextWithOptionalClassMember(sourceFile, typeMemberName, typeName);
+      return updateTextWithOptionalClassMember(diagnostic, sourceFile, typeMemberName, typeName);
     }
-    return updateTextWithOptionalTypeMember(sourceFile, typeMemberName, typeName);
+    return updateTextWithOptionalTypeMember(diagnostic, sourceFile, typeMemberName, typeName);
   };
 }
 
 function optionalTypeMember(
+  diagnostic: ts.DiagnosticWithLocation,
   sourceFile: ts.SourceFile,
   declaration: ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   typeMemberName: string
-): FixedFile[] {
+): FixResult {
   let matchedMember;
   if (ts.isInterfaceDeclaration(declaration)) {
     matchedMember = getInterfaceMemberByName(declaration, typeMemberName);
@@ -71,24 +73,20 @@ function optionalTypeMember(
   }
 
   if (!matchedMember) {
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   }
 
   const nameEnd = (matchedMember as ts.PropertySignature).name.getEnd();
   const updatedText = insertIntoText(sourceFile.getFullText(), nameEnd, OPTIONAL_TOKEN);
-  return [
-    {
-      fileName: sourceFile.fileName,
-      text: updatedText,
-    },
-  ];
+  return getCodemodResult(sourceFile, updatedText, nameEnd);
 }
 
 function updateTextWithOptionalTypeMember(
+  diagnostic: ts.DiagnosticWithLocation,
   sourceFile: ts.SourceFile,
   typeMemberName: string,
   typeName: string
-): FixedFile[] {
+): FixResult {
   const matchedInterface: ts.InterfaceDeclaration | undefined = getInterfaceByName(
     sourceFile,
     typeName
@@ -99,44 +97,41 @@ function updateTextWithOptionalTypeMember(
   );
 
   if (matchedInterface) {
-    return optionalTypeMember(sourceFile, matchedInterface, typeMemberName);
+    return optionalTypeMember(diagnostic, sourceFile, matchedInterface, typeMemberName);
   } else if (matchedTypeAlias) {
-    return optionalTypeMember(sourceFile, matchedTypeAlias, typeMemberName);
+    return optionalTypeMember(diagnostic, sourceFile, matchedTypeAlias, typeMemberName);
   } else {
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   }
 }
 
 function optionalClassMember(
+  diagnostic: ts.DiagnosticWithLocation,
   sourceFile: ts.SourceFile,
   matchedClass: ts.ClassDeclaration,
   typeMemberName: string
-): FixedFile[] {
+): FixResult {
   const matchedMember = getClassMemberByName(matchedClass, typeMemberName);
   if (!matchedMember) {
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   }
 
   const nameEnd = (matchedMember as ts.PropertyDeclaration).name.getEnd();
   const updatedText = insertIntoText(sourceFile.getFullText(), nameEnd, OPTIONAL_TOKEN);
-  return [
-    {
-      fileName: sourceFile.fileName,
-      text: updatedText,
-    },
-  ];
+  return getCodemodResult(sourceFile, updatedText, nameEnd);
 }
 
 function updateTextWithOptionalClassMember(
+  diagnostic: ts.DiagnosticWithLocation,
   sourceFile: ts.SourceFile,
   memberName: string,
   typeName: string
-): FixedFile[] {
+): FixResult {
   const matchedClass: ts.ClassDeclaration | undefined = getClassByName(sourceFile, typeName);
 
   if (matchedClass) {
-    return optionalClassMember(sourceFile, matchedClass, memberName);
+    return optionalClassMember(diagnostic, sourceFile, matchedClass, memberName);
   } else {
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   }
 }

--- a/packages/upgrade/src/transforms/6133-fix-transform.ts
+++ b/packages/upgrade/src/transforms/6133-fix-transform.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 
-import { FixTransform, type FixedFile } from '../interfaces/fix-transform';
+import { FixTransform, type FixResult } from '../interfaces/fix-transform';
+import { getCommentsOnlyResult, getCodemodResult } from '../helpers/transform-utils';
 
 import { isSourceCodeChanged } from '../helpers/strings';
 import { transformDiagnosedNode } from '../helpers/typescript-ast';
@@ -8,7 +9,7 @@ import { transformDiagnosedNode } from '../helpers/typescript-ast';
 export class FixTransform6133 extends FixTransform {
   hint = `The declaration '{0}' is never read or used. Remove the declaration or use it.`;
 
-  fix = (diagnostic: ts.DiagnosticWithLocation): FixedFile[] => {
+  fix = (diagnostic: ts.DiagnosticWithLocation): FixResult => {
     const text = transformDiagnosedNode(diagnostic, (node: ts.Node) => {
       if (ts.isImportDeclaration(node) || ts.isImportSpecifier(node)) {
         // Remove all export declarations and undefined imported functions
@@ -26,8 +27,8 @@ export class FixTransform6133 extends FixTransform {
 
     const hasChanged = isSourceCodeChanged(diagnostic.file.getFullText(), text);
     if (hasChanged) {
-      return [{ fileName: diagnostic.file.fileName, text }];
+      return getCodemodResult(diagnostic.file, text, diagnostic.start);
     }
-    return [];
+    return getCommentsOnlyResult(diagnostic);
   };
 }

--- a/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.json
+++ b/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.json
@@ -7,7 +7,17 @@
   },
   "items": [
     {
-      "file": "2322.ts",
+      "analysisTarget": "2322.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2322.ts",
+          "location": {
+            "line": 2,
+            "character": 6
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'number'.",
@@ -15,7 +25,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "dummy_const",
-      "location": {
+      "nodeLocation": {
         "start": 42,
         "length": 11,
         "line": 2,
@@ -23,7 +33,17 @@
       }
     },
     {
-      "file": "2322.ts",
+      "analysisTarget": "2322.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2322.ts",
+          "location": {
+            "line": 6,
+            "character": 0
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'number'.",
@@ -31,7 +51,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "dummy_var",
-      "location": {
+      "nodeLocation": {
         "start": 280,
         "length": 9,
         "line": 6,
@@ -39,7 +59,17 @@
       }
     },
     {
-      "file": "2322.ts",
+      "analysisTarget": "2322.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2322.ts",
+          "location": {
+            "line": 12,
+            "character": 2
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'void'.",
@@ -47,7 +77,7 @@
       "fixed": false,
       "nodeKind": "ReturnStatement",
       "nodeText": "return 'dummy-string';",
-      "location": {
+      "nodeLocation": {
         "start": 561,
         "length": 22,
         "line": 12,
@@ -55,7 +85,17 @@
       }
     },
     {
-      "file": "2345.ts",
+      "analysisTarget": "2345.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2345.ts",
+          "location": {
+            "line": 7,
+            "character": 28
+          }
+        }
+      ],
       "code": 2345,
       "category": "Error",
       "message": "Argument of type 'unknown' is not assignable to parameter of type 'string'.",
@@ -63,7 +103,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "changeable",
-      "location": {
+      "nodeLocation": {
         "start": 184,
         "length": 10,
         "line": 7,
@@ -71,7 +111,17 @@
       }
     },
     {
-      "file": "2345.ts",
+      "analysisTarget": "2345.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2345.ts",
+          "location": {
+            "line": 11,
+            "character": 28
+          }
+        }
+      ],
       "code": 2345,
       "category": "Error",
       "message": "Argument of type 'number' is not assignable to parameter of type 'string'.",
@@ -79,7 +129,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "num",
-      "location": {
+      "nodeLocation": {
         "start": 536,
         "length": 3,
         "line": 11,
@@ -87,7 +137,17 @@
       }
     },
     {
-      "file": "2571.ts",
+      "analysisTarget": "2571.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2571.ts",
+          "location": {
+            "line": 5,
+            "character": 14
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2571,
       "category": "Error",
       "message": "Object is of type 'unknown'.",
@@ -95,7 +155,7 @@
       "fixed": true,
       "nodeKind": "Identifier",
       "nodeText": "e",
-      "location": {
+      "nodeLocation": {
         "start": 97,
         "length": 1,
         "line": 5,
@@ -103,7 +163,17 @@
       }
     },
     {
-      "file": "2571.ts",
+      "analysisTarget": "2571.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2571.ts",
+          "location": {
+            "line": 7,
+            "character": 16
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2571,
       "category": "Error",
       "message": "Object is of type 'unknown'.",
@@ -111,7 +181,7 @@
       "fixed": true,
       "nodeKind": "Identifier",
       "nodeText": "e",
-      "location": {
+      "nodeLocation": {
         "start": 140,
         "length": 1,
         "line": 7,
@@ -119,7 +189,17 @@
       }
     },
     {
-      "file": "2571.ts",
+      "analysisTarget": "2571.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "2571.ts",
+          "location": {
+            "line": 19,
+            "character": 0
+          }
+        }
+      ],
       "code": 2571,
       "category": "Error",
       "message": "Object is of type 'unknown'.",
@@ -127,7 +207,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "dummy",
-      "location": {
+      "nodeLocation": {
         "start": 365,
         "length": 5,
         "line": 19,
@@ -135,7 +215,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790-import-1.ts",
+          "location": {
+            "line": 2,
+            "character": 8
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -143,7 +233,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "animal.weight",
-      "location": {
+      "nodeLocation": {
         "start": 265,
         "length": 13,
         "line": 10,
@@ -151,7 +241,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790-import-1.ts",
+          "location": {
+            "line": 8,
+            "character": 7
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -159,7 +259,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "car.color",
-      "location": {
+      "nodeLocation": {
         "start": 381,
         "length": 9,
         "line": 18,
@@ -167,7 +267,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790-import-2.ts",
+          "location": {
+            "line": 2,
+            "character":13
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -175,7 +285,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "employee.badgeNumber",
-      "location": {
+      "nodeLocation": {
         "start": 483,
         "length": 20,
         "line": 21,
@@ -183,7 +293,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790-import-4.ts",
+          "location": {
+            "line": 1,
+            "character": 8
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -191,7 +311,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "human.height",
-      "location": {
+      "nodeLocation": {
         "start": 579,
         "length": 12,
         "line": 27,
@@ -199,7 +319,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790-import-3.ts",
+          "location": {
+            "line": 1,
+            "character": 7
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -207,7 +337,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "rabbit.color",
-      "location": {
+      "nodeLocation": {
         "start": 718,
         "length": 12,
         "line": 34,
@@ -215,7 +345,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790.ts",
+          "location": {
+            "line": 39,
+            "character": 9
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -223,7 +363,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "person.address",
-      "location": {
+      "nodeLocation": {
         "start": 933,
         "length": 14,
         "line": 48,
@@ -231,7 +371,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790.ts",
+          "location": {
+            "line": 53,
+            "character": 8
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -239,7 +389,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "student.gender",
-      "location": {
+      "nodeLocation": {
         "start": 1283,
         "length": 14,
         "line": 62,
@@ -247,7 +397,17 @@
       }
     },
     {
-      "file": "2790.ts",
+      "analysisTarget": "2790.ts",
+      "fixedFiles": [
+        {
+          "fileName": "2790.ts",
+          "location": {
+            "line": 67,
+            "character": 8
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 2790,
       "category": "Error",
       "message": "The operand of a 'delete' operator must be optional.",
@@ -255,7 +415,7 @@
       "fixed": true,
       "nodeKind": "PropertyAccessExpression",
       "nodeText": "oak.height",
-      "location": {
+      "nodeLocation": {
         "start": 1465,
         "length": 10,
         "line": 75,
@@ -263,7 +423,17 @@
       }
     },
     {
-      "file": "4082-1.tsx",
+      "analysisTarget": "4082-1.tsx",
+      "fixedFiles": [
+        {
+          "fileName": "4082-1.tsx",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'React' is declared but its value is never read.",
@@ -271,7 +441,7 @@
       "fixed": true,
       "nodeKind": "ImportDeclaration",
       "nodeText": "import React from 'react';",
-      "location": {
+      "nodeLocation": {
         "start": 0,
         "length": 26,
         "line": 0,
@@ -279,7 +449,17 @@
       }
     },
     {
-      "file": "4082-1.tsx",
+      "analysisTarget": "4082-1.tsx",
+      "fixedFiles": [
+        {
+          "fileName": "4082-1-import.tsx",
+          "location": {
+            "line": 2,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 4082,
       "category": "Error",
       "message": "Default export of the module has or is using private name 'Props'.",
@@ -287,7 +467,7 @@
       "fixed": true,
       "nodeKind": "ExportAssignment",
       "nodeText": "export default {\n    kid: Kid,\n    title: 'Kid',\n};",
-      "location": {
+      "nodeLocation": {
         "start": 57,
         "length": 51,
         "line": 3,
@@ -295,7 +475,17 @@
       }
     },
     {
-      "file": "4082-2.tsx",
+      "analysisTarget": "4082-2.tsx",
+      "fixedFiles": [
+        {
+          "fileName": "4082-2-import.tsx",
+          "location": {
+            "line": 12,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 4082,
       "category": "Error",
       "message": "Default export of the module has or is using private name 'InjectedProps'.",
@@ -303,7 +493,7 @@
       "fixed": true,
       "nodeKind": "ExportAssignment",
       "nodeText": "export default makeToDo(ToDo);",
-      "location": {
+      "nodeLocation": {
         "start": 511,
         "length": 30,
         "line": 19,
@@ -311,7 +501,17 @@
       }
     },
     {
-      "file": "4082-2.tsx",
+      "analysisTarget": "4082-2.tsx",
+      "fixedFiles": [
+        {
+          "fileName": "4082-2-import.tsx",
+          "location": {
+            "line": 8,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 4082,
       "category": "Error",
       "message": "Default export of the module has or is using private name 'ToDoState'.",
@@ -319,7 +519,7 @@
       "fixed": true,
       "nodeKind": "ExportAssignment",
       "nodeText": "export default makeToDo(ToDo);",
-      "location": {
+      "nodeLocation": {
         "start": 511,
         "length": 30,
         "line": 19,
@@ -327,7 +527,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'fs' is declared but its value is never read.",
@@ -335,7 +545,7 @@
       "fixed": true,
       "nodeKind": "ImportDeclaration",
       "nodeText": "import fs from 'fs';",
-      "location": {
+      "nodeLocation": {
         "start": 0,
         "length": 20,
         "line": 0,
@@ -343,7 +553,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 1,
+            "character": 9
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'parse' is declared but its value is never read.",
@@ -351,7 +571,7 @@
       "fixed": true,
       "nodeKind": "ImportSpecifier",
       "nodeText": "parse",
-      "location": {
+      "nodeLocation": {
         "start": 20,
         "length": 5,
         "line": 1,
@@ -359,7 +579,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 5,
+            "character": 6
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'defined_var' is declared but its value is never read.",
@@ -367,7 +597,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "defined_var",
-      "location": {
+      "nodeLocation": {
         "start": 72,
         "length": 11,
         "line": 5,
@@ -375,7 +605,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 8,
+            "character": 6
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'defined_const' is declared but its value is never read.",
@@ -383,7 +623,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "defined_const",
-      "location": {
+      "nodeLocation": {
         "start": 231,
         "length": 13,
         "line": 8,
@@ -391,7 +631,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 11,
+            "character": 9
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'defined_function' is declared but its value is never read.",
@@ -399,7 +649,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "defined_function",
-      "location": {
+      "nodeLocation": {
         "start": 397,
         "length": 16,
         "line": 11,
@@ -407,7 +657,17 @@
       }
     },
     {
-      "file": "6133.ts",
+      "analysisTarget": "6133.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "6133.ts",
+          "location": {
+            "line": 16,
+            "character": 38
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'defined_param' is declared but its value is never read.",
@@ -415,7 +675,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "defined_param",
-      "location": {
+      "nodeLocation": {
         "start": 608,
         "length": 13,
         "line": 16,
@@ -423,7 +683,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 0,
+            "character": 0
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'fs' is declared but its value is never read.",
@@ -431,7 +701,7 @@
       "fixed": true,
       "nodeKind": "ImportDeclaration",
       "nodeText": "import fs from 'fs';",
-      "location": {
+      "nodeLocation": {
         "start": 0,
         "length": 20,
         "line": 0,
@@ -439,7 +709,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 0,
+            "character": 18
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'parse' is declared but its value is never read.",
@@ -447,7 +727,7 @@
       "fixed": true,
       "nodeKind": "ImportSpecifier",
       "nodeText": "parse",
-      "location": {
+      "nodeLocation": {
         "start": 18,
         "length": 5,
         "line": 0,
@@ -455,7 +735,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 2,
+            "character": 9
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'sleep' is declared but its value is never read.",
@@ -463,7 +753,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "sleep",
-      "location": {
+      "nodeLocation": {
         "start": 52,
         "length": 5,
         "line": 2,
@@ -471,7 +761,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 7,
+            "character": 4
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'foo' is declared but its value is never read.",
@@ -479,7 +779,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "foo",
-      "location": {
+      "nodeLocation": {
         "start": 276,
         "length": 3,
         "line": 7,
@@ -487,7 +787,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 13,
+            "character": 19
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'inSeconds' is declared but its value is never read.",
@@ -495,7 +805,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "inSeconds",
-      "location": {
+      "nodeLocation": {
         "start": 471,
         "length": 9,
         "line": 13,
@@ -503,7 +813,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 17,
+            "character": 4
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'number'.",
@@ -511,7 +831,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "foo",
-      "location": {
+      "nodeLocation": {
         "start": 702,
         "length": 3,
         "line": 17,
@@ -519,7 +839,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 19,
+            "character": 13
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'timestamp' is declared but its value is never read.",
@@ -527,7 +857,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "timestamp",
-      "location": {
+      "nodeLocation": {
         "start": 894,
         "length": 9,
         "line": 19,
@@ -535,7 +865,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 21,
+            "character": 14
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'b' is declared but its value is never read.",
@@ -543,7 +883,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "b",
-      "location": {
+      "nodeLocation": {
         "start": 1059,
         "length": 1,
         "line": 21,
@@ -551,7 +891,17 @@
       }
     },
     {
-      "file": "first.ts",
+      "analysisTarget": "first.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "first.ts",
+          "location": {
+            "line": 23,
+            "character": 8
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'void'.",
@@ -559,7 +909,7 @@
       "fixed": false,
       "nodeKind": "ReturnStatement",
       "nodeText": "return 'a';",
-      "location": {
+      "nodeLocation": {
         "start": 1189,
         "length": 11,
         "line": 23,
@@ -567,7 +917,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 3,
+            "character": 8
+          }
+        }
+      ],
+      "commentedFiles": [],
       "code": 6133,
       "category": "Error",
       "message": "'unused' is declared but its value is never read.",
@@ -575,7 +935,7 @@
       "fixed": true,
       "nodeKind": "Identifier",
       "nodeText": "unused",
-      "location": {
+      "nodeLocation": {
         "start": 71,
         "length": 6,
         "line": 3,
@@ -583,7 +943,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 3,
+            "character": 10
+          }
+        }
+      ],
       "code": 6133,
       "category": "Error",
       "message": "'unused' is declared but its value is never read.",
@@ -591,7 +961,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "unused",
-      "location": {
+      "nodeLocation": {
         "start": 73,
         "length": 6,
         "line": 3,
@@ -599,7 +969,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 8,
+            "character": 22
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingElement'.",
@@ -607,7 +987,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "NonExistingElement",
-      "location": {
+      "nodeLocation": {
         "start": 277,
         "length": 18,
         "line": 8,
@@ -615,7 +995,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 13,
+            "character": 7
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingElement'.",
@@ -623,7 +1013,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "NonExistingElement",
-      "location": {
+      "nodeLocation": {
         "start": 529,
         "length": 18,
         "line": 13,
@@ -631,7 +1021,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 15,
+            "character": 12
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type '{ $notExistingVariable: any; }' is not assignable to type 'ReactNode'..   Object literal may only specify known properties, and '$notExistingVariable' does not exist in type 'ReactElement<any, string | JSXElementConstructor<any>> | ReactFragment | ReactPortal'.",
@@ -639,7 +1039,7 @@
       "fixed": false,
       "nodeKind": "ShorthandPropertyAssignment",
       "nodeText": "$notExistingVariable",
-      "location": {
+      "nodeLocation": {
         "start": 667,
         "length": 20,
         "line": 15,
@@ -647,7 +1047,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 21,
+            "character": 12
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingFragment'.",
@@ -655,7 +1065,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "NonExistingFragment",
-      "location": {
+      "nodeLocation": {
         "start": 1045,
         "length": 19,
         "line": 21,
@@ -663,7 +1073,17 @@
       }
     },
     {
-      "file": "react.tsx",
+      "analysisTarget": "react.tsx",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "react.tsx",
+          "location": {
+            "line": 28,
+            "character": 29
+          }
+        }
+      ],
       "code": 2322,
       "category": "Error",
       "message": "Type '{ doesNotExist: string; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement>'..   Property 'doesNotExist' does not exist on type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement>'.",
@@ -671,7 +1091,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "doesNotExist",
-      "location": {
+      "nodeLocation": {
         "start": 1263,
         "length": 12,
         "line": 28,
@@ -679,7 +1099,17 @@
       }
     },
     {
-      "file": "second.ts",
+      "analysisTarget": "second.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 1,
+            "character": 9
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'readFileSync'.",
@@ -687,7 +1117,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "readFileSync",
-      "location": {
+      "nodeLocation": {
         "start": 63,
         "length": 12,
         "line": 1,
@@ -695,7 +1125,17 @@
       }
     },
     {
-      "file": "second.ts",
+      "analysisTarget": "second.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 12,
+            "character": 21
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExist'.",
@@ -703,7 +1143,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "doesNotExist",
-      "location": {
+      "nodeLocation": {
         "start": 339,
         "length": 12,
         "line": 12,
@@ -711,7 +1151,17 @@
       }
     },
     {
-      "file": "second.ts",
+      "analysisTarget": "second.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 20,
+            "character": 6
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExist'.",
@@ -719,7 +1169,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "doesNotExist",
-      "location": {
+      "nodeLocation": {
         "start": 538,
         "length": 12,
         "line": 20,
@@ -727,7 +1177,17 @@
       }
     },
     {
-      "file": "second.ts",
+      "analysisTarget": "second.ts",
+      "fixedFiles": [],
+      "commentedFiles": [
+        {
+          "fileName": "second.ts",
+          "location": {
+            "line": 22,
+            "character": 6
+          }
+        }
+      ],
       "code": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",
@@ -735,7 +1195,7 @@
       "fixed": false,
       "nodeKind": "Identifier",
       "nodeText": "doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString",
-      "location": {
+      "nodeLocation": {
         "start": 631,
         "length": 92,
         "line": 22,

--- a/packages/upgrade/test/upgrade.test.ts
+++ b/packages/upgrade/test/upgrade.test.ts
@@ -72,7 +72,15 @@ function expectedReport(basePath: string, timestamp: string): Report {
   report.summary.basePath = basePath;
   report.summary.timestamp = timestamp;
   report.summary.tsVersion = ts.version;
-  report.items.map((v) => (v.file = resolve(basePath, v.file)));
+  report.items.forEach((item) => {
+    item.analysisTarget = resolve(basePath, item.analysisTarget);
+    if (item.fixedFiles?.length > 0) {
+      item.fixedFiles.forEach((file) => (file.fileName = resolve(basePath, file.fileName)));
+    }
+    if (item.commentedFiles?.length > 0) {
+      item.commentedFiles.forEach((file) => (file.fileName = resolve(basePath, file.fileName)));
+    }
+  });
 
   return report;
 }


### PR DESCRIPTION
This PR changes the report to include more transform data that will be used for the sarif file. 

1. Return type of the transform function changes from `FixedFile[]` to `FixResult.` The former only includes the name and content of source files that have been modified, while the latter includes an array of source files that have been modified and an array of source file to which only comments have been added, and locations in these source files where codemods are made or comments are added.
2. For readability, in the ReportItem type, `file` field is changed to `analysisTarget` to differentiate it from `fixedFiles` and `commentedFiles`, borrowing a term from sarif. `location` is changed to `nodeLocation`, as `nodeKind` or `nodeText`, to be differentiated from `location` in `fixedFiles` and `commentedFiles`.