### PR TITLE
chore: Return pre-commit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "conventional-changelog-cli": "^2.1.1",
     "husky": "^8.0.1",
     "lerna": "^5.0.0",
+    "pre-commit": "^1.2.2",
     "prettier": "^2.7.1",
     "typescript": "4.7.4"
   },


### PR DESCRIPTION
It was [recently removed](https://github.com/rehearsal-js/rehearsal-js/pull/270/files#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L95), but we need this to run the hook