### PR TITLE
Remove linking in test

### DIFF
--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import packageJson from '../../package.json';
 import { getLatestTSVersion, git } from '../../src/utils';
-import { gitDeleteLocalBranch, run, YARN_PATH } from '../test-helpers';
+import { gitDeleteLocalBranch, runTSNode, YARN_PATH } from '../test-helpers';
 
 const FIXTURE_APP_PATH = resolve(__dirname, '../fixtures/app');
 const RESULTS_FILEPATH = join(FIXTURE_APP_PATH, '.rehearsal.json');
@@ -40,7 +40,7 @@ describe('upgrade:command', async () => {
   afterAll(afterEachCleanup);
 
   test('against fixture', async () => {
-    const result = await run('upgrade', [
+    const result = await runTSNode('upgrade', [
       '--src_dir',
       FIXTURE_APP_PATH,
       '--dry_run',
@@ -104,7 +104,7 @@ describe('upgrade:command tsc version check', async () => {
 
   test(`it is on typescript invalid tsc_version`, async () => {
     try {
-      await run('upgrade', ['--tsc_version', '']);
+      await runTSNode('upgrade', ['--tsc_version', '']);
     } catch (error) {
       expect(`${error}`).to.contain(
         `The tsc_version specified is an invalid string. Please specify a valid version as n.n.n`
@@ -112,7 +112,7 @@ describe('upgrade:command tsc version check', async () => {
     }
 
     try {
-      await run('upgrade', ['--tsc_version', '0']);
+      await runTSNode('upgrade', ['--tsc_version', '0']);
     } catch (error) {
       expect(`${error}`).to.contain(
         `The tsc_version specified is an invalid string. Please specify a valid version as n.n.n`
@@ -125,7 +125,7 @@ describe('upgrade:command tsc version check', async () => {
     await execa(YARN_PATH, ['add', '-D', `typescript@${TEST_TSC_VERSION}`, '--ignore-scripts']);
     await execa(YARN_PATH, ['install']);
 
-    const result = await run('upgrade', [
+    const result = await runTSNode('upgrade', [
       '--src_dir',
       FIXTURE_APP_PATH,
       '--tsc_version',

--- a/packages/cli/test/test-helpers.ts
+++ b/packages/cli/test/test-helpers.ts
@@ -27,7 +27,7 @@ export async function gitDeleteLocalBranch(checkoutBranch?: string): Promise<voi
 
 // helper funcion to run a command via ts-node
 // stdout of commands available via ExecaChildProcess.stdout
-export function run(
+export function runTSNode(
   command: string,
   args: string[],
   options: execa.Options = {}
@@ -39,11 +39,13 @@ export function run(
   return execa(YARN_PATH, ['ts-node', cliPath, command, ...args], options);
 }
 
-// Run linked rehearsal bin directly
-export function runLinkedBin(
+// helper funcion to run a command via the actual bin
+// stdout of commands available via ExecaChildProcess.stdout
+export function runBin(
   command: string,
   args: string[],
   options: execa.Options = {}
 ): execa.ExecaChildProcess {
-  return execa('rehearsal', [command, ...args], options);
+  const cliPath = resolve(__dirname, `../bin/rehearsal.js`);
+  return execa(cliPath, [command, ...args], options);
 }


### PR DESCRIPTION
It's not necessary and clean to do `yarn link` to get executable on the machine for test in `migrate`, this PR adds a helper function to run the bin directly from `./bin/rehearsal.js`