### PR TITLE
fix: Fix `migrate` test

### DIFF
--- a/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
@@ -14,7 +14,8 @@ console.log(say('hello'));
 `;
 
 exports[`migrate - JS to TS conversion > able to migrate single JS file 1`] = `
-"import path from 'path';
+"/* @ts-ignore @rehearsal TODO TS2307: Cannot find module 'path' or its corresponding type declarations. */
+import path from 'path';
 
 export function power(foo, bar) {
   return Math.pow(foo, bar);


### PR DESCRIPTION
Fix for an interesting issue.

The app from fixtures is copied to temp directory and uses globally installed deps (because we don't run install in migrate).
Test passed with `yarn` because engineers had `path` package globally installed on dev machines.
This is not the case with `pnpm` by default.

This PR is just fixes the test to pass on dev machine.
To get rig of this message we have to either install test app deps or install them globaly.