### PR TITLE
test: add vitest config for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "name": "Debug Current Test File",
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
-      "args": ["run", "${relativeFile}"],
+      "args": ["run", "${relativeFile}", "--config", "${workspaceFolder}/vitest.config.ts"],
       "smartStep": true,
       "console": "integratedTerminal"
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+//eslint-disable-next-line import/no-default-export
+export default defineConfig({
+  test: {
+    testTimeout: 100_000,
+    hookTimeout: 50_000,
+    watchExclude: ['package.json', '**/fixtures/**'],
+    threads: false,
+  },
+});


### PR DESCRIPTION
This PR adds a vitest.config.ts to the project root for vscode and fixes launch.json type to `node`