### PR TITLE
chore: only publish the cli

### DIFF
--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/codefixes",
   "version": "0.0.33",
   "description": "Rehearsal Dependency Codefixes Collection",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/migrate",
   "version": "0.0.33",
   "description": "Rehearsal JavaScript to TypeScript Migration Tool",

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/migration-graph-ember",
   "version": "0.0.33",
   "description": "Tool for generating a typescript conversion graph for a ember.js",

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/migration-graph",
   "version": "0.0.33",
   "description": "Tool for generating a typescript conversion graph",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/plugins",
   "version": "0.0.33",
   "description": "Rehearsal JavaScript to TypeScript Shared Libraries",

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/reporter",
   "version": "0.0.33",
   "description": "Rehearsal Reporter",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/service",
   "version": "0.0.33",
   "description": "Rehearsal Service",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/upgrade",
   "version": "0.0.33",
   "description": "Rehearsal Dependency Upgrade Tool",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rehearsal/utils",
   "version": "0.0.33",
   "description": "Rehearsal Utils",


### PR DESCRIPTION
As we get closer to GA we want to reduce the public API surface area. This PR flags all packages as `private` except the `cli`.

`Lerna will never publish packages which are marked as private ("private": true in the package.json).`