### PR TITLE
test: reduce eslint import rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,8 @@ module.exports = {
     'import/no-extraneous-dependencies': 'error',
     'import/no-unassigned-import': 'error',
     'import/no-unresolved': 'off',
+    'import/namespace': 'off',
+    'import/named': 'off',
     'import/order': [
       'error',
       {


### PR DESCRIPTION
This PR turns off 2 eslint plugins because they are taking forever to run:
- import/named
- import/namespace