### PR TITLE
chore: remove unused dependencies in migration-graph

### DIFF
--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -21,7 +21,7 @@
     "@babel/generator": "^7.18.13",
     "@babel/parser": "^7.18.13",
     "@babel/traverse": "^7.18.13",
-    "@rehearsal/migration-graph-shared": "^0.0.37",
+    "@rehearsal/migration-graph-shared": "workspace:*",
     "@swc/core": "^1.3.9",
     "debug": "^4.3.2",
     "enhanced-resolve": "^5.10.0",

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -15,28 +15,16 @@
     "test": "vitest --run"
   },
   "dependencies": {
-    "@babel/parser": "^7.18.4",
-    "@babel/traverse": "^7.18.2",
     "@rehearsal/migration-graph-ember": "workspace:*",
     "@rehearsal/migration-graph-shared": "workspace:*",
-    "@swc/core": "^1.3.2",
     "debug": "^4.3.4",
-    "enhanced-resolve": "^5.10.0",
-    "fast-glob": "^3.2.12",
     "fs-extra": "^10.1.0",
-    "jsonc-parser": "^3",
     "minimatch": "^5.1.0",
     "path": "^0.12.7"
   },
   "devDependencies": {
     "@rehearsal/test-support": "workspace:*",
-    "@types/lodash.merge": "^4.6.7",
     "@types/minimatch": "^5.1.2",
-    "@types/rimraf": "^3.0.2",
-    "fixturify": "^2",
-    "lodash.merge": "^4.6.2",
-    "rimraf": "^3.0.2",
-    "tmp": "^0.2.1",
     "vitest": "^0.23.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
       '@babel/parser': ^7.18.13
       '@babel/traverse': ^7.18.13
       '@babel/types': ^7.18.13
-      '@rehearsal/migration-graph-shared': ^0.0.37
+      '@rehearsal/migration-graph-shared': workspace:*
       '@rehearsal/test-support': workspace:*
       '@swc/core': ^1.3.9
       '@types/lodash.merge': ^4.6.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,49 +191,25 @@ importers:
 
   packages/migration-graph:
     specifiers:
-      '@babel/parser': ^7.18.4
-      '@babel/traverse': ^7.18.2
       '@rehearsal/migration-graph-ember': workspace:*
       '@rehearsal/migration-graph-shared': workspace:*
       '@rehearsal/test-support': workspace:*
-      '@swc/core': ^1.3.2
-      '@types/lodash.merge': ^4.6.7
       '@types/minimatch': ^5.1.2
-      '@types/rimraf': ^3.0.2
       debug: ^4.3.4
-      enhanced-resolve: ^5.10.0
-      fast-glob: ^3.2.12
-      fixturify: ^2
       fs-extra: ^10.1.0
-      jsonc-parser: ^3
-      lodash.merge: ^4.6.2
       minimatch: ^5.1.0
       path: ^0.12.7
-      rimraf: ^3.0.2
-      tmp: ^0.2.1
       vitest: ^0.23.4
     dependencies:
-      '@babel/parser': 7.19.1
-      '@babel/traverse': 7.19.1
       '@rehearsal/migration-graph-ember': link:../migration-graph-ember
       '@rehearsal/migration-graph-shared': link:../migration-graph-shared
-      '@swc/core': 1.3.2
       debug: 4.3.4
-      enhanced-resolve: 5.10.0
-      fast-glob: 3.2.12
       fs-extra: 10.1.0
-      jsonc-parser: 3.2.0
       minimatch: 5.1.0
       path: 0.12.7
     devDependencies:
       '@rehearsal/test-support': link:../test-support
-      '@types/lodash.merge': 4.6.7
       '@types/minimatch': 5.1.2
-      '@types/rimraf': 3.0.2
-      fixturify: 2.1.1
-      lodash.merge: 4.6.2
-      rimraf: 3.0.2
-      tmp: 0.2.1
       vitest: 0.23.4
 
   packages/migration-graph-ember:
@@ -976,17 +952,6 @@ packages:
       colors: 1.2.5
       string-argv: 0.3.1
 
-  /@swc/core-android-arm-eabi/1.3.2:
-    resolution: {integrity: sha512-jCqckwATVC4HbNjjrJii6xZzFKl7ecxVtY94odGD15+7qu5VCMuLD+Pj3bYxIQxQyzvi1z8S/187uUrAKMC2/w==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.122
-    dev: false
-    optional: true
-
   /@swc/core-android-arm-eabi/1.3.9:
     resolution: {integrity: sha512-+F+sU2l49Po4tJoNtIpFwt0k1sspymvPMM+DCpnkHF1idzRiOU5NGgVzmLDjoO9AnxHa7EBJ3itN+PP2Dd06+A==}
     engines: {node: '>=10'}
@@ -995,17 +960,6 @@ packages:
     requiresBuild: true
     dependencies:
       '@swc/wasm': 1.2.122
-    dev: false
-    optional: true
-
-  /@swc/core-android-arm64/1.3.2:
-    resolution: {integrity: sha512-zZ3EX5jmY6kTBlnAqLmIhDFGlsAB3Tiwk/sqoMLruZT1RsueDToQAXtjT5TWSlPh/GXAZyJQwqar2xIdi5pPAA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.130
     dev: false
     optional: true
 
@@ -1020,28 +974,10 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-arm64/1.3.2:
-    resolution: {integrity: sha512-YQpbRkd5zhycr+Nl1mm1p7koFqr8hsY8Z7XzNjfNIaJeFsXg9wjjH7yVmedQl+If+ibaPWpS3gMWfcIoUhdvGg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@swc/core-darwin-arm64/1.3.9:
     resolution: {integrity: sha512-E7WJY1LsMJtOtUYc/JXl8qlt6USnzodWmdO1eAAOSAODEdX9AjgG3fRT94o3UcmvMrto7sxBXVExj8wG7Cxeng==}
     engines: {node: '>=10'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@swc/core-darwin-x64/1.3.2:
-    resolution: {integrity: sha512-DMvvdWgi/2dHtSGk4m6OcmlW8AAEUUl7Zys+Sxp+AtyIlQvn0Lbw9HCMPG6pqC0SHEO1kcNj6f6ARt3lL25jSA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
@@ -1056,33 +992,11 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-freebsd-x64/1.3.2:
-    resolution: {integrity: sha512-GUXqDnmJTWZBoTbOMOKG+mw/jJ7dAOOKuUKwnQvyzconLkqHZZfJTimDsc1KWpikf9IPdQNY0+0/NqAVPGA0Dg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.130
-    dev: false
-    optional: true
-
   /@swc/core-freebsd-x64/1.3.9:
     resolution: {integrity: sha512-JbHIeklQPRBEZUfKAKt/IB/ayi7dJZ9tEGu/fDxNfk8Znu1Md+YOKRyN5FPMXfYrL5yFUXnlFOb2LX6wjNhhjQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.130
-    dev: false
-    optional: true
-
-  /@swc/core-linux-arm-gnueabihf/1.3.2:
-    resolution: {integrity: sha512-Df3ln4IhiFxOYBNr/x192tXhRBTVEhJPMLRDl9Q0WY/lvPp/n5Ee0VgKR1CaQ16bg3/z3lZjXrZRBw01kENEew==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
     requiresBuild: true
     dependencies:
       '@swc/wasm': 1.2.130
@@ -1100,26 +1014,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-gnu/1.3.2:
-    resolution: {integrity: sha512-jPtcA61HqWFxlIr5OCToa97kqTS6u4I2GJR5whc8u2rSzn2N+M5CfqskOGHBETcEhUWfFa0hJq3+i6w9lqKV+w==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@swc/core-linux-arm64-gnu/1.3.9:
     resolution: {integrity: sha512-PrBjmPIMhoQLCpfaZl2b1cCXnaNPddQB/ssMVqQ6eXChBJfcv14M5BjxtI2ORi4HoEDlsbX+k50sL666M3lnBw==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@swc/core-linux-arm64-musl/1.3.2:
-    resolution: {integrity: sha512-GhGM49GTzpjxKrzi8IpyHNlrJkOwiS6Pk4xhy3D7nrbB5KppU8O+lppkiRjiF9awD+mIzFq27TdokbmEoQcXaQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1136,26 +1032,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-gnu/1.3.2:
-    resolution: {integrity: sha512-JgN5rGHAKe2hvtU1H1V9toxSDWKEAWbrrb+/Wp/6CrxBxNgexmgXuDGt0VP21jbRA2qTRNEhx9zzuzZK9ggNTQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@swc/core-linux-x64-gnu/1.3.9:
     resolution: {integrity: sha512-60ZreTvrJk3N7xvPzQeQJDePsXUmSUZkKD6lc0xzug4bv53NyUIQ8gH8nzVsV++D9NZeVxXp6WqqFLcgt7yEDQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@swc/core-linux-x64-musl/1.3.2:
-    resolution: {integrity: sha512-VpT6jgU7qqNjQmKt5RaOpkocv9MI5FTxWon4OQvTc+kHCoTAmXIndaW6aA+j4VEDSTJ/7DQAFWSXpSCffoQMsA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1172,32 +1050,10 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-arm64-msvc/1.3.2:
-    resolution: {integrity: sha512-bilVzxfq5upHsil1WwPSoArZLkhPJyqJJ+5EzbiDS3Y38BPkPYZuN0h6sKuEiXLMHGODXtzuAkSgQyy0VVQKIA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.130
-    dev: false
-    optional: true
-
   /@swc/core-win32-arm64-msvc/1.3.9:
     resolution: {integrity: sha512-4FQSalXbbnqTLVGRljRnw/bJ99Jwj1WnXz/aJM/SVL8S9Zbc82+3v+wXL/9NGwaAndu2QUkb2KPYNAHvB7PCdw==}
     engines: {node: '>=10'}
     cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dependencies:
-      '@swc/wasm': 1.2.130
-    dev: false
-    optional: true
-
-  /@swc/core-win32-ia32-msvc/1.3.2:
-    resolution: {integrity: sha512-UzHbZvJnfGZKvoEPiHoKtKehtuiDuNP/mKKBAaG5Cnu8m47z/cE5Mi0onR2iJi1p64GX0RhRIBcGa8x9PVHGjA==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dependencies:
@@ -1216,15 +1072,6 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-x64-msvc/1.3.2:
-    resolution: {integrity: sha512-RSFgS2imGONhdN8anvDI+8wL+sinmeKUy2SmSiy8hSmqke1bCslirULCckyGzQAIMf3qCjuaTXxOFiQrsoSoIA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@swc/core-win32-x64-msvc/1.3.9:
     resolution: {integrity: sha512-moKi2prCKzYnXXlrLf5nwAN4uGSm4YpsW2xzYiZWJJDRqu74VoUWoDkG25jalHTfN/PSBQg4dkFWhhUe89JJVw==}
     engines: {node: '>=10'}
@@ -1233,27 +1080,6 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
-
-  /@swc/core/1.3.2:
-    resolution: {integrity: sha512-p2nLRVgtaz/v5UkNW9Ur5WrQUKB5YH1X7mE15UD2kihiAMc/04wvo0SNLW0BIeGSqeFdoZQ45TX5uOIxhAvRSg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@swc/core-android-arm-eabi': 1.3.2
-      '@swc/core-android-arm64': 1.3.2
-      '@swc/core-darwin-arm64': 1.3.2
-      '@swc/core-darwin-x64': 1.3.2
-      '@swc/core-freebsd-x64': 1.3.2
-      '@swc/core-linux-arm-gnueabihf': 1.3.2
-      '@swc/core-linux-arm64-gnu': 1.3.2
-      '@swc/core-linux-arm64-musl': 1.3.2
-      '@swc/core-linux-x64-gnu': 1.3.2
-      '@swc/core-linux-x64-musl': 1.3.2
-      '@swc/core-win32-arm64-msvc': 1.3.2
-      '@swc/core-win32-ia32-msvc': 1.3.2
-      '@swc/core-win32-x64-msvc': 1.3.2
-    dev: false
 
   /@swc/core/1.3.9:
     resolution: {integrity: sha512-PCRCO9vIoEX3FyS3z/FkWVYJzuspUq0LLaWdK3L30+KQDtH29K+LQdRc2Dzin2MU5MpY4bSHydAwl9M6cmZ9OA==}
@@ -3803,10 +3629,6 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  /jsonc-parser/3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: false
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}


### PR DESCRIPTION
- `migration-graph` The package has been hollowed out to migration-graph-shared and migration-graph-ember. These deps are no longer used.
- `migration-graph-ember` replace version with workspace:* for `migration-graph-shared` dep.