### PR TITLE
chore: improvements for migrate

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -9,6 +9,7 @@ import { Command } from 'commander';
 import { existsSync, readJSONSync, rmSync, writeJsonSync } from 'fs-extra';
 import { Listr } from 'listr2';
 import { resolve } from 'path';
+// import inquirer from 'inquirer';
 import { createLogger, format, transports } from 'winston';
 
 import { generateReports } from '../helpers/report';
@@ -57,20 +58,36 @@ migrateCommand
       transports: [new transports.Console({ format: format.cli(), level: loggerLevel })],
     });
 
-    // get custom config
-    const userConfig = options.userConfig
-      ? new UserConfig(options.basePath, options.userConfig, 'migrate')
-      : undefined;
-
     const tasks = new Listr<MigrateCommandContext>(
       [
+        {
+          title: 'Initializatoin',
+          task: async (_ctx, task) => {
+            // get custom config
+            const userConfig = options.userConfig
+              ? new UserConfig(options.basePath, options.userConfig, 'migrate')
+              : undefined;
+
+            _ctx.userConfig = userConfig;
+
+            const strategy = getMigrationStrategy(options.basePath, {
+              entrypoint: options.entrypoint,
+            });
+            const files: Array<SourceFile> = strategy.getMigrationOrder();
+            _ctx.strategy = strategy;
+            _ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);
+            _ctx.sourceFilesWithRelativePath = files.map((f) => f.relativePath);
+
+            task.title = `Initializatoin Completed! Running migration on ${_ctx.strategy.sourceType}`;
+          },
+        },
         {
           title: 'Installing dependencies',
           task: async (_ctx, task) => {
             // install custom dependencies
-            if (userConfig?.hasDependencies) {
+            if (_ctx.userConfig?.hasDependencies) {
               task.title = `Installing custom dependencies`;
-              await userConfig.install();
+              await _ctx.userConfig.install();
             }
 
             if (ifHasTypescriptInDevdep(options.basePath)) {
@@ -83,9 +100,9 @@ migrateCommand
         {
           title: 'Creating tsconfig.json',
           task: async (_ctx, task) => {
-            if (userConfig?.hasTsSetup) {
+            if (_ctx.userConfig?.hasTsSetup) {
               task.title = `Creating tsconfig from custom config.`;
-              await userConfig.tsSetup();
+              await _ctx.userConfig.tsSetup();
             } else {
               const configPath = resolve(options.basePath, 'tsconfig.json');
 
@@ -94,36 +111,25 @@ migrateCommand
               } else {
                 task.title = `Creating ${options.strict ? 'strict' : 'basic'} tsconfig.`;
 
-                // TODO We shouldn't run this twice, but it's ok for small applications.
-                const strategy = getMigrationStrategy(options.basePath, {
-                  entrypoint: options.entrypoint,
-                });
-                const files: Array<SourceFile> = strategy.getMigrationOrder();
-                const sourceFiles: Array<string> = files.map((f) => f.relativePath);
-
-                createTSConfig(options.basePath, sourceFiles, !!options.strict);
+                createTSConfig(
+                  options.basePath,
+                  _ctx.sourceFilesWithRelativePath,
+                  !!options.strict
+                );
               }
             }
           },
         },
         {
           title: 'Converting JS files to TS',
-          task: async (ctx, task) => {
+          task: async (_ctx, task) => {
             const projectName = (await determineProjectName()) || '';
             const reporter = new Reporter(projectName, options.basePath, logger);
 
-            // TODO We shouldn't run this twice, but it's ok for small applications.
-            const strategy = getMigrationStrategy(options.basePath, {
-              entrypoint: options.entrypoint,
-            });
-            const files: Array<SourceFile> = strategy.getMigrationOrder();
-            const sourceFiles: string[] = files.map((f) => f.path);
-
-            ctx.sourceFiles = sourceFiles;
-            if (sourceFiles) {
+            if (_ctx.sourceFilesWithAbsolutePath) {
               const input = {
                 basePath: options.basePath,
-                sourceFiles,
+                sourceFiles: _ctx.sourceFilesWithAbsolutePath,
                 logger: options.verbose ? logger : undefined,
                 reporter,
               };
@@ -145,9 +151,9 @@ migrateCommand
         },
         {
           title: 'Clean up old JS files', // TODO: flag
-          task: async (ctx, task) => {
-            if (ctx.sourceFiles.length && options.clean) {
-              cleanJSFiles(ctx.sourceFiles);
+          task: async (_ctx, task) => {
+            if (_ctx.sourceFilesWithAbsolutePath.length && options.clean) {
+              cleanJSFiles(_ctx.sourceFilesWithAbsolutePath);
             } else {
               task.skip(`Skipping clean up task`);
             }
@@ -164,9 +170,9 @@ migrateCommand
         {
           title: 'Creating lint config',
           task: async (_ctx, task) => {
-            if (userConfig?.hasLintSetup) {
+            if (_ctx.userConfig?.hasLintSetup) {
               task.title = `Creating .eslintrc.js from custom config.`;
-              await userConfig.lintSetup();
+              await _ctx.userConfig.lintSetup();
             } else {
               task.skip(`Skip creating .eslintrc.js since no custom config is provided.`);
             }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -9,7 +9,6 @@ import { Command } from 'commander';
 import { existsSync, readJSONSync, rmSync, writeJsonSync } from 'fs-extra';
 import { Listr } from 'listr2';
 import { resolve } from 'path';
-// import inquirer from 'inquirer';
 import { createLogger, format, transports } from 'winston';
 
 import { generateReports } from '../helpers/report';

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,6 @@
+import { MigrationStrategy } from '@rehearsal/migration-graph';
+
+import { UserConfig } from './userConfig';
 export type CliCommand = `upgrade` | 'migrate';
 
 export type MigrateCommandOptions = {
@@ -14,7 +17,10 @@ export type MigrateCommandOptions = {
 
 export type MigrateCommandContext = {
   skip: boolean;
-  sourceFiles: string[];
+  userConfig: UserConfig | undefined;
+  strategy: MigrationStrategy;
+  sourceFilesWithAbsolutePath: string[];
+  sourceFilesWithRelativePath: string[];
 };
 
 export type UpgradeCommandContext = {

--- a/packages/migration-graph/src/migration-strategy.ts
+++ b/packages/migration-graph/src/migration-strategy.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { join, relative } from 'path';
 
-import { buildMigrationGraph, MigrationGraphOptions } from './migration-graph';
+import { buildMigrationGraph, DetectedSource, MigrationGraphOptions } from './migration-graph';
 import { ModuleNode, PackageNode } from './types';
 import { GraphNode } from './utils/graph-node';
 
@@ -35,6 +35,11 @@ export class SourceFile {
 
 export class MigrationStrategy {
   #files: Array<SourceFile> = [];
+  #sourceType: DetectedSource;
+
+  constructor(sourceType: DetectedSource) {
+    this.#sourceType = sourceType;
+  }
 
   addFile(file: SourceFile): void {
     this.#files.push(file);
@@ -42,6 +47,10 @@ export class MigrationStrategy {
 
   get files(): Array<SourceFile> {
     return this.#files;
+  }
+
+  get sourceType(): DetectedSource {
+    return this.#sourceType;
   }
 
   getMigrationOrder(): Array<SourceFile> {
@@ -65,7 +74,7 @@ export function getMigrationStrategy(
   rootDir = fs.realpathSync(rootDir);
   const m = buildMigrationGraph(rootDir, options);
 
-  const strategy = new MigrationStrategy();
+  const strategy = new MigrationStrategy(m.sourceType);
 
   m.graph
     .topSort()

--- a/packages/migration-graph/tests/migration-strategy.test.ts
+++ b/packages/migration-graph/tests/migration-strategy.test.ts
@@ -6,6 +6,7 @@ const TEST_TIMEOUT = 500000;
 
 import { PreparedApp } from 'scenario-tester';
 
+import { DetectedSource } from '../src/migration-graph';
 import { getMigrationStrategy, SourceFile } from '../src/migration-strategy';
 import { getLibrarySimple, getLibraryWithEntrypoint } from './fixtures/library';
 
@@ -17,6 +18,7 @@ describe('migration-strategy', () => {
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
       expect(relativePaths).toStrictEqual(['lib/a.js', 'index.js']);
+      expect(strategy.sourceType).toBe(DetectedSource.Library);
     });
     test('simple with entrypoint', () => {
       const rootDir = getLibraryWithEntrypoint();
@@ -24,6 +26,7 @@ describe('migration-strategy', () => {
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
       expect(relativePaths).toStrictEqual(['foo.js', 'depends-on-foo.js']);
+      expect(strategy.sourceType).toBe(DetectedSource.Library);
     });
   });
 
@@ -45,6 +48,7 @@ describe('migration-strategy', () => {
           'app/components/salutation.js',
           'app/router.js',
         ]);
+        expect(strategy.sourceType).toBe(DetectedSource.EmberApp);
       },
       TEST_TIMEOUT
     );
@@ -65,6 +69,7 @@ describe('migration-strategy', () => {
           'app/components/salutation.js',
           'app/router.js',
         ]);
+        expect(strategy.sourceType).toBe(DetectedSource.EmberApp);
       },
       TEST_TIMEOUT
     );
@@ -86,6 +91,7 @@ describe('migration-strategy', () => {
           'app/components/salutation.js',
           'app/router.js',
         ]);
+        expect(strategy.sourceType).toBe(DetectedSource.EmberApp);
       },
       TEST_TIMEOUT
     );
@@ -102,6 +108,7 @@ describe('migration-strategy', () => {
           'app/components/greet.js',
           'index.js',
         ]);
+        expect(strategy.sourceType).toBe(DetectedSource.EmberAddon);
       },
       TEST_TIMEOUT
     );


### PR DESCRIPTION
This PR:
- In `migrate cli`, use `context` to store all data so that we don't need to call `getMigrationStrategy` multiple times
- Expose `sourceType` in `MigrationStrategy`, so we have a way to tell the project type in the `interactive` mode