### PR TITLE
feat: migration state

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -135,8 +135,6 @@ migrateCommand
             _ctx.strategy = strategy;
             _ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);
             _ctx.sourceFilesWithRelativePath = files.map((f) => f.relativePath);
-
-            // _ctx.skip = true;
           },
         },
         {
@@ -182,8 +180,6 @@ migrateCommand
           task: async (_ctx, task) => {
             const projectName = (await determineProjectName()) || '';
             const reporter = new Reporter(projectName, options.basePath, logger);
-
-            _ctx.skip = true;
 
             if (_ctx.sourceFilesWithAbsolutePath) {
               const input = {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -69,7 +69,6 @@ migrateCommand
         {
           title: 'Initialization',
           task: async (_ctx, task) => {
-            // _ctx.skip = true;
             // get custom config
             const userConfig = options.userConfig
               ? new UserConfig(options.basePath, options.userConfig, 'migrate')

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -35,6 +35,10 @@ function ifHasTypescriptInDevdep(basePath: string): boolean {
 
 export const migrateCommand = new Command();
 
+process.on('SIGINT', () => {
+  console.log('Received SIGINT. Press Control-D to exit.');
+});
+
 migrateCommand
   .name('migrate')
   .description('Migrate Javascript project to Typescript')
@@ -77,7 +81,7 @@ migrateCommand
             if (options.interactive) {
               // Init state and store
               const state = new State(
-                projectName as string,
+                projectName,
                 packages.map((p) => p.path)
               );
               _ctx.state = state;

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -5,7 +5,7 @@ import execa from 'execa';
 // The reaosn to have packageMap is getting all files in a package faster
 // than loop through everyhing in the files
 export type Store = {
-  name: string;
+  name: string | null;
   packageMap: PackageMap;
   files: FileStateMap;
 };
@@ -41,7 +41,11 @@ const REHEARSAL_TODO_REGEX = /@rehearsal TODO/g;
 export class State {
   private configPath: string;
   private store: Store;
-  constructor(name: string, packages: string[] = [], configPath: string = DEFAULT_CONFIG_PATH) {
+  constructor(
+    name: string | null,
+    packages: string[] = [],
+    configPath: string = DEFAULT_CONFIG_PATH
+  ) {
     this.configPath = configPath;
     let store;
     if (this.isStateExists()) {
@@ -53,7 +57,7 @@ export class State {
         map[current] = [];
         return map;
       }, initPackageMap);
-      store = { name, packageMap, files: {} };
+      store = { name: name ? name : '', packageMap, files: {} };
     }
     this.store = store;
     this.saveState();

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -1,0 +1,142 @@
+import { resolve } from 'path';
+import { existsSync, writeJSONSync, readJSONSync, readFileSync, mkdirSync } from 'fs-extra';
+import execa from 'execa';
+
+export type Store = {
+  name: string;
+  packageMap: PackageMap;
+  files: FileStateMap;
+};
+
+// represent single file state
+type FileState = {
+  package: string;
+  errorCount: number;
+};
+
+// use file path as key
+export type FileStateMap = {
+  [key: string]: FileState;
+};
+
+// help to get all files from a package instead of looping all files
+type PackageMap = {
+  [key: string]: string[];
+};
+
+type PackageMigrateProgress = {
+  completeFileCount: number;
+  inProgressFileCount: number;
+  totalFileCount: number;
+};
+
+const DEFAULT_REHEARSAL_PATH = resolve(process.cwd(), '.rehearsal');
+const DEFAULT_CONFIG_PATH = resolve(DEFAULT_REHEARSAL_PATH, 'migrate-state.json');
+const REHEARSAL_TODO_REGEX = /@rehearsal TODO/g;
+
+export class State {
+  private configPath: string;
+  private store: Store;
+  constructor(name: string, packages: string[] = [], configPath: string = DEFAULT_CONFIG_PATH) {
+    this.configPath = configPath;
+    if (this.checkState()) {
+      const store = this.readState();
+      this.store = store;
+      this.saveState();
+    } else {
+      const initPackageMap: PackageMap = {};
+      const packageMap: PackageMap = packages.reduce((map, current) => {
+        map[current] = [];
+        return map;
+      }, initPackageMap);
+      this.store = { name, packageMap, files: {} };
+      this.saveState();
+    }
+  }
+
+  get packages(): PackageMap {
+    return this.store.packageMap;
+  }
+
+  get files(): FileStateMap {
+    return this.store.files;
+  }
+
+  // if state exists, load the state file and verify
+  readState(): Store {
+    const store: Store = readJSONSync(this.configPath);
+    Object.entries(store.packageMap).forEach(([packageName, fileMap]) => {
+      const result = fileMap.filter((f) => {
+        if (!existsSync(f)) {
+          // if a file in state doesn't exist, remove if from both files and inside the package map
+          delete store.files[f];
+          return false;
+        }
+        return true;
+      });
+      store.packageMap[packageName] = result;
+    });
+    return store;
+  }
+
+  checkState(): boolean {
+    if (!existsSync(DEFAULT_REHEARSAL_PATH)) {
+      mkdirSync(DEFAULT_REHEARSAL_PATH);
+    }
+    return existsSync(this.configPath);
+  }
+
+  saveState(): void {
+    writeJSONSync(this.configPath, this.store, { spaces: 2 });
+  }
+
+  addFilesToPackage(packageName: string, files: string[]): void {
+    const fileMap: FileStateMap = {};
+    // save files to package map for easier retrieve
+    this.store.packageMap[packageName] = files;
+
+    files.forEach(
+      (f: keyof FileStateMap) =>
+        (fileMap[f] = {
+          package: packageName,
+          errorCount: calculateTSError(f as string),
+        })
+    );
+    this.store.files = { ...this.store.files, ...fileMap };
+    this.saveState();
+  }
+
+  getPackageMigrateProgress(packageName: string): PackageMigrateProgress {
+    const fileList = this.store.packageMap[packageName];
+    let completeFileCount = 0;
+    let inProgressFileCount = 0;
+    fileList.forEach((f) => {
+      const fileState = this.store.files[f];
+      if (fileState.errorCount === 0) {
+        completeFileCount++;
+      } else {
+        inProgressFileCount++;
+      }
+    });
+    return {
+      completeFileCount,
+      inProgressFileCount,
+      totalFileCount: completeFileCount + inProgressFileCount,
+    };
+  }
+
+  async addStateFileToGit(): Promise<void> {
+    try {
+      // check if git history exists
+      await execa('git', ['status']);
+      await execa('git', ['add', this.configPath]);
+    } catch (e) {
+      // no ops
+    }
+  }
+}
+
+export function calculateTSError(filePath: string): number {
+  const content = readFileSync(filePath, 'utf-8');
+  return (content.match(REHEARSAL_TODO_REGEX) || []).length;
+}

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -76,6 +76,8 @@ export class State {
         // if a ts file in state doesn't exist on disk, mark it as un-migrated
         store.files[f].current = null;
       }
+      // update ts-ignore count
+      store.files[f].errorCount = calculateTSIgnoreCount(f);
     }
     return store;
   }
@@ -102,7 +104,7 @@ export class State {
           origin: f.replace('.ts', '.js'),
           current: f,
           package: packageName,
-          errorCount: calculateTSError(f as string),
+          errorCount: calculateTSIgnoreCount(f as string),
         })
     );
     this.store.files = { ...this.store.files, ...fileMap };
@@ -147,7 +149,7 @@ export class State {
   }
 }
 
-export function calculateTSError(filePath: string): number {
+export function calculateTSIgnoreCount(filePath: string): number {
   if (existsSync(filePath)) {
     const content = readFileSync(filePath, 'utf-8');
     return (content.match(REHEARSAL_TODO_REGEX) || []).length;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -69,9 +69,9 @@ export type CustomConfig = {
 
 export type PackageSelection = {
   name: string;
-  location: string;
+  path: string;
 };
 
-export type packageChoiceMap = {
+export type MenuMap = {
   [key: string]: string;
 };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,7 @@
 import { MigrationStrategy } from '@rehearsal/migration-graph';
 
 import { UserConfig } from './userConfig';
+import { State } from './helpers/state';
 export type CliCommand = `upgrade` | 'migrate';
 
 export type MigrateCommandOptions = {
@@ -21,7 +22,8 @@ export type MigrateCommandContext = {
   sourceFilesWithAbsolutePath: string[];
   sourceFilesWithRelativePath: string[];
   input: unknown;
-  targetPacakgePath: string;
+  targetPackagePath: string;
+  state: State;
 };
 
 export type UpgradeCommandContext = {
@@ -70,6 +72,6 @@ export type PackageSelection = {
   location: string;
 };
 
-export type PackageMap = {
+export type packageChoiceMap = {
   [key: string]: string;
 };

--- a/packages/cli/test/helpers/__snapshots__/state.test.ts.snap
+++ b/packages/cli/test/helpers/__snapshots__/state.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1
+
+exports[`state > constructor should init state to disk 1`] = `
+{
+  "files": {},
+  "name": "foo",
+  "packageMap": {},
+}
+`;

--- a/packages/cli/test/helpers/state.test.ts
+++ b/packages/cli/test/helpers/state.test.ts
@@ -1,0 +1,135 @@
+import { resolve } from 'path';
+import { readJSONSync, writeJSONSync, existsSync, writeFileSync } from 'fs-extra';
+import { dirSync, setGracefulCleanup } from 'tmp';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { State, calculateTSError, Store } from '../../src/helpers/state';
+
+setGracefulCleanup();
+
+function prepareTmpDir(): string {
+  const { name: targetDir } = dirSync();
+  return targetDir;
+}
+
+describe('state', async () => {
+  let basePath = '';
+
+  beforeEach(() => {
+    basePath = prepareTmpDir();
+  });
+
+  test('constructor should init state to disk', async () => {
+    const configPath = resolve(basePath, 'state.json');
+    const { packages, files } = new State('foo', [], configPath);
+
+    expect(packages).toEqual({});
+    expect(files).toEqual({});
+    expect(existsSync(configPath)).toBeTruthy();
+    expect(readJSONSync(configPath)).matchSnapshot();
+  });
+
+  test('constructor should load existed state', async () => {
+    const configPath = resolve(basePath, 'state.json');
+    const fooPath = resolve(basePath, 'foo');
+    const existedStore: Store = {
+      name: 'bar',
+      packageMap: {
+        bar: [fooPath],
+      },
+      files: {},
+    };
+    existedStore.files[fooPath] = {
+      package: 'bar',
+      errorCount: 2,
+    };
+
+    // write existed state
+    writeJSONSync(configPath, existedStore);
+    // write foo file
+    writeFileSync(fooPath, '');
+
+    const { packages, files } = new State('foo', [], configPath);
+
+    expect(packages.bar).toEqual([fooPath]);
+    expect(files[fooPath].package).toBe('bar');
+  });
+
+  test('constructor should verify existed state', async () => {
+    const configPath = resolve(basePath, 'state.json');
+    const fooPath = resolve(basePath, 'foo');
+    const existedStore: Store = {
+      name: 'bar',
+      packageMap: {
+        bar: [fooPath],
+      },
+      files: {},
+    };
+    existedStore.files[fooPath] = {
+      package: 'bar',
+      errorCount: 2,
+    };
+
+    // write existed state
+    writeJSONSync(configPath, existedStore);
+
+    const { packages, files } = new State('foo', [], configPath);
+
+    expect(packages.bar).toEqual([]);
+    expect(files[fooPath]).toBe(undefined);
+  });
+
+  test('addFilesToPackages', async () => {
+    const configPath = resolve(basePath, 'state.json');
+    const fooPath = resolve(basePath, 'foo');
+
+    // write foo file
+    writeFileSync(fooPath, '');
+
+    const state = new State('bar', ['bar'], configPath);
+
+    state.addFilesToPackage('bar', [fooPath]);
+
+    expect(state.packages.bar).toEqual([fooPath]);
+    expect(state.files[fooPath].package).toBe('bar');
+  });
+
+  test('calculateTSError', async () => {
+    const foo = '@rehearsal TODO foo bar';
+    const fooPath = resolve(basePath, 'foo');
+
+    const bar = '@rehearsal TODO foo\n@rehearsal TODO bar';
+    const barPath = resolve(basePath, 'bar');
+
+    writeFileSync(fooPath, foo, 'utf-8');
+    writeFileSync(barPath, bar, 'utf-8');
+
+    expect(calculateTSError(fooPath)).toBe(1);
+    expect(calculateTSError(barPath)).toBe(2);
+  });
+
+  test('getPackageMigrateProgress', async () => {
+    const configPath = resolve(basePath, 'state.json');
+
+    const foo = '@rehearsal TODO foo bar';
+    const fooPath = resolve(basePath, 'foo');
+
+    const bar = '@rehearsal TODO foo\n@rehearsal TODO bar';
+    const barPath = resolve(basePath, 'bar');
+
+    const state = new State('bar', ['sample-package'], configPath);
+
+    writeFileSync(fooPath, foo, 'utf-8');
+    writeFileSync(barPath, bar, 'utf-8');
+
+    state.addFilesToPackage('sample-package', [fooPath, barPath]);
+
+    const expected = {
+      completeFileCount: 0,
+      inProgressFileCount: 2,
+      totalFileCount: 2,
+    };
+
+    expect(state.getPackageMigrateProgress('sample-package')).toStrictEqual(expected);
+  });
+});

--- a/packages/cli/test/helpers/state.test.ts
+++ b/packages/cli/test/helpers/state.test.ts
@@ -40,6 +40,8 @@ describe('state', async () => {
       files: {},
     };
     existedStore.files[fooPath] = {
+      origin: 'foo',
+      current: 'foo',
       package: 'bar',
       errorCount: 2,
     };
@@ -66,6 +68,8 @@ describe('state', async () => {
       files: {},
     };
     existedStore.files[fooPath] = {
+      origin: 'foo',
+      current: 'foo',
       package: 'bar',
       errorCount: 2,
     };
@@ -75,8 +79,8 @@ describe('state', async () => {
 
     const { packages, files } = new State('foo', [], configPath);
 
-    expect(packages.bar).toEqual([]);
-    expect(files[fooPath]).toBe(undefined);
+    expect(packages.bar).toEqual([fooPath]);
+    expect(files[fooPath].current).toBe(null);
   });
 
   test('addFilesToPackages', async () => {

--- a/packages/cli/test/helpers/state.test.ts
+++ b/packages/cli/test/helpers/state.test.ts
@@ -3,7 +3,7 @@ import { readJSONSync, writeJSONSync, existsSync, writeFileSync } from 'fs-extra
 import { dirSync, setGracefulCleanup } from 'tmp';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { State, calculateTSError, Store } from '../../src/helpers/state';
+import { State, calculateTSIgnoreCount, Store } from '../../src/helpers/state';
 
 setGracefulCleanup();
 
@@ -98,7 +98,7 @@ describe('state', async () => {
     expect(state.files[fooPath].package).toBe('bar');
   });
 
-  test('calculateTSError', async () => {
+  test('calculateTSIgnoreCount', async () => {
     const foo = '@rehearsal TODO foo bar';
     const fooPath = resolve(basePath, 'foo');
 
@@ -108,8 +108,8 @@ describe('state', async () => {
     writeFileSync(fooPath, foo, 'utf-8');
     writeFileSync(barPath, bar, 'utf-8');
 
-    expect(calculateTSError(fooPath)).toBe(1);
-    expect(calculateTSError(barPath)).toBe(2);
+    expect(calculateTSIgnoreCount(fooPath)).toBe(1);
+    expect(calculateTSIgnoreCount(barPath)).toBe(2);
   });
 
   test('getPackageMigrateProgress', async () => {


### PR DESCRIPTION
This PR adds migration state to keep track of the progress of migration in interactive mode, including:
1. Create a state file `.rehearsal/migration-state.json` and `git add` it
2. Every time when running `rehearsal migration`, it would load the previous state if there is any, verify and update the state if needed.
  - Make sure migration status in state file matches what we have on disk
  - Update ts-ignore count for each migrated file
4. There are 3 cases when showing the migration progress/state in interactive mode:
  - package has not started any migration before -> show "no progress found"
  - package had a migration with remaining JS files ->  show "x/x migrated, x rehearsal todos"
  - fully migrated with no JS and rehearsal todo -> show "completed" and disable this option

![Screen Shot 2022-11-06 at 01 43 01](https://user-images.githubusercontent.com/2744803/200162166-24cd3728-9f6c-4133-bd89-cfd8d5292f87.png)

5. We had discussion about making the state file readable to other tools/platforms, I could have follow up PR for that if needed.
