### PR TITLE
chore: Avoid using `executableFile` to make command compilable for GitHub Action

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -22,7 +22,7 @@ function ifHasTypescriptInDevdep(root: string): boolean {
   );
 }
 
-const migrateCommand = new Command();
+export const migrateCommand = new Command('migrate');
 
 type migrateCommandOptions = {
   root: string;
@@ -140,8 +140,6 @@ migrateCommand
       logger.error(`${e}`);
     }
   });
-
-migrateCommand.parse(process.argv);
 
 /**
  * Generate tsconfig

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -41,7 +41,7 @@ type Context = {
   skip: boolean;
 };
 
-const upgradeCommand = new Command();
+export const upgradeCommand = new Command('upgrade');
 
 function validateTscVersion(value: string): string {
   if (isValidSemver(value)) {
@@ -291,5 +291,3 @@ upgradeCommand
 
     return;
   });
-
-upgradeCommand.parse(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,21 +1,16 @@
 import { Command } from 'commander';
 import { version } from '../package.json';
-import { join } from 'path';
+
+import { upgradeCommand } from "./commands/upgrade";
+import { migrateCommand } from "./commands/migrate";
 
 const program = new Command();
 
 program
   .name('rehearsal')
   .version(version)
-  .command(
-    'upgrade',
-    'Upgrade typescript dev-dependency with compilation insights and auto-fix options',
-    {
-      executableFile: join(__dirname, './commands/upgrade'),
-    }
-  )
-  .command('migrate', 'Migrate Javascript project to Typescript', {
-    executableFile: join(__dirname, './commands/migrate'),
-  });
+  .addCommand(upgradeCommand)
+  .addCommand(migrateCommand)
+  .parse(process.argv);
 
 export { program as cli };


### PR DESCRIPTION
See: https://github.com/rehearsal-js/action-test/runs/8218693448?check_suite_focus=true#step:4:8