### PR TITLE
feat: improve UX when running tsc command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "@rehearsal/migration-graph": "workspace:*",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/upgrade": "workspace:*",
+    "chalk": "^4.1.2",
     "commander": "^9.4.0",
     "compare-versions": "^5.0.1",
     "debug": "^4.3.2",

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -15,7 +15,6 @@ import { existsSync } from 'fs-extra';
 import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
 import chalk from 'chalk';
-import { createLogger, format, transports } from 'winston';
 import { debug } from 'debug';
 
 import { generateReports } from '../helpers/report';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,7 @@ importers:
       '@rehearsal/reporter': workspace:*
       '@rehearsal/upgrade': workspace:*
       '@types/which': ^2.0.1
+      chalk: ^4.1.2
       commander: ^9.4.0
       compare-versions: ^5.0.1
       debug: ^4.3.2
@@ -139,6 +140,7 @@ importers:
       '@rehearsal/migration-graph': link:../migration-graph
       '@rehearsal/reporter': link:../reporter
       '@rehearsal/upgrade': link:../upgrade
+      chalk: 4.1.2
       commander: 9.4.0
       compare-versions: 5.0.1
       debug: 4.3.4


### PR DESCRIPTION
Couple of UX improvements:
- Move running `tsc` to the end of all tasks
- Although we should expect the migration covers all the stuff and `tsc` should exit on `0`, just for rare cases additional message has been added to let the user know what happened.