### PR TITLE
fix: don't use --ignore-scripts option with yarn@3

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -151,6 +151,17 @@ export async function isYarnManager(): Promise<boolean> {
   return !!yarnPath;
 }
 
+export async function isYarnBerryManager(): Promise<boolean> {
+  const lockFilePath = await findup('yarn.lock', {
+    cwd: process.cwd(),
+  });
+  const berryConfigPath = await findup('.yarnrc.yml', {
+    cwd: process.cwd(),
+  });
+
+  return !!lockFilePath && !!berryConfigPath;
+}
+
 export async function isPnpmManager(): Promise<boolean> {
   const pnpmPath = await findup('pnpm-lock.yaml', {
     cwd: process.cwd(),
@@ -211,11 +222,12 @@ export async function getModuleManagerInstaller(
 
   switch (manager) {
     case 'yarn':
+      // since yarn@3 doesn't have --ignore-scripts anymore
       return {
         bin,
         args: isDev
-          ? ['add', '-D', ...depList, '--ignore-scripts']
-          : ['add', ...depList, '--ignore-scripts'],
+          ? ['add', '-D', ...depList, ...((await isYarnBerryManager()) ? [] : ['--ignore-scripts'])]
+          : ['add', ...depList, ...((await isYarnBerryManager()) ? [] : ['--ignore-scripts'])],
       };
     case 'pnpm':
       return {


### PR DESCRIPTION
When running `yarn tsc` with `yarn@3`, it would error out since there is no `--ignore-scripts` option anymore.

```
✖ Command failed with exit code 1: yarn add -D typescript --ignore-scripts
  Unknown Syntax Error: Command not found; did you mean one of:
  0. yarn add [--json] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode…
  1. yarn add [--json] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode…
  While running add -D typescript --ignore-scripts
```

This PR detects if it's on `yarn@3` and remove `--ignore-scripts` for this case.