### PR TITLE
chore: Don't create a branch when run with --dry_run

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -141,8 +141,10 @@ upgradeCommand
               {
                 title: `Bumping TypeScript Dev-Dependency to typescript@${ctx.tsVersion}`,
                 task: async (ctx: UpgradeCommandContext) => {
-                  // there will be a diff so branch is created
-                  await gitCheckoutNewLocalBranch(`${ctx.tsVersion}`);
+                  if (!options.dry_run) {
+                    // there will be a diff so branch is created
+                    await gitCheckoutNewLocalBranch(`${ctx.tsVersion}`);
+                  }
                   await bumpDevDep(`typescript@${ctx.tsVersion}`);
                 },
               },


### PR DESCRIPTION
Planning to remove all git interaction, but let's just keep them disabled with --dry_run for now.