### PR TITLE
chore: Avoid running CLI in index.ts file, only in ./bin

### DIFF
--- a/packages/cli/bin/rehearsal.js
+++ b/packages/cli/bin/rehearsal.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// TODO: This dosen't look good to me for now :(
 
-const { cli } = require('../dist/src/index');
-cli.parse(process.argv);
+require('../dist/src')
+  .rehearsal
+  .parse(process.argv);

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -22,7 +22,7 @@ function ifHasTypescriptInDevdep(root: string): boolean {
   );
 }
 
-export const migrateCommand = new Command('migrate');
+export const migrateCommand = new Command();
 
 type migrateCommandOptions = {
   root: string;
@@ -45,6 +45,7 @@ type ParsedModuleResult = {
 };
 
 migrateCommand
+  .name('migrate')
   .description('Migrate Javascript project to Typescript')
   .requiredOption('-r, --root <project root>', 'Base dir (root) of your project.')
   .requiredOption('-e, --entrypoint <entrypoint>', 'entrypoint js file for your project')

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -41,7 +41,7 @@ type Context = {
   skip: boolean;
 };
 
-export const upgradeCommand = new Command('upgrade');
+export const upgradeCommand = new Command();
 
 function validateTscVersion(value: string): string {
   if (isValidSemver(value)) {
@@ -64,6 +64,7 @@ type UpgradeCommandOptions = {
 };
 
 upgradeCommand
+  .name('upgrade')
   .description('Upgrade typescript dev-dependency with compilation insights and auto-fix options')
   .option('-b, --build <beta|next|latest>', 'typescript build variant', DEFAULT_TS_BUILD)
   .option('-s, --src_dir <src directory>', 'typescript source directory', DEFAULT_SRC_DIR)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,16 +1,11 @@
 import { Command } from 'commander';
 import { version } from '../package.json';
 
-import { upgradeCommand } from "./commands/upgrade";
-import { migrateCommand } from "./commands/migrate";
+import { migrateCommand } from './commands/migrate';
+import { upgradeCommand } from './commands/upgrade';
 
 const program = new Command();
 
-program
-  .name('rehearsal')
-  .version(version)
-  .addCommand(upgradeCommand)
-  .addCommand(migrateCommand)
-  .parse(process.argv);
+program.name('rehearsal').version(version).addCommand(migrateCommand).addCommand(upgradeCommand);
 
-export { program as cli };
+export { program as rehearsal, migrateCommand, upgradeCommand };

--- a/packages/cli/test/runner.ts
+++ b/packages/cli/test/runner.ts
@@ -1,0 +1,3 @@
+import { rehearsal } from '../src';
+
+rehearsal.parse(process.argv);

--- a/packages/cli/test/test-helpers.ts
+++ b/packages/cli/test/test-helpers.ts
@@ -31,7 +31,7 @@ export function run(
   args: string[],
   options: execa.Options = {}
 ): execa.ExecaChildProcess {
-  const cliPath = resolve(__dirname, `../src/index`);
+  const cliPath = resolve(__dirname, `./runner.ts`);
   // why use ts-node instead of calling bin/rehearsal.js directly?
   // during the test process there would be yarn install typescript
   // we need to run build after every install to make sure dist dir is ready to use


### PR DESCRIPTION
I'm trying to `import { rehearsal } from "@rehearsal/cli"` in GitHub Action, but it runs because of `parse(...)` in `index.js`.
Let's keep calling `parse(...)` in `./bin` and make is possible to import commands and tun them in different scenarios (including test can be upgraded).