### PR TITLE
refactor: ux improvements

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -44,9 +44,9 @@ upgradeCommand
   .option('-o, --outputPath <outputPath>', 'Reports output path', '.rehearsal')
   .option(
     '-r, --report <reportTypes>',
-    'Report types separated by comma, e.g. -r json,sarif,md',
+    'Report types separated by comma, e.g. -r json,sarif,md,sonarqube',
     parseCommaSeparatedList,
-    []
+    ['sarif']
   )
   .option('-d, --dryRun', `Don't commit any changes`, false)
 
@@ -74,9 +74,12 @@ upgradeCommand
     DEBUG_CALLBACK('options: %O', options);
 
     // grab the consuming apps project name
-    const projectName = (await determineProjectName()) || '';
+    const projectName = determineProjectName() || '';
 
-    const reporter = new Reporter(projectName, basePath, logger);
+    const reporter = new Reporter(
+      { tsVersion: '', projectName, basePath, commandName: '@rehearsal/upgrade' },
+      logger
+    );
 
     const tasks = new Listr<UpgradeCommandContext>(
       [
@@ -137,6 +140,7 @@ upgradeCommand
                     await gitCheckoutNewLocalBranch(`${ctx.tsVersion}`);
                   }
                   await addDep([`typescript@${ctx.tsVersion}`], true);
+                  reporter.report.summary.tsVersion = ctx.tsVersion;
                 },
               },
               {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -39,17 +39,6 @@ describe('migrate - install dependencies', async () => {
     expect(result.stdout).toContain('[SUCCESS] Installing dependencies');
   });
 
-  test('Do not install typescript dependency if project already has one', async () => {
-    // at this point project already have typescript installed in previous test
-    const result = await runBin('migrate', [], {
-      cwd: basePath,
-    });
-
-    expect(result.stdout).toContain(
-      '[SKIPPED] typescript already exists. Skipping installing typescript.'
-    );
-  });
-
   test('Install custom dependencies with user config provided', async () => {
     basePath = prepareTmpDir('initialization');
     createUserConfig(basePath, {
@@ -89,14 +78,17 @@ describe('migrate - generate tsconfig', async () => {
     expect(readdirSync(basePath)).toContain('tsconfig.json');
   });
 
-  test('Do not create tsconfig if there is an existed one', async () => {
+  test('On tsconfig exists, esure strict mode', async () => {
     // tsconfig already created from previous test
     const result = await runBin('migrate', [], {
       cwd: basePath,
     });
 
-    expect(result.stdout).toContain('skipping creating tsconfig.json');
+    expect(result.stdout).toContain('ensuring strict mode is enabled');
     expect(readdirSync(basePath)).toContain('tsconfig.json');
+
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    expect(tsConfig.compilerOptions.strict).toBeTruthy;
   });
 
   test('runBin custom ts config command with user config provided', async () => {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -78,7 +78,7 @@ describe('migrate - generate tsconfig', async () => {
     expect(readdirSync(basePath)).toContain('tsconfig.json');
   });
 
-  test('On tsconfig exists, esure strict mode', async () => {
+  test('On tsconfig exists, ensure strict mode', async () => {
     // tsconfig already created from previous test
     const result = await runBin('migrate', [], {
       cwd: basePath,
@@ -212,11 +212,11 @@ describe('migrate - handle custom basePath', async () => {
       cwd: basePath, // still run cli in basePath
     });
 
-    expect(result.stdout).toContain('[SUCCESS] Installing dependencies');
+    expect(result.stdout).toContain('Installing dependencies');
     expect(result.stdout).toContain('Creating tsconfig');
     expect(readdirSync(customBasePath)).toContain('tsconfig.json');
 
-    expect(result.stdout).toContain(`[SUCCESS] Converting JS files to TS`);
+    expect(result.stdout).toContain(`Converting JS files to TS`);
     expect(readdirSync(customBasePath)).toContain('index.ts');
     expect(readdirSync(customBasePath)).not.toContain('index.js');
 

--- a/packages/migrate/tests/index.test.ts
+++ b/packages/migrate/tests/index.test.ts
@@ -48,7 +48,15 @@ describe('migrate', () => {
       transports: [new transports.Console({ format: format.cli(), level: 'debug' })],
     });
 
-    reporter = new Reporter('@rehearsal/test', basePath, logger);
+    reporter = new Reporter(
+      {
+        tsVersion: '',
+        projectName: '@rehearsal/test',
+        basePath,
+        commandName: '@rehearsal/migrate',
+      },
+      logger
+    );
   });
 
   afterEach(() => {

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -225,7 +225,7 @@ function createRun(report: Report): Run {
   return {
     tool: {
       driver: {
-        name: '@rehearsal/upgrade',
+        name: `${report.summary.commandName}`,
         informationUri: 'https://github.com/rehearsal-js/rehearsal-js',
         rules: [],
       },
@@ -234,11 +234,7 @@ function createRun(report: Report): Run {
     results: [],
     automationDetails: {
       description: {
-        text:
-          'This is the run of @rehearsal/upgrade on your product against TypeScript ' +
-          report.summary.tsVersion +
-          ' at ' +
-          report.summary.timestamp,
+        text: `This is the run of ${report.summary.commandName} on your product against TypeScript ${report.summary.tsVersion} at ${report.summary.timestamp}`,
       },
     },
   };

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -1,8 +1,15 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { DiagnosticCategory, flattenDiagnosticMessageText, SyntaxKind, version } from 'typescript';
+import { DiagnosticCategory, flattenDiagnosticMessageText, SyntaxKind } from 'typescript';
 import { type ProcessedFile, type Report, type ReportFormatter, type ReportItem } from './types';
 import type { DiagnosticWithLocation, Node } from 'typescript';
 import type { Logger } from 'winston';
+
+type ReporterMeta = {
+  projectName: string;
+  basePath: string;
+  commandName: string;
+  tsVersion: string;
+};
 
 /**
  * Representation of diagnostic and migration report.
@@ -13,13 +20,16 @@ export class Reporter {
   public report: Report;
   private logger?: Logger;
 
-  constructor(projectName = '', basePath = '', logger?: Logger) {
+  constructor(meta: ReporterMeta, logger?: Logger) {
+    const { projectName, basePath, commandName, tsVersion } = meta;
+
     this.basePath = basePath;
     this.logger = logger?.child({ service: 'rehearsal-reporter' });
+
     this.report = {
       summary: {
         projectName: projectName,
-        tsVersion: version,
+        tsVersion: tsVersion,
         timestamp: new Date().toLocaleString('en-US', {
           year: 'numeric',
           month: 'numeric',
@@ -30,6 +40,7 @@ export class Reporter {
           second: '2-digit',
         }),
         basePath: basePath,
+        commandName: commandName,
       },
       items: [],
     };

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -3,6 +3,7 @@ export type ReportSummary = Record<string, unknown> & {
   basePath: string;
   tsVersion: string;
   timestamp: string;
+  commandName: string;
 };
 
 export type FileRole = 'analysisTarget' | 'tracedFile' | 'unmodified' | 'modified';

--- a/packages/reporter/test/__snapshots__/reporter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/reporter.test.ts.snap
@@ -6,7 +6,8 @@ exports[`Test reporter > addItem 1`] = `
     \\"projectName\\": \\"@rehearsal/test\\",
     \\"tsVersion\\": \\"4.7.4\\",
     \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\"
+    \\"basePath\\": \\"/base/path\\",
+    \\"commandName\\": \\"@rehearsal/reporter\\"
   },
   \\"items\\": [
     {
@@ -366,6 +367,7 @@ exports[`Test reporter > load 1`] = `
   ],
   "summary": {
     "basePath": "/base/path",
+    "commandName": "@rehearsal/reporter",
     "projectName": "@rehearsal/test",
     "timestamp": "9/16/2022, 13:24:57",
     "tsVersion": "4.7.4",
@@ -379,7 +381,8 @@ exports[`Test reporter > print, json 1`] = `
     \\"projectName\\": \\"@rehearsal/test\\",
     \\"tsVersion\\": \\"4.7.4\\",
     \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\"
+    \\"basePath\\": \\"/base/path\\",
+    \\"commandName\\": \\"@rehearsal/reporter\\"
   },
   \\"items\\": [
     {
@@ -518,7 +521,8 @@ exports[`Test reporter > save 1`] = `
     \\"projectName\\": \\"@rehearsal/test\\",
     \\"tsVersion\\": \\"4.7.4\\",
     \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\"
+    \\"basePath\\": \\"/base/path\\",
+    \\"commandName\\": \\"@rehearsal/reporter\\"
   },
   \\"items\\": [
     {

--- a/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
@@ -216,7 +216,7 @@ exports[`Test sarif-formatter > should set the correct version, $schema, and ini
     {
       \\"tool\\": {
         \\"driver\\": {
-          \\"name\\": \\"@rehearsal/upgrade\\",
+          \\"name\\": \\"@rehearsal/reporter\\",
           \\"informationUri\\": \\"https://github.com/rehearsal-js/rehearsal-js\\",
           \\"rules\\": []
         }
@@ -225,7 +225,7 @@ exports[`Test sarif-formatter > should set the correct version, $schema, and ini
       \\"results\\": [],
       \\"automationDetails\\": {
         \\"description\\": {
-          \\"text\\": \\"This is the run of @rehearsal/upgrade on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
+          \\"text\\": \\"This is the run of @rehearsal/reporter on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
         }
       }
     }

--- a/packages/reporter/test/fixtures/reporter/rehearsal-report.json
+++ b/packages/reporter/test/fixtures/reporter/rehearsal-report.json
@@ -3,7 +3,8 @@
     "projectName": "@rehearsal/test",
     "tsVersion": "4.7.4",
     "timestamp": "9/16/2022, 13:24:57",
-    "basePath": "/base/path"
+    "basePath": "/base/path",
+    "commandName": "@rehearsal/reporter"
   },
   "items": [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
@@ -5,7 +5,8 @@ const addArtifactData: Report = {
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:55",
-    basePath: "/reporter/test/sarif-formatter"
+    basePath: "/reporter/test/sarif-formatter",
+    commandName: "@rehearsal/reporter"
   },
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
@@ -5,7 +5,8 @@ const addResultData: Report = {
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:57",
-    basePath: "/reporter/test/sarif-formatter"
+    basePath: "/reporter/test/sarif-formatter",
+    commandName: "@rehearsal/reporter"
   },
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
@@ -5,7 +5,8 @@ const addRuleData: Report = {
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:52",
-    basePath: "/reporter/test/sarif-formatter"
+    basePath: "/reporter/test/sarif-formatter",
+    commandName: "@rehearsal/reporter"
   },
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
@@ -5,7 +5,8 @@ const initialData: Report = {
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 20:16:50",
-    basePath: "/reporter/test/sarif-formatter"
+    basePath: "/reporter/test/sarif-formatter",
+    commandName: "@rehearsal/reporter"
   },
   items: []
 };

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -12,7 +12,12 @@ describe('Test reporter', function () {
   let reporter: Reporter | undefined;
 
   beforeEach(() => {
-    reporter = new Reporter('test', basePath).load(resolve(basePath, 'rehearsal-report.json'));
+    reporter = new Reporter({
+      tsVersion: '',
+      projectName: 'test',
+      basePath,
+      commandName: '@rehearsal/reporter',
+    }).load(resolve(basePath, 'rehearsal-report.json'));
   });
 
   afterEach(() => {

--- a/packages/upgrade/test/upgrade.test.ts
+++ b/packages/upgrade/test/upgrade.test.ts
@@ -15,7 +15,10 @@ describe('Test upgrade', async function () {
     transports: [new transports.Console({ format: format.cli(), level: 'debug' })],
   });
 
-  const reporter = new Reporter('@rehearsal/test', basePath, logger);
+  const reporter = new Reporter(
+    { tsVersion: '', projectName: '@rehearsal/test', basePath, commandName: '@rehearsal/upgrade' },
+    logger
+  );
 
   createTsFilesFromInputs(files);
 


### PR DESCRIPTION
This PR address various UX bugs:

- removes redundant tsc check post cli/migrate migration
- adds sonarqube formatter to upgrade/migrate cli
- defaults sarif formatter for upgrade/migrate cli
- implements a ReporterMeta, cleans params
- fixes hardcoded values in reporter with tsc version and command name
- defaults adding @latest tsc with migrate cli for all instances
- defaults tsconfig strict to true with migrate cli when tsconfig exists