### PR TITLE
chore: Reduce peerDependencies TS version to 4.0

### DIFF
--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -38,7 +38,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -40,7 +40,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -38,7 +38,7 @@
     "walk-sync": "^3"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -32,7 +32,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -37,7 +37,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {


### PR DESCRIPTION
Closes #305. We can try even 3.x (but we need to test r, but I think 4.0 is fine for now. 