### PR TITLE
fix: Fix `migrate` test

### DIFF
--- a/packages/cli/test/fixtures/app_for_migrate/src/basic/index.js
+++ b/packages/cli/test/fixtures/app_for_migrate/src/basic/index.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import ts from 'typescript';
 
 export function power(foo, bar) {
   return Math.pow(foo, bar);

--- a/packages/cli/test/fixtures/app_for_migrate/src/basic/package.json
+++ b/packages/cli/test/fixtures/app_for_migrate/src/basic/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "path": "*"    
+    "typescript": "*"    
   },
   "packageManager": "pnpm@7.12.1"
 }


### PR DESCRIPTION
Fix for an interesting issue.

We previously imported `path` and the test worked well because some other packages had a `path` in dependencies and `yarn` installed it directly to node_modules, this is not the case for `pnpm` because it installs app packages to `.pmpm` and only put symlinks to deps mentioned in the project's package.json (to deps of deps) root `node_modules`. 

Fix for issues is to import something we have in our package json.

Don't have an idea why tests pass in CI though...