### PR TITLE
fix: use json5 to parse

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -17,14 +17,20 @@ import {
   sonarqubeFormatter,
 } from '@rehearsal/reporter';
 import { Command } from 'commander';
-import { existsSync, readJSONSync, writeJSONSync } from 'fs-extra';
+import { existsSync, writeJSONSync } from 'fs-extra';
 import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
 import { debug } from 'debug';
 import execa = require('execa');
 
 import { generateReports } from '../helpers/report';
-import { MigrateCommandContext, MigrateCommandOptions, PackageSelection, MenuMap } from '../types';
+import {
+  MigrateCommandContext,
+  MigrateCommandOptions,
+  PackageSelection,
+  MenuMap,
+  TSConfig,
+} from '../types';
 import { UserConfig } from '../userConfig';
 import {
   addDep,
@@ -32,6 +38,7 @@ import {
   parseCommaSeparatedList,
   writeTSConfig,
   getPathToBinary,
+  readJSON,
 } from '../utils';
 import { State } from '../helpers/state';
 
@@ -197,7 +204,7 @@ migrateCommand
               if (existsSync(configPath)) {
                 task.title = `${configPath} already exists, ensuring strict mode is enabled.`;
 
-                const tsConfig = readJSONSync(configPath);
+                const tsConfig = readJSON<TSConfig>(configPath) as TSConfig;
                 tsConfig.compilerOptions.strict = true;
                 writeJSONSync(configPath, tsConfig, { spaces: 2 });
               } else {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -75,3 +75,9 @@ export type PackageSelection = {
 export type MenuMap = {
   [key: string]: string;
 };
+
+export type TSConfig = {
+  compilerOptions: {
+    strict: boolean;
+  };
+};

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -62,7 +62,7 @@ export function msToSeconds(ms: number): number {
   return Math.round(ms / 1000);
 }
 
-export function readJSON<TJson = unknown>(file: string): TJson | undefined {
+export function readJSON<T>(file: string): T | undefined {
   const text = readText(file);
   if (text !== undefined) {
     return parse(text);


### PR DESCRIPTION
This resolves an issue we could have when comments are contained within tsconfig.json. We should use JSON5 instead of readJSON to handle.