### PR TITLE
chore: Remove -a and -i options from upgrade command + typo

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -14,8 +14,8 @@ import { createLogger, format, transports } from 'winston';
 
 import {
   FormatterMap,
-  migrateCommandContext,
-  migrateCommandOptions,
+  MigrateCommandContext,
+  MigrateCommandOptions,
   ParsedModuleResult,
 } from '../types';
 import { UserConfig } from '../userConfig';
@@ -50,7 +50,7 @@ migrateCommand
     'File path for custom config'
   )
   .option('-v, --verbose', 'Print more logs to debug.')
-  .action(async (options: migrateCommandOptions) => {
+  .action(async (options: MigrateCommandOptions) => {
     console.log(options);
     const loggerLevel = options.verbose ? 'debug' : 'info';
     const logger = createLogger({
@@ -62,7 +62,7 @@ migrateCommand
       ? new UserConfig(options.basePath, options.userConfig, 'migrate')
       : undefined;
 
-    const tasks = new Listr<migrateCommandContext>(
+    const tasks = new Listr<MigrateCommandContext>(
       [
         {
           title: 'Installing dependencies',

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,12 +1,12 @@
 import { Report } from '@rehearsal/reporter';
 
-export type CliConmand = `upgrade` | 'migrate';
+export type CliCommand = `upgrade` | 'migrate';
 
-export type migrateCommandOptions = {
+export type MigrateCommandOptions = {
   basePath: string;
   entrypoint: string;
   files: string;
-  report: Array<string> | undefined;
+  report: string[] | undefined;
   outputPath: string | undefined;
   verbose: boolean | undefined;
   clean: boolean | undefined;
@@ -14,14 +14,14 @@ export type migrateCommandOptions = {
   userConfig: string | undefined;
 };
 
-export type migrateCommandContext = {
+export type MigrateCommandContext = {
   skip: boolean;
-  sourceFiles: Array<string>;
+  sourceFiles: string[];
 };
 
 export type ParsedModuleResult = {
   edgeList: Array<[string, string | undefined]>;
-  coreDepList: Array<string>;
+  coreDepList: string[];
 };
 
 export type FormatterFunction = (report: Report) => string;
@@ -44,27 +44,26 @@ export type UpgradeCommandOptions = {
   dry_run: boolean | undefined;
   tsc_version: string;
   report_output: string;
-  is_test: boolean | undefined;
 };
 
-export type dependencyConfig = {
+export type DependencyConfig = {
   dependencies?: string[];
   devDependencies?: string[];
 };
 
-export type setupConfigCommand = {
+export type SetupConfigCommand = {
   command: string;
   args: string[];
 };
 
-export type setupConfig = {
-  ts?: setupConfigCommand;
-  lint?: setupConfigCommand;
+export type SetupConfig = {
+  ts?: SetupConfigCommand;
+  lint?: SetupConfigCommand;
 };
 
 export type CustomCommandConfig = {
-  install?: dependencyConfig;
-  setup?: setupConfig;
+  install?: DependencyConfig;
+  setup?: SetupConfig;
 };
 
 export type CustomConfig = {

--- a/packages/cli/src/userConfig.ts
+++ b/packages/cli/src/userConfig.ts
@@ -2,10 +2,10 @@ import execa from 'execa';
 import { readJSONSync } from 'fs-extra';
 import { resolve } from 'path';
 
-import { CliConmand, CustomCommandConfig, CustomConfig } from './types';
+import { CliCommand, CustomCommandConfig, CustomConfig } from './types';
 import { addDep } from './utils';
 
-// Storage and ruuner for user custom cli config
+// Storage and runner for user custom cli config
 export class UserConfig {
   private basePath: string;
   private config: CustomCommandConfig;
@@ -26,7 +26,7 @@ export class UserConfig {
     return !!this.config?.setup?.lint;
   }
 
-  constructor(basePath: string, configPath: string, command: CliConmand) {
+  constructor(basePath: string, configPath: string, command: CliCommand) {
     const config: CustomConfig = readJSONSync(resolve(basePath, configPath));
     this.config = config[command]!;
     this.basePath = basePath;

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -35,26 +35,24 @@ const revertTSCVersion = async (): Promise<void> => {
 
 afterAll(revertTSCVersion);
 
-describe('upgrade:command against fixture', async () => {
+describe('upgrade:command', async () => {
   beforeAll(beforeSetup);
   afterAll(afterEachCleanup);
 
-  test('WITH autofix', async () => {
+  test('against fixture', async () => {
     const result = await run('upgrade', [
       '--src_dir',
       FIXTURE_APP_PATH,
       '--dry_run',
-      '--is_test',
       '--report_output',
       FIXTURE_APP_PATH,
-      '--autofix',
     ]);
 
     // default is beta unless otherwise specified
     const latestPublishedTSVersion = await getLatestTSVersion();
 
     expect(result.stdout).contain(`Rehearsing with typescript@${latestPublishedTSVersion}`);
-    expect(result.stdout).to.contain(`Autofix successful: code changes applied`);
+    expect(result.stdout).to.contain(`Codefixes applied successfully`);
     expect(existsSync(RESULTS_FILEPATH)).toBeTruthy;
 
     const report: Report = readJSONSync(RESULTS_FILEPATH);
@@ -98,19 +96,6 @@ describe('upgrade:command against fixture', async () => {
       `'execa' can only be imported by using 'import execa = require("execa")' or a default import.`
     );
   });
-
-  test('WITHOUT autofix', async () => {
-    const result = await run('upgrade', [
-      '--src_dir',
-      FIXTURE_APP_PATH,
-      '--dry_run',
-      '--is_test',
-      '--report_output',
-      FIXTURE_APP_PATH,
-    ]);
-
-    expect(result.stdout).toContain(`Autofix successful: ts-expect-error comments added`);
-  });
 });
 
 describe('upgrade:command tsc version check', async () => {
@@ -146,7 +131,6 @@ describe('upgrade:command tsc version check', async () => {
       '--tsc_version',
       TEST_TSC_VERSION,
       '--dry_run',
-      '--is_test',
     ]);
 
     // TODO: Fix CLI or this test


### PR DESCRIPTION
Removed redundant options (-a doesn't currently work as expected)
Fix some typo, rename types to start from upper case letters 