### PR TITLE
fix: yarn classic binary path

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -285,14 +285,14 @@ export async function getPathToBinary(
 
   try {
     const { stdout } = await execa(moduleManagerBin, ['bin', binaryName], options);
-    stdoutMsg = stdout;
+    stdoutMsg = stdout.trim().split(`/${binaryName}`)[0];
   } catch (e) {
     throw new Error(`Unable to find binary path to ${binaryName}`);
   }
 
   // return the path to the binary
   try {
-    return resolve(join(stdoutMsg.trim(), binaryName));
+    return resolve(join(stdoutMsg, binaryName));
   } catch (error) {
     throw new Error(`Unable to find ${binaryName} with ${moduleManagerBin}`);
   }


### PR DESCRIPTION
Fixes a bug where yarn classic will return the `binaryName` with the path. Implementation now covers both.