### PR TITLE
feat: add sarif-formatter

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -18,9 +18,9 @@ export function reportFormatter(report: Report): string {
 
   report.items.forEach((item) => {
     const fixed = item.fixed ? 1 : 0;
-    fixedErrors[item.code] = (fixedErrors[item.code] || 0) + fixed;
+    fixedErrors[item.errorCode] = (fixedErrors[item.errorCode] || 0) + fixed;
     fixedErrorsCounter += fixed;
-    totalErrors[item.code] = (totalErrors[item.code] || 0) + 1;
+    totalErrors[item.errorCode] = (totalErrors[item.errorCode] || 0) + 1;
     totalErrorsCounter += 1;
   });
 

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -86,7 +86,7 @@ describe('upgrade:command against fixture', async () => {
 
     const firstFileReportError = report.items[0];
 
-    expect(firstFileReportError.code).toEqual(2616);
+    expect(firstFileReportError.errorCode).toEqual(2616);
     expect(firstFileReportError.category).toEqual('Error');
     expect(firstFileReportError.fixed).toEqual(false);
     expect(firstFileReportError.nodeKind).toEqual('ImportSpecifier');

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@rehearsal/utils": "^0.0.28",
+    "@rehearsal/reporter": "^0.0.28",
     "@types/eslint": "^8.4.1",
     "vitest": "^0.22.1"
   },

--- a/packages/plugins/src/data/index.ts
+++ b/packages/plugins/src/data/index.ts
@@ -1,0 +1,1 @@
+export { getFilesData } from './utils';

--- a/packages/plugins/src/data/utils.ts
+++ b/packages/plugins/src/data/utils.ts
@@ -1,0 +1,100 @@
+import { type ProcessedFile, type Location, type FileRole } from '@rehearsal/reporter';
+import ts from 'typescript';
+import { type FixedFile } from '../fix-transform/interfaces';
+
+export function getFilesData(
+  fixedFiles: FixedFile[],
+  diagnostic: ts.DiagnosticWithLocation,
+  hint = ''
+): { [fileName: string]: ProcessedFile } {
+  const entryFileName = diagnostic.file.fileName;
+
+  let filesData: { [fileName: string]: ProcessedFile } = {
+    [entryFileName]: getInitialEntryFileData(diagnostic),
+  };
+
+  if (fixedFiles.length > 0) {
+    for (const fixedFile of fixedFiles) {
+      filesData = {
+        ...filesData,
+        [fixedFile.fileName]: getFixedFileData(fixedFile, entryFileName),
+      };
+    }
+  } else {
+    filesData = {
+      [entryFileName]: {
+        ...filesData[entryFileName],
+        hintAdded: true,
+        hint,
+      },
+    };
+  }
+
+  return filesData;
+}
+
+function getRoles(fileName: string, entryFileName: string, fixed: boolean): FileRole[] {
+  const isEntryFile = fileName === entryFileName;
+
+  if (isEntryFile) {
+    return fixed
+      ? ['analysisTarget' as const, 'modified' as const]
+      : ['analysisTarget', 'unmodified'];
+  }
+  return fixed ? ['tracedFile' as const, 'modified' as const] : ['tracedFile', 'unmodified'];
+}
+
+export function getLocation(sourceFile: ts.SourceFile, start: number): Location {
+  const { line, character } = ts.getLineAndCharacterOfPosition(sourceFile, start);
+
+  return {
+    line: line + 1,
+    character: character + 1,
+  };
+}
+
+export function getFixedFileData(fixedFile: FixedFile, entryFileName: string): ProcessedFile {
+  const roles = getRoles(fixedFile.fileName, entryFileName, true);
+  return {
+    fileName: fixedFile.fileName,
+    location: fixedFile.location,
+    fixed: true,
+    code: fixedFile.code,
+    codeFixAction: fixedFile.codeFixAction,
+    hint: undefined,
+    hintAdded: false,
+    roles,
+  };
+}
+
+export function getCommentedFileData(
+  fileName: string,
+  location: Location,
+  hint: string,
+  entryFileName: string
+): ProcessedFile {
+  const roles = getRoles(fileName, entryFileName, false);
+  return {
+    fileName,
+    location,
+    fixed: false,
+    code: undefined,
+    codeFixAction: undefined,
+    hint: hint,
+    hintAdded: true,
+    roles,
+  };
+}
+
+export function getInitialEntryFileData(diagnostic: ts.DiagnosticWithLocation): ProcessedFile {
+  return {
+    fileName: diagnostic.file.fileName,
+    location: getLocation(diagnostic.file, diagnostic.start),
+    fixed: false,
+    code: undefined,
+    codeFixAction: undefined,
+    hint: undefined,
+    hintAdded: false,
+    roles: ['analysisTarget', 'unmodified'],
+  };
+}

--- a/packages/plugins/src/fix-transform/index.ts
+++ b/packages/plugins/src/fix-transform/index.ts
@@ -1,10 +1,10 @@
 import ts from 'typescript';
 import { type RehearsalService } from '@rehearsal/service';
-import { getCodemodResult } from './utils';
-import { type FixedFile, FixTransform as FixTransformI } from './interfaces';
+import { getCodemodData } from './utils';
+import { type FixedFile, FixTransform as FixTransformI, type CodeFixAction } from './interfaces';
 
-export { getCodemodResult };
-export { FixedFile };
+export { getCodemodData };
+export { type FixedFile, CodeFixAction };
 
 export class FixTransform implements FixTransformI {
   /** Function to fix the diagnostic issue */

--- a/packages/plugins/src/fix-transform/interfaces.ts
+++ b/packages/plugins/src/fix-transform/interfaces.ts
@@ -1,9 +1,12 @@
 import ts from 'typescript';
 import { type RehearsalService } from '@rehearsal/service';
 
+export type CodeFixAction = 'add' | 'delete';
 export interface FixedFile {
   fileName: string;
-  updatedText?: string;
+  updatedText: string;
+  code?: string;
+  codeFixAction?: CodeFixAction;
   location: {
     line: number;
     character: number;

--- a/packages/plugins/src/fix-transform/utils.ts
+++ b/packages/plugins/src/fix-transform/utils.ts
@@ -1,20 +1,24 @@
 import ts from 'typescript';
-import { type FixedFile } from '.';
+import { type FixedFile, type CodeFixAction } from '.';
 
-export function getCodemodResult(
+export function getCodemodData(
   modifiedSourceFile: ts.SourceFile,
   updatedText: string,
-  insertionPos: number
+  insertionPos: number,
+  code?: string,
+  action?: CodeFixAction
 ): FixedFile[] {
   const { line, character } = ts.getLineAndCharacterOfPosition(modifiedSourceFile, insertionPos);
   return [
     {
       fileName: modifiedSourceFile.fileName,
       updatedText,
+      code: code,
       location: {
-        line,
-        character,
+        line: line + 1, //bump line 0 to line 1, so on and so forth
+        character: character + 1, //bump character 0 to character 1, so on and so forth
       },
+      codeFixAction: action,
     },
   ];
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -1,2 +1,3 @@
 export * from './fix-transform';
 export * from './plugins';
+export * from './data';

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/eslint": "^8.4.1",
+    "@types/sarif": "^2.1.4",
     "vitest": "^0.22.1"
   },
   "peerDependencies": {

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -20,7 +20,7 @@ export function mdFormatter(report: Report): string {
 
     for (const item of items) {
       text += `\n`;
-      text += `**${item.category} TS${item.code}**: ${
+      text += `**${item.category} TS${item.errorCode}**: ${
         item.fixed ? 'FIXED' : 'NEED TO BE FIXED MANUALLY'
       }\n`;
       text += `${item.hint}\n`;

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -1,0 +1,238 @@
+import { Log, Run, ReportingDescriptor, Result, Artifact, Location, PropertyBag } from 'sarif';
+import { Report, ReportItem, ProcessedFile, FileCollection } from '../types';
+
+let ruleIndexMap: { [ruleId: string]: number } | undefined;
+let rules: ReportingDescriptor[] = [];
+
+let artifactIndexMap: { [fileName: string]: number } | undefined;
+let artifacts: Artifact[] = [];
+
+let results: Result[] = [];
+
+export function sarifFormatter(report: Report): string {
+  const run = buildRun(report.items);
+  const log = {
+    ...initLog(),
+    runs: [run],
+  };
+  cleanUp();
+  return JSON.stringify(log, null, 2);
+}
+
+function initLog(): Log {
+  return {
+    version: '2.1.0' as const,
+    $schema: 'http://json.schemastore.org/sarif-2.1.0-rtm.4',
+    runs: [],
+  };
+}
+
+function buildRun(items: ReportItem[]): Run {
+  const run = initRun();
+
+  for (const item of items) {
+    const ruleId = `TS${item.errorCode}`;
+    rules = addRule(ruleId, item.message, rules);
+
+    artifacts = addArtifact(item.files, artifacts);
+
+    results = addResult(item, results);
+  }
+
+  const tool = {
+    ...run.tool,
+    driver: {
+      ...run.tool.driver,
+      rules,
+    },
+  };
+
+  return {
+    ...run,
+    tool,
+    artifacts,
+    results,
+  };
+}
+
+function ruleExists(ruleId: string): boolean {
+  return !!(ruleIndexMap && Object.getOwnPropertyDescriptor(ruleIndexMap, ruleId));
+}
+
+function artifactExists(artifactName: string): boolean {
+  return !!(artifactIndexMap && Object.getOwnPropertyDescriptor(artifactIndexMap, artifactName));
+}
+
+function updateArtifact(artifact: Artifact, file: ProcessedFile): Artifact {
+  let roles = Array.from(new Set(artifact.roles?.concat(file.roles)));
+  if (roles.includes('modified') && roles.includes('unmodified')) {
+    roles = roles.filter((role) => role !== 'unmodified');
+  }
+  artifact.roles = roles;
+  artifact.properties!.fixed = file.fixed || artifact.properties!.fixed;
+  artifact.properties!.hintAdded = file.hintAdded || artifact.properties!.hintAdded;
+  return artifact;
+}
+
+function addRule(
+  ruleId: string,
+  message: string,
+  rules: ReportingDescriptor[]
+): ReportingDescriptor[] {
+  if (!ruleExists(ruleId)) {
+    const rule = {
+      id: ruleId,
+      name: ruleId,
+      shortDescription: {
+        text: message,
+      },
+      helpUri: '',
+    };
+
+    rules = [...rules, rule];
+
+    ruleIndexMap = {
+      ...(ruleIndexMap || {}),
+      [ruleId]: rules.length - 1,
+    };
+  }
+  return rules;
+}
+
+function addArtifact(files: FileCollection, artifacts: Artifact[]): Artifact[] {
+  for (const file in files) {
+    if (!artifactExists(file)) {
+      const newArtifact = buildArtifact(files[file]);
+      artifacts = [...artifacts, newArtifact];
+
+      artifactIndexMap = {
+        ...(artifactIndexMap || {}),
+        [file]: artifacts.length - 1,
+      };
+    } else {
+      const index = artifactIndexMap![file];
+      const existingArtifact = artifacts[index];
+      artifacts[index] = updateArtifact(existingArtifact, files[file]);
+    }
+  }
+  return artifacts;
+}
+
+function buildArtifact(file: ProcessedFile): Artifact {
+  return {
+    location: {
+      uri: file.fileName,
+    },
+    roles: file.roles,
+    properties: {
+      fixed: file.fixed,
+      hintAdded: file.hintAdded,
+    },
+  };
+}
+
+function addResult(item: ReportItem, results: Result[]): Result[] {
+  const result = buildResult(item);
+  return [...results, result];
+}
+
+function buildResult(item: ReportItem): Result {
+  const { locations, fixes } = getFilesData(item.files);
+  return {
+    ruleId: `TS${item.errorCode}`,
+    ruleIndex: ruleIndexMap && ruleIndexMap[`TS${item.errorCode}`],
+    level: levelConverter(item.category),
+    message: {
+      text: item.hint,
+    },
+    analysisTarget: {
+      uri: item.analysisTarget,
+    },
+    locations,
+    properties: {
+      fixed: item.fixed || false,
+      fixes,
+    },
+  };
+}
+
+function getFilesData(files: FileCollection): PropertyBag {
+  let locations: Location[] = [];
+  let fixes: { [key: string]: string | undefined }[] = [];
+  Object.values(files).forEach((file) => {
+    locations = [...locations, buildLocation(file)];
+    if (file.fixed) {
+      fixes = [
+        ...fixes,
+        {
+          fileName: file.fileName,
+          code: file.code || undefined,
+          codeFixAction: file.codeFixAction || undefined,
+        },
+      ];
+    }
+  });
+
+  return {
+    locations,
+    fixes,
+  };
+}
+
+function buildLocation(file: ProcessedFile): Location {
+  return {
+    physicalLocation: {
+      artifactLocation: {
+        uri: file.fileName,
+      },
+      region: {
+        startLine: file.location?.line,
+        startColumn: file.location?.character,
+      },
+      properties: {
+        code: file.code,
+        codeFixAction: file.codeFixAction,
+        roles: file.roles,
+      },
+    },
+  };
+}
+
+function levelConverter(category: string): Result.level {
+  switch (category) {
+    case 'Warning':
+      return 'warning';
+    case 'Error':
+      return 'error';
+    case 'Suggestion':
+      return 'note';
+    case 'Message':
+      return 'note';
+    default:
+      return 'none';
+  }
+}
+
+function initRun(): Run {
+  return {
+    tool: {
+      driver: {
+        name: '@rehearsal/migrate',
+        informationUri: 'https://github.com/rehearsal-js/rehearsal-js',
+        rules: [],
+      },
+    },
+    artifacts: [],
+    results: [],
+  };
+}
+
+function cleanUp(): void {
+  ruleIndexMap = undefined;
+  rules = [];
+
+  artifactIndexMap = undefined;
+  artifacts = [];
+
+  results = [];
+}

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -1,5 +1,14 @@
 export { Reporter as Reporter } from './reporter';
 export { jsonFormatter } from './formatters/json-formatter';
 export { mdFormatter } from './formatters/md-formatter';
+export { sarifFormatter } from './formatters/sarif-formatter';
 
-export type { Report, ReportItem, ReportSummary } from './types';
+export type {
+  Report,
+  ReportItem,
+  ReportSummary,
+  CodeFixAction,
+  ProcessedFile,
+  Location,
+  FileRole,
+} from './types';

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import ts from 'typescript';
 import winston from 'winston';
 
-import { type FixedFile, type Report, type ReportItem } from './types';
+import { type Report, type ReportItem, type ProcessedFile } from './types';
 
 /**
  * Representation of diagnostic and migration report.
@@ -47,20 +47,19 @@ export class Reporter {
    */
   addItem(
     diagnostic: ts.DiagnosticWithLocation,
-    fixedFiles: FixedFile[],
-    commentedFiles: FixedFile[],
+    files: { [fileName: string]: ProcessedFile },
+    fixed: boolean,
     node?: ts.Node,
     hint = ''
   ): void {
     this.report.items.push({
       analysisTarget: diagnostic.file.fileName,
-      fixedFiles: fixedFiles,
-      commentedFiles: commentedFiles,
-      code: diagnostic.code,
+      files,
+      errorCode: diagnostic.code,
       category: ts.DiagnosticCategory[diagnostic.category],
       message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '. '),
       hint: hint,
-      fixed: fixedFiles.length > 0,
+      fixed,
       nodeKind: node ? ts.SyntaxKind[node.kind] : undefined,
       nodeText: node?.getText(),
       nodeLocation: {

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -5,11 +5,31 @@ export type ReportSummary = Record<string, unknown> & {
   timestamp: string;
 };
 
+export type FileRole = 'analysisTarget' | 'tracedFile' | 'unmodified' | 'modified';
+export type CodeFixAction = 'add' | 'delete';
+
+export interface Location {
+  line: number;
+  character: number;
+}
+
+export interface ProcessedFile {
+  fileName: string;
+  location: Location;
+  fixed: boolean;
+  code: string | undefined;
+  codeFixAction: CodeFixAction | undefined;
+  hintAdded: boolean;
+  hint: string | undefined;
+  roles: FileRole[];
+}
+
+export type FileCollection = { [fileName: string]: ProcessedFile };
+
 export type ReportItem = {
   analysisTarget: string;
-  fixedFiles: FixedFile[];
-  commentedFiles: FixedFile[];
-  code: number;
+  files: FileCollection;
+  errorCode: number;
   category: string;
   message: string;
   hint?: string;
@@ -29,11 +49,13 @@ export type Report = {
   items: ReportItem[];
 };
 
-export type FixedFile = {
+export interface FixedFile {
   fileName: string;
-  updatedText?: string;
+  updatedText: string;
+  code?: string;
+  codeFixAction?: CodeFixAction;
   location: {
     line: number;
     character: number;
   };
-};
+}

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -30,9 +30,9 @@
     "test:watch": "vitest --coverage --watch"
   },
   "dependencies": {
+    "@rehearsal/plugins": "^0.0.28",
     "@rehearsal/reporter": "^0.0.28",
     "@rehearsal/service": "^0.0.28",
-    "@rehearsal/plugins": "^0.0.28",
     "@rehearsal/utils": "^0.0.28",
     "commander": "^9.4.0",
     "winston": "^3.6.0"
@@ -42,6 +42,7 @@
     "@types/eslint": "^8.4.1",
     "@types/node": "^18.0.3",
     "@types/react": "^18.0.9",
+    "@types/sarif": "^2.1.4",
     "vitest": "^0.22.1"
   },
   "peerDependencies": {

--- a/packages/upgrade/src/transforms/2571/index.ts
+++ b/packages/upgrade/src/transforms/2571/index.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 
-import { FixTransform, type FixedFile, getCodemodResult } from '@rehearsal/plugins';
+import { FixTransform, type FixedFile, getCodemodData } from '@rehearsal/plugins';
 import {
   isSourceCodeChanged,
   isVariableOfCatchClause,
@@ -23,7 +23,7 @@ export class FixTransform2571 extends FixTransform {
 
     const hasChanged = isSourceCodeChanged(diagnostic.file.getFullText(), text);
     if (hasChanged) {
-      return getCodemodResult(diagnostic.file, text, diagnostic.start);
+      return getCodemodData(diagnostic.file, text, diagnostic.start);
     }
 
     return [];

--- a/packages/upgrade/src/transforms/2790/index.ts
+++ b/packages/upgrade/src/transforms/2790/index.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 
 import { type RehearsalService } from '@rehearsal/service';
 
-import { FixTransform, type FixedFile, getCodemodResult } from '@rehearsal/plugins';
+import { FixTransform, type FixedFile, getCodemodData } from '@rehearsal/plugins';
 import {
   findNodeAtPosition,
   insertIntoText,
@@ -69,7 +69,7 @@ export class FixTransform2790 extends FixTransform {
 
     const updatedText = insertIntoText(sourceFile.getFullText(), nameEnd, OPTIONAL_TOKEN);
 
-    return getCodemodResult(sourceFile, updatedText, nameEnd);
+    return getCodemodData(sourceFile, updatedText, nameEnd, OPTIONAL_TOKEN, 'add');
   };
 }
 

--- a/packages/upgrade/src/transforms/4082/index.ts
+++ b/packages/upgrade/src/transforms/4082/index.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 
 import { type RehearsalService } from '@rehearsal/service';
-import { FixTransform, type FixedFile, getCodemodResult } from '@rehearsal/plugins';
+import { FixTransform, type FixedFile, getCodemodData } from '@rehearsal/plugins';
 import {
   findNodeAtPosition,
   getTypeDeclarationFromTypeSymbol,
@@ -52,7 +52,13 @@ export class FixTransform4082 extends FixTransform {
       `${EXPORT_KEYWORD} `
     );
 
-    return getCodemodResult(sourceFile, updatedText, targetTypeDeclaration.getStart());
+    return getCodemodData(
+      sourceFile,
+      updatedText,
+      targetTypeDeclaration.getStart(),
+      EXPORT_KEYWORD,
+      'add'
+    );
   };
 }
 

--- a/packages/upgrade/src/transforms/6133/index.ts
+++ b/packages/upgrade/src/transforms/6133/index.ts
@@ -1,10 +1,13 @@
 import ts from 'typescript';
 
-import { FixTransform, type FixedFile, getCodemodResult } from '@rehearsal/plugins';
-import { isSourceCodeChanged, transformDiagnosedNode } from '@rehearsal/utils';
+import { FixTransform, type FixedFile, getCodemodData } from '@rehearsal/plugins';
+import { isSourceCodeChanged, transformDiagnosedNode, findNodeAtPosition } from '@rehearsal/utils';
 
 export class FixTransform6133 extends FixTransform {
   fix = (diagnostic: ts.DiagnosticWithLocation): FixedFile[] => {
+    const errorNode = findNodeAtPosition(diagnostic.file, diagnostic.start, diagnostic.length);
+    const textRemoved = errorNode && errorNode.getFullText();
+
     const text = transformDiagnosedNode(diagnostic, (node: ts.Node) => {
       if (ts.isImportDeclaration(node) || ts.isImportSpecifier(node)) {
         // Remove all export declarations and undefined imported functions
@@ -18,7 +21,6 @@ export class FixTransform6133 extends FixTransform {
     if (!hasChanged) {
       return [];
     }
-
-    return getCodemodResult(diagnostic.file, text, diagnostic.start);
+    return getCodemodData(diagnostic.file, text, diagnostic.start, textRemoved, 'delete');
   };
 }

--- a/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.json
+++ b/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.json
@@ -8,17 +8,24 @@
   "items": [
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 0,
-            "character": 0
-          }
+            "line": 1,
+            "character": 1
+          },
+          "fixed": true,
+          "code": "import fs from 'fs';",
+          "codeFixAction": "delete",
+          "hintAdded": false,
+          "roles": [
+            "analysisTarget",
+            "modified"
+          ]
         }
-      ],
-      "commentedFiles": [],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'fs' is declared but its value is never read.",
       "hint": "The declaration 'fs' is never read or used. Remove the declaration or use it.",
@@ -34,17 +41,24 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 0,
-            "character": 18
-          }
+            "line": 1,
+            "character": 19
+          },
+          "fixed": true,
+          "code": " parse",
+          "codeFixAction": "delete",
+          "hintAdded": false,
+          "roles": [
+            "analysisTarget",
+            "modified"
+          ]
         }
-      ],
-      "commentedFiles": [],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'parse' is declared but its value is never read.",
       "hint": "The declaration 'parse' is never read or used. Remove the declaration or use it.",
@@ -60,17 +74,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 2,
-            "character": 9
-          }
+            "line": 3,
+            "character": 10
+          },
+          "fixed": false,
+          "hint": "The function 'sleep' is never called. Remove the function or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'sleep' is declared but its value is never read.",
       "hint": "The function 'sleep' is never called. Remove the function or use it.",
@@ -86,17 +106,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 7,
-            "character": 4
-          }
+            "line": 8,
+            "character": 5
+          },
+          "fixed": false,
+          "hint": "The variable 'foo' is never read or used. Remove the variable or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'foo' is declared but its value is never read.",
       "hint": "The variable 'foo' is never read or used. Remove the variable or use it.",
@@ -112,17 +138,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 13,
-            "character": 19
-          }
+            "line": 14,
+            "character": 20
+          },
+          "fixed": false,
+          "hint": "The parameter 'inSeconds' is never used. Remove the parameter from function definition or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'inSeconds' is declared but its value is never read.",
       "hint": "The parameter 'inSeconds' is never used. Remove the parameter from function definition or use it.",
@@ -138,17 +170,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 17,
-            "character": 4
-          }
+            "line": 18,
+            "character": 5
+          },
+          "fixed": false,
+          "hint": "The variable 'foo' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2322,
+      },
+      "errorCode": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'number'.",
       "hint": "The variable 'foo' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.",
@@ -164,17 +202,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 19,
-            "character": 13
-          }
+            "line": 20,
+            "character": 14
+          },
+          "fixed": false,
+          "hint": "The function 'timestamp' is never called. Remove the function or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'timestamp' is declared but its value is never read.",
       "hint": "The function 'timestamp' is never called. Remove the function or use it.",
@@ -190,17 +234,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 21,
-            "character": 14
-          }
+            "line": 22,
+            "character": 15
+          },
+          "fixed": false,
+          "hint": "The variable 'b' is never read or used. Remove the variable or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'b' is declared but its value is never read.",
       "hint": "The variable 'b' is never read or used. Remove the variable or use it.",
@@ -216,17 +266,23 @@
     },
     {
       "analysisTarget": "first.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "first.ts": {
           "fileName": "first.ts",
           "location": {
-            "line": 23,
-            "character": 8
-          }
+            "line": 24,
+            "character": 9
+          },
+          "fixed": false,
+          "hint": "The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2322,
+      },
+      "errorCode": 2322,
       "category": "Error",
       "message": "Type 'string' is not assignable to type 'void'.",
       "hint": "The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type.",
@@ -242,17 +298,24 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 3,
-            "character": 8
-          }
+            "line": 4,
+            "character": 9
+          },
+          "fixed": true,
+          "code": " unused",
+          "codeFixAction": "delete",
+          "hintAdded": false,
+          "roles": [
+            "analysisTarget",
+            "modified"
+          ]
         }
-      ],
-      "commentedFiles": [],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'unused' is declared but its value is never read.",
       "hint": "The variable 'unused' is never read or used. Remove the variable or use it.",
@@ -268,17 +331,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 3,
-            "character": 10
-          }
+            "line": 4,
+            "character": 11
+          },
+          "fixed": false,
+          "hint": "The variable 'unused' is never read or used. Remove the variable or use it.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 6133,
+      },
+      "errorCode": 6133,
       "category": "Error",
       "message": "'unused' is declared but its value is never read.",
       "hint": "The variable 'unused' is never read or used. Remove the variable or use it.",
@@ -294,17 +363,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 8,
-            "character": 22
-          }
+            "line": 9,
+            "character": 23
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'NonExistingElement'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingElement'.",
       "hint": "Cannot find name 'NonExistingElement'.",
@@ -320,17 +395,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 13,
-            "character": 7
-          }
+            "line": 14,
+            "character": 8
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'NonExistingElement'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingElement'.",
       "hint": "Cannot find name 'NonExistingElement'.",
@@ -346,17 +427,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 15,
-            "character": 12
-          }
+            "line": 16,
+            "character": 13
+          },
+          "fixed": false,
+          "hint": "Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode'",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2322,
+      },
+      "errorCode": 2322,
       "category": "Error",
       "message": "Type '{ $notExistingVariable: any; }' is not assignable to type 'ReactNode'..   Object literal may only specify known properties, and '$notExistingVariable' does not exist in type 'ReactElement<any, string | JSXElementConstructor<any>> | ReactFragment | ReactPortal'.",
       "hint": "Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode'",
@@ -372,17 +459,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 21,
-            "character": 12
-          }
+            "line": 22,
+            "character": 13
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'NonExistingFragment'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'NonExistingFragment'.",
       "hint": "Cannot find name 'NonExistingFragment'.",
@@ -398,17 +491,23 @@
     },
     {
       "analysisTarget": "react.tsx",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "react.tsx": {
           "fileName": "react.tsx",
           "location": {
-            "line": 28,
-            "character": 29
-          }
+            "line": 29,
+            "character": 30
+          },
+          "fixed": false,
+          "hint": "The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2322,
+      },
+      "errorCode": 2322,
       "category": "Error",
       "message": "Type '{ doesNotExist: string; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement>'..   Property 'doesNotExist' does not exist on type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement>'.",
       "hint": "The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type.",
@@ -424,17 +523,23 @@
     },
     {
       "analysisTarget": "second.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "second.ts": {
           "fileName": "second.ts",
           "location": {
-            "line": 1,
-            "character": 9
-          }
+            "line": 2,
+            "character": 10
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'readFileSync'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'readFileSync'.",
       "hint": "Cannot find name 'readFileSync'.",
@@ -450,17 +555,23 @@
     },
     {
       "analysisTarget": "second.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "second.ts": {
           "fileName": "second.ts",
           "location": {
-            "line": 12,
-            "character": 21
-          }
+            "line": 13,
+            "character": 22
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'doesNotExist'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExist'.",
       "hint": "Cannot find name 'doesNotExist'.",
@@ -476,17 +587,23 @@
     },
     {
       "analysisTarget": "second.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "second.ts": {
           "fileName": "second.ts",
           "location": {
-            "line": 20,
-            "character": 6
-          }
+            "line": 21,
+            "character": 7
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'doesNotExist'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExist'.",
       "hint": "Cannot find name 'doesNotExist'.",
@@ -502,17 +619,23 @@
     },
     {
       "analysisTarget": "second.ts",
-      "fixedFiles": [],
-      "commentedFiles": [
-        {
+      "files": {
+        "second.ts": {
           "fileName": "second.ts",
           "location": {
-            "line": 22,
-            "character": 6
-          }
+            "line": 23,
+            "character": 7
+          },
+          "fixed": false,
+          "hint": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",
+          "hintAdded": true,
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ]
         }
-      ],
-      "code": 2304,
+      },
+      "errorCode": 2304,
       "category": "Error",
       "message": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",
       "hint": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'.",

--- a/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.sarif
+++ b/packages/upgrade/test/fixtures/upgrade/.rehearsal-report.output.sarif
@@ -1,0 +1,787 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "@rehearsal/migrate",
+          "informationUri": "https://github.com/rehearsal-js/rehearsal-js",
+          "rules": [
+            {
+              "id": "TS6133",
+              "name": "TS6133",
+              "shortDescription": {
+                "text": "'fs' is declared but its value is never read."
+              },
+              "helpUri": ""
+            },
+            {
+              "id": "TS2322",
+              "name": "TS2322",
+              "shortDescription": {
+                "text": "Type 'string' is not assignable to type 'number'."
+              },
+              "helpUri": ""
+            },
+            {
+              "id": "TS2304",
+              "name": "TS2304",
+              "shortDescription": {
+                "text": "Cannot find name 'NonExistingElement'."
+              },
+              "helpUri": ""
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "first.ts"
+          },
+          "roles": [
+            "analysisTarget",
+            "modified"
+          ],
+          "properties": {
+            "fixed": true,
+            "hintAdded": true
+          }
+        },
+        {
+          "location": {
+            "uri": "react.tsx"
+          },
+          "roles": [
+            "analysisTarget",
+            "modified"
+          ],
+          "properties": {
+            "fixed": true,
+            "hintAdded": true
+          }
+        },
+        {
+          "location": {
+            "uri": "second.ts"
+          },
+          "roles": [
+            "analysisTarget",
+            "unmodified"
+          ],
+          "properties": {
+            "fixed": false,
+            "hintAdded": true
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The declaration 'fs' is never read or used. Remove the declaration or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                },
+                "properties": {
+                  "code": "import fs from 'fs';",
+                  "codeFixAction": "delete",
+                  "roles": [
+                    "analysisTarget",
+                    "modified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": true,
+            "fixes": [
+              {
+                "fileName": "first.ts",
+                "code": "import fs from 'fs';",
+                "codeFixAction": "delete"
+              }
+            ]
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The declaration 'parse' is never read or used. Remove the declaration or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 19
+                },
+                "properties": {
+                  "code": " parse",
+                  "codeFixAction": "delete",
+                  "roles": [
+                    "analysisTarget",
+                    "modified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": true,
+            "fixes": [
+              {
+                "fileName": "first.ts",
+                "code": " parse",
+                "codeFixAction": "delete"
+              }
+            ]
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The function 'sleep' is never called. Remove the function or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 3,
+                  "startColumn": 10
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The variable 'foo' is never read or used. Remove the variable or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 5
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The parameter 'inSeconds' is never used. Remove the parameter from function definition or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 20
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2322",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "The variable 'foo' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 18,
+                  "startColumn": 5
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The function 'timestamp' is never called. Remove the function or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 20,
+                  "startColumn": 14
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The variable 'b' is never read or used. Remove the variable or use it."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 22,
+                  "startColumn": 15
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2322",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type."
+          },
+          "analysisTarget": {
+            "uri": "first.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "first.ts"
+                },
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 9
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The variable 'unused' is never read or used. Remove the variable or use it."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 9
+                },
+                "properties": {
+                  "code": " unused",
+                  "codeFixAction": "delete",
+                  "roles": [
+                    "analysisTarget",
+                    "modified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": true,
+            "fixes": [
+              {
+                "fileName": "react.tsx",
+                "code": " unused",
+                "codeFixAction": "delete"
+              }
+            ]
+          }
+        },
+        {
+          "ruleId": "TS6133",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "The variable 'unused' is never read or used. Remove the variable or use it."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 11
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'NonExistingElement'."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 23
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'NonExistingElement'."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 8
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2322",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode'"
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 16,
+                  "startColumn": 13
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'NonExistingFragment'."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 22,
+                  "startColumn": 13
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2322",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type."
+          },
+          "analysisTarget": {
+            "uri": "react.tsx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "react.tsx"
+                },
+                "region": {
+                  "startLine": 29,
+                  "startColumn": 30
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'readFileSync'."
+          },
+          "analysisTarget": {
+            "uri": "second.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "second.ts"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 10
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'doesNotExist'."
+          },
+          "analysisTarget": {
+            "uri": "second.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "second.ts"
+                },
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 22
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'doesNotExist'."
+          },
+          "analysisTarget": {
+            "uri": "second.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "second.ts"
+                },
+                "region": {
+                  "startLine": 21,
+                  "startColumn": 7
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        },
+        {
+          "ruleId": "TS2304",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Cannot find name 'doesNotExistAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'."
+          },
+          "analysisTarget": {
+            "uri": "second.ts"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "second.ts"
+                },
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 7
+                },
+                "properties": {
+                  "roles": [
+                    "analysisTarget",
+                    "unmodified"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "fixed": false,
+            "fixes": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/sarif@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.4.tgz#471c5788199d22f572f255de9a8166a30abf1245"
+  integrity sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"


### PR DESCRIPTION
Adds sarif-formatter in @rehearsal/reporter; Adds transform data collection in @rehearsal/upgrade transforms; Add data messaging in @rehearsal/plugins. 

See attached file for sample sarif file generated locally.

Next iteration will be to fully utilize the built-in properties as shown in the sarif viewer, such as 'suppressed', 'unchanged', 'updated'.