### PR TITLE
bring back fixture files

### DIFF
--- a/packages/plugins/test/__snapshots__/empty-lines-restore.plugin.test.ts.snap
+++ b/packages/plugins/test/__snapshots__/empty-lines-restore.plugin.test.ts.snap
@@ -4,24 +4,24 @@ exports[`Test EmptyLinesRestorePlugin > run 1`] = `
 "// This is a single line comment
 
 // This is another single line comment
-  const someTrueVariable = true;
+ const someTrueVariable = true;
 
 /*
-  * This is multiline comment
-  *
-    
-    With some empty lines it it
-  */
+ * This is multiline comment
+ *
+   
+   With some empty lines it it
+ */
 const someFalseVariable = false;
 
-
-
+ 
+  
 /**
  * This is a JSDoc comment
  *
-
-  * With some empty lines it it
-  */
+   
+ * With some empty lines it it
+ */
 function someFunction(): void {
   
   return ;

--- a/packages/plugins/test/empty-lines-preserve.plugin.test.ts
+++ b/packages/plugins/test/empty-lines-preserve.plugin.test.ts
@@ -1,5 +1,6 @@
 import { RehearsalService } from '@rehearsal/service';
 import { Project } from 'fixturify-project';
+import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
@@ -18,33 +19,10 @@ describe('Test EmptyLinesPreservePlugin', function () {
   });
 
   test('run', async () => {
-    project.files['index.ts'] = `
-// This is a single line comment
-
-// This is another single line comment
-const someTrueVariable = true;
-
-/*
-* This is multiline comment
-*
-
-  With some empty lines it it
-*/
-const someFalseVariable = false;
-
-
-
-/**
- * This is a JSDoc comment
- *
-
-* With some empty lines it it
-*/
-function someFunction(): void {
-
-  return ;
-}
-    `;
+    project.files['index.ts'] = await readFile(
+      './test/fixtures/empty-lines-preserve.fixture',
+      'utf-8'
+    );
 
     project.write();
 

--- a/packages/plugins/test/empty-lines-restore.plugin.test.ts
+++ b/packages/plugins/test/empty-lines-restore.plugin.test.ts
@@ -1,5 +1,6 @@
 import { RehearsalService } from '@rehearsal/service';
 import { Project } from 'fixturify-project';
+import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
@@ -18,33 +19,10 @@ describe('Test EmptyLinesRestorePlugin', function () {
   });
 
   test('run', async () => {
-    project.files['index.ts'] = `
-// This is a single line comment
-//:line:
-// This is another single line comment
-  const someTrueVariable = true;
-//:line:
-/*
-  * This is multiline comment
-  *
-    //:line:
-    With some empty lines it it
-  */
-const someFalseVariable = false;
-//:line:
-//:line:
-//:line:
-/**
- * This is a JSDoc comment
- *
-//:line:
-  * With some empty lines it it
-  */
-function someFunction(): void {
-  //:line:
-  return ;
-}
-    `;
+    project.files['index.ts'] = await readFile(
+      './test/fixtures/empty-lines-restore.fixture',
+      'utf-8'
+    );
     project.write();
 
     const fileNames = Object.keys(project.files).map((file) => resolve(project.baseDir, file));

--- a/packages/plugins/test/fixtures/empty-lines-preserve.fixture
+++ b/packages/plugins/test/fixtures/empty-lines-preserve.fixture
@@ -1,29 +1,25 @@
-// Vitest Snapshot v1
+// This is a single line comment
 
-exports[`Test EmptyLinesPreservePlugin > run 1`] = `
-"// This is a single line comment
-//:line:
 // This is another single line comment
  const someTrueVariable = true;
-//:line:
+
 /*
  * This is multiline comment
  *
-//:line:
+
    With some empty lines it it
  */
 const someFalseVariable = false;
-//:line:
-//:line:
-//:line:
+
+
+
 /**
  * This is a JSDoc comment
  *
-//:line:
+
  * With some empty lines it it
  */
 function someFunction(): void {
-//:line:
+
   return ;
-}"
-`;
+}

--- a/packages/plugins/test/fixtures/empty-lines-restore.fixture
+++ b/packages/plugins/test/fixtures/empty-lines-restore.fixture
@@ -1,7 +1,4 @@
-// Vitest Snapshot v1
-
-exports[`Test EmptyLinesPreservePlugin > run 1`] = `
-"// This is a single line comment
+// This is a single line comment
 //:line:
 // This is another single line comment
  const someTrueVariable = true;
@@ -9,21 +6,20 @@ exports[`Test EmptyLinesPreservePlugin > run 1`] = `
 /*
  * This is multiline comment
  *
-//:line:
+   //:line:
    With some empty lines it it
  */
 const someFalseVariable = false;
 //:line:
-//:line:
-//:line:
+ //:line:
+  //:line:
 /**
  * This is a JSDoc comment
  *
-//:line:
+   //:line:
  * With some empty lines it it
  */
 function someFunction(): void {
-//:line:
+  //:line:
   return ;
-}"
-`;
+}

--- a/packages/plugins/test/fixtures/re-rehearse.fixture
+++ b/packages/plugins/test/fixtures/re-rehearse.fixture
@@ -1,0 +1,32 @@
+/**
+ * This is a file with some comments added in a previous run of rehearsal
+ */
+import fs from 'fs';
+
+/* @rehearsal TODO TS6133: This message should be updated... */
+function unusedFunction(): boolean {
+  return fs.existsSync('.')
+}
+
+/* @rehearsal TODO TS007: This comment should be kept, plus another comment needs to be added 6133. */
+let unusedVariable: number;
+
+/* This is just a second comment that should not be touch */
+/* @rehearsal TODO TS6133: The variable 'unusedConst' is never read or used. Remove the variable or use it. */
+const unusedConst1 = null;
+
+/* @rehearsal TODO TS6133: Comment. */ fs.existsSync('.');
+const unusedConst2 = null;
+
+fs.existsSync('.'); /* @rehearsal TODO TS6133: Comment. */
+const unusedConst3 = null;
+
+
+fs.existsSync('@rehearsal')
+const unusedConstWithoutCommentButWithRehearsalTagAbove = null;
+
+const resultValue = something
+    ? /* @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
+      missingVar
+    : /* @rehearsal TODO TS2304: Cannot find name 'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'. */
+      missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;

--- a/packages/plugins/test/re-rehearse.plugin.test.ts
+++ b/packages/plugins/test/re-rehearse.plugin.test.ts
@@ -1,5 +1,6 @@
 import { RehearsalService } from '@rehearsal/service';
 import { Project } from 'fixturify-project';
+import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
@@ -18,41 +19,7 @@ describe('Test ReRehearsalPlugin', function () {
   });
 
   test('run', async () => {
-    project.files['index.ts'] = `
-/**
- * This is a file with some comments added in a previous run of rehearsal
- */
-import fs from 'fs';
-
-/* @rehearsal TODO TS6133: This message should be updated... */
-function unusedFunction(): boolean {
-  return fs.existsSync('.')
-}
-
-/* @rehearsal TODO TS007: This comment should be kept, plus another comment needs to be added 6133. */
-let unusedVariable: number;
-
-/* This is just a second comment that should not be touch */
-/* @rehearsal TODO TS6133: The variable 'unusedConst' is never read or used. Remove the variable or use it. */
-const unusedConst1 = null;
-
-/* @rehearsal TODO TS6133: Comment. */ fs.existsSync('.');
-const unusedConst2 = null;
-
-fs.existsSync('.'); /* @rehearsal TODO TS6133: Comment. */
-const unusedConst3 = null;
-
-
-fs.existsSync('@rehearsal')
-const unusedConstWithoutCommentButWithRehearsalTagAbove = null;
-
-const resultValue = something
-    ? /* @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
-      missingVar
-    : /* @rehearsal TODO TS2304: Cannot find name 'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'. */
-      missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;
-    `;
-
+    project.files['index.ts'] = await readFile('./test/fixtures/re-rehearse.fixture', 'utf-8');
     project.write();
     const fileNames = Object.keys(project.files).map((file) => resolve(project.baseDir, file));
 


### PR DESCRIPTION
This brings back fixture input files to make sure we can control the whitespace of the input. We still should retain the snapshots because they will fail if we mess up the whitespace and its easy to update if the change is intentional.