### PR TITLE
chore: node lts and volta extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/rehearsal-js/rehearsal-js.git"
   },
   "volta": {
-    "node": "16.13.2",
+    "node": "16.17.0",
     "yarn": "1.22.17"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,10 +77,9 @@
     "vitest": "^0.22.1"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -46,10 +46,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -42,10 +42,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -39,10 +39,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -43,10 +43,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.13.2",
-    "yarn": "1.22.17"
+    "extends": "../../package.json"
   }
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -48,10 +48,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,10 +41,9 @@
     "typescript": ">4.7"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.16.0"
   },
   "volta": {
-    "node": "16.16.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
- bumps node to lts
- leverages volta extends so we only need to manage node/yarn versions once
- bumps min node version engine from 10 to 14