### PR TITLE
fix: graph edge cases

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -83,7 +83,10 @@ export class EmberAppProjectGraph extends ProjectGraph {
     super(rootDir, options);
   }
 
-  addPackageToGraph(p: EmberAppPackage | EmberAddonPackage | Package): GraphNode<PackageNode> {
+  addPackageToGraph(
+    p: EmberAppPackage | EmberAddonPackage | Package,
+    crawl = true
+  ): GraphNode<PackageNode> {
     if (p instanceof EmberAddonPackage) {
       // Check the graph if it has this node already
       const hasNodeByPackageName = this.graph.hasNode(p.packageName);
@@ -96,28 +99,19 @@ export class EmberAppProjectGraph extends ProjectGraph {
         }
       }
     }
-
     const node = super.addPackageToGraph(p);
 
-    this.buildAnalyzedPackageTree(node);
+    if (crawl) {
+      this.buildAnalyzedPackageTree(node);
+    }
 
     DEBUG_CALLBACK('debugAnalysis', debugAnalysis(node));
 
     return node;
   }
 
-  buildAnalyzedPackageTree(currentNode: GraphNode<PackageNode>, depth = 1): void {
-    // Ensure we're dealing with a full fledged node, otherwise it could be synthetic
-    if (!currentNode.content?.synthetic) {
-      return;
-      // throw new Error('No package found for node ... TBD');
-    }
-
-    if (!currentNode?.content.pkg) {
-      return;
-    }
-
-    const pkg = currentNode?.content?.pkg;
+  buildAnalyzedPackageTree(source: GraphNode<PackageNode>, depth = 1): void {
+    const pkg = source?.content?.pkg;
 
     if (!pkg) {
       throw new Error('Unable to buildAnalyzedPackageTree; node has no package defined.');
@@ -125,38 +119,16 @@ export class EmberAppProjectGraph extends ProjectGraph {
 
     const explicitDependencies = this.getExplicitPackageDependencies(pkg);
 
-    explicitDependencies.forEach((p: Package) => {
-      const key = p.packageName;
+    DEBUG_CALLBACK('explicitDependencies: %O', explicitDependencies);
 
-      let depNode;
+    explicitDependencies.forEach((p: Package | EmberAddonPackage) => {
+      const dest = this.addPackageToGraph(p, false);
 
-      if (!this.graph.hasNode(key)) {
-        // DEBUG_CALLBACK('buildAnalyzedPackagTree - addNode');
+      DEBUG_CALLBACK('Adding edge from %s to %s', source.content.key, dest.content.key);
 
-        depNode = this.graph.addNode({
-          key,
-          pkg: p,
-          converted: p.isConvertedToTypescript(),
-        });
+      this.graph.addEdge(source, dest);
 
-        // Need to refactor data flow here. Seems odd how we're creating the graph node without modules then populating it after.
-        // Probably should lazily populate this.
-
-        // depNode.content.modules = p.createModuleGraph({
-        //   project: this,
-        //   parent: depNode,
-        // });
-      } else {
-        depNode = this.graph.getNode(key);
-      }
-
-      if (!depNode) {
-        throw new Error(`Unable to find node for ${key}`);
-      }
-
-      this.graph.addEdge(currentNode, depNode);
-
-      this.buildAnalyzedPackageTree(depNode, depth + 1);
+      this.buildAnalyzedPackageTree(dest, depth + 1);
     });
   }
 
@@ -210,7 +182,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
    */
   findPackageByAddonName(addonName: string): GraphNode<PackageNode> | undefined {
     return Array.from(this.graph.nodes).find((n: GraphNode<PackageNode>) => {
-      DEBUG_CALLBACK('findPackageNodeByAddonName: %0', n.content);
+      DEBUG_CALLBACK('findPackageNodeByAddonName: %O', n.content);
 
       const somePackage: Package = n.content.pkg;
 
@@ -218,7 +190,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
         n.content.key === addonName ||
         (somePackage instanceof EmberAddonPackage && this.isMatch(addonName, somePackage))
       ) {
-        DEBUG_CALLBACK('Found an EmberAddonPackage %0', somePackage);
+        DEBUG_CALLBACK('Found an EmberAddonPackage %O', somePackage);
         return true;
       }
       return false;

--- a/packages/migration-graph-ember/tests/entities/ember-addon-package-graph.test.ts
+++ b/packages/migration-graph-ember/tests/entities/ember-addon-package-graph.test.ts
@@ -3,7 +3,7 @@ import { getEmberProject, setupProject } from '@rehearsal/test-support';
 import { EmberAddonPackage } from '../../src/entities/ember-addon-package';
 import { EmberAddonPackageGraph } from '../../src/entities/ember-addon-package-graph';
 
-describe('EmberAddonPackageDependencyGraph', () => {
+describe('EmberAddonPackageGraph', () => {
   test('should create an edge between app/components/<file>.js and addon/components/<file>.js', async () => {
     const project = getEmberProject('addon');
 

--- a/packages/migration-graph-ember/tests/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/tests/entities/ember-app-package-graph.test.ts
@@ -221,19 +221,19 @@ describe('EmberAppPackageGraph', () => {
 
     await setupProject(project);
 
-    const m = new EmberAppProjectGraph(project.baseDir);
+    const projectGraph = new EmberAppProjectGraph(project.baseDir);
 
     const emberPackage = new EmberAppPackage(project.baseDir);
-    const appNode = m.addPackageToGraph(emberPackage);
+    const appNode = projectGraph.addPackageToGraph(emberPackage, false);
 
-    const options: EmberAppPackageGraphOptions = { parent: appNode, project: m };
+    const options: EmberAppPackageGraphOptions = { parent: appNode, project: projectGraph };
     emberPackage.getModuleGraph(options);
 
-    const node: GraphNode<PackageNode> = m.graph.getNode('some-addon');
+    const node: GraphNode<PackageNode> = projectGraph.graph.getNode('some-addon');
     expect(node?.content.synthetic).toBe(true);
 
     const emberAddonPackage = new EmberAddonPackage(join(project.baseDir, 'lib/some-addon'));
-    const addonNode = m.addPackageToGraph(emberAddonPackage);
+    const addonNode = projectGraph.addPackageToGraph(emberAddonPackage);
     expect(addonNode.content.synthetic).toBeFalsy();
 
     // Validate that addonn package has an the edge exists between
@@ -317,7 +317,7 @@ describe('EmberAppPackageGraph', () => {
     const m = new EmberAppProjectGraph(project.baseDir);
 
     const emberAppPackage = new EmberAppPackage(project.baseDir);
-    const appNode = m.addPackageToGraph(emberAppPackage);
+    const appNode = m.addPackageToGraph(emberAppPackage, false);
 
     const options: EmberAppPackageGraphOptions = { parent: appNode, project: m };
     emberAppPackage.getModuleGraph(options);
@@ -542,7 +542,7 @@ describe('EmberAppPackageGraph', () => {
 
     // Add the app to the project graph
     const emberAppPackage = new EmberAppPackage(project.baseDir);
-    const appNode = projectGraph.addPackageToGraph(emberAppPackage);
+    const appNode = projectGraph.addPackageToGraph(emberAppPackage, false);
 
     const options: EmberAppPackageGraphOptions = { parent: appNode, project: projectGraph };
     emberAppPackage.getModuleGraph(options);

--- a/packages/migration-graph-ember/tests/entities/ember-app-project-graph.test.ts
+++ b/packages/migration-graph-ember/tests/entities/ember-app-project-graph.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'vitest';
+import { getEmberProject, setupProject } from '@rehearsal/test-support';
+import { EmberAppPackage } from '../../src/entities/ember-app-package';
+import { EmberAppProjectGraph } from '../../src/entities/ember-app-project-graph';
+
+describe('EmberAppProjectGraph', () => {
+  test('should discover in-repo-addon from package.json', async () => {
+    const project = getEmberProject('app-with-in-repo-addon');
+
+    await setupProject(project);
+
+    const projectGraph = new EmberAppProjectGraph(project.baseDir);
+
+    const appPackage = new EmberAppPackage(project.baseDir);
+    projectGraph.addPackageToGraph(appPackage);
+
+    expect(projectGraph.graph.hasNode('some-addon')).toBe(true);
+  });
+
+  test('should create an edge between app and in-repo addon', async () => {
+    const project = getEmberProject('app-with-in-repo-addon');
+
+    await setupProject(project);
+
+    const projectGraph = new EmberAppProjectGraph(project.baseDir);
+
+    const appPackage = new EmberAppPackage(project.baseDir);
+    projectGraph.addPackageToGraph(appPackage);
+
+    const rootNode = projectGraph.graph.getNode('app-template');
+    const addonNode = projectGraph.graph.getNode('some-addon');
+    expect(
+      rootNode.adjacent.has(addonNode),
+      'should have an edge between app and in-repo-addon'
+    ).toBe(true);
+  });
+
+  test('options.eager=true should create a synethic node and then backfill when packageName differs from addonName', async () => {
+    // If a parent app is crawled first eagerly, it may create some synthetic nodes.
+
+    // Create an app where the app users a service with ambigous coordinates
+
+    // package.name is @some-org/some-addon
+
+    // Usage is like:
+    // @service('some-addon@some-service') myService
+
+    // The problem here is that the left-part of the coordinates are ember-addon-name and not package.name
+
+    // We put packages in the graph by their packageName
+
+    // This tests the logic in EmberAppProjectGrpah.addPackageToGrpah()
+
+    // To add a entry in the registry for this lookup so we can update the synthetic node that is injected when this service is not found.
+
+    const project = getEmberProject('app-with-in-repo-addon');
+
+    const addonPackageJson = `
+      {
+        "name": "@some-org/some-addon",
+        "keywords": [
+          "ember-addon"
+        ],
+        "dependencies": {
+          "ember-cli-babel": "*",
+          "ember-cli-htmlbars": "*",
+          "@glimmer/component": "*"
+        }
+      }
+    `;
+
+    project.mergeFiles({
+      app: {
+        components: {
+          'salutation.js': `
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Salutation extends Component {
+  @service('some-addon@some-service') myService;
+}`,
+        },
+      },
+      lib: {
+        'some-addon': {
+          addon: {
+            services: {
+              'some-service.js': `
+              import Service from '@ember/service';
+        
+              export default class SomeService extends Service {}
+              `,
+            },
+          },
+          app: {
+            services: {
+              'some-service.js': `export { default } from 'some-addon/services/some-service';`,
+            },
+          },
+          'index.js': `
+            'use strict';
+        
+            module.exports = {
+              name: 'some-addon',
+        
+              isDevelopingAddon() {
+                return true;
+              },
+            };
+          `,
+          'package.json': addonPackageJson,
+        },
+      },
+    });
+
+    await setupProject(project);
+
+    const projectGraph = new EmberAppProjectGraph(project.baseDir, { eager: true });
+    const appPackage = new EmberAppPackage(project.baseDir);
+    const rootPackageNode = projectGraph.addPackageToGraph(appPackage);
+
+    const rootNode = projectGraph.graph.getNode('app-template');
+
+    expect(projectGraph.graph.nodes.size).toBe(2);
+
+    const sourceNode = rootPackageNode.content.pkg
+      ?.getModuleGraph()
+      .getNode('app/components/salutation.js');
+
+    expect(sourceNode?.content.parsed, 'the component should have been parsed').toBe(true);
+
+    // We should have a synthetic node for some-addon
+    const addonFoundByAddonName = projectGraph.graph.getNode('some-addon');
+    expect(addonFoundByAddonName.content.synthetic).toBeFalsy();
+    expect(
+      rootNode.adjacent.has(addonFoundByAddonName),
+      'should have an edge between app and in-repo-addon'
+    ).toBe(true);
+
+    const addonFoundByPackageName = projectGraph.graph.getNode('@some-org/some-addon');
+    expect(
+      rootNode.adjacent.has(addonFoundByPackageName),
+      'should have an edge between app and in-repo-addon'
+    ).toBe(true);
+  });
+});

--- a/packages/migration-graph-shared/src/graph/graph.ts
+++ b/packages/migration-graph-shared/src/graph/graph.ts
@@ -45,10 +45,6 @@ export class Graph<T extends UniqueNode> {
     const { key } = content;
     if (this.hasNode(key)) {
       const node = this.getNode(key);
-      if (!node) {
-        throw new Error(`Registry populated with undefined graph node at ${key}`);
-      }
-
       return node;
     }
 

--- a/packages/migration-graph-shared/src/graph/graph.ts
+++ b/packages/migration-graph-shared/src/graph/graph.ts
@@ -59,13 +59,16 @@ export class Graph<T extends UniqueNode> {
     return this;
   }
 
-  topSort(): GraphNode<T>[] {
+  topSort(start: GraphNode<T> | undefined = undefined): GraphNode<T>[] {
     const visited = new Set<GraphNode<T>>();
     const stack = new Array<GraphNode<T>>();
 
+    if (start) {
+      this.topSortUtil(start, visited, stack);
+    }
+
     Array.from(this.#nodes).forEach((node: GraphNode<T>) => {
       if (!visited.has(node)) {
-        // const iterator = topSort(node, visited);
         this.topSortUtil(node, visited, stack);
       }
     });

--- a/packages/migration-graph-shared/tests/graph/graph.test.ts
+++ b/packages/migration-graph-shared/tests/graph/graph.test.ts
@@ -32,12 +32,12 @@ describe('graph', () => {
     // Reference https://www.geeksforgeeks.org/topological-sorting/
     const graph = new Graph<UniqueNode>();
 
+    const f = graph.addNode(createNode('5'));
     const a = graph.addNode(createNode('0'));
     const b = graph.addNode(createNode('1'));
     const c = graph.addNode(createNode('2'));
     const d = graph.addNode(createNode('3'));
     const e = graph.addNode(createNode('4'));
-    const f = graph.addNode(createNode('5'));
 
     graph.addEdge(f, c); // 5,2
     graph.addEdge(f, a); // 5,0
@@ -47,8 +47,36 @@ describe('graph', () => {
     graph.addEdge(d, b); // 3,1
 
     // We expect a leaf-to-root output.
-    const expected = ['0', '1', '3', '2', '4', '5'];
+    // const expected = ['0', '1', '3', '2', '4', '5'];
+    // This order is determiend by the order for which the node was added to the graph.
+    // Node f was added first and it's dependencies are in the order of adjacencies.
+    const expected = ['1', '3', '2', '0', '5', '4'];
     const nodes = graph.topSort();
+    const actual = nodes.map((node) => node.content.key);
+    expect(actual).toEqual(expected);
+  });
+
+  test('should print a graph relative to a passed node', async () => {
+    // Reference https://www.geeksforgeeks.org/topological-sorting/
+    const graph = new Graph<UniqueNode>();
+
+    const f = graph.addNode(createNode('5'));
+    const a = graph.addNode(createNode('0'));
+    const b = graph.addNode(createNode('1'));
+    const c = graph.addNode(createNode('2'));
+    const d = graph.addNode(createNode('3'));
+    const e = graph.addNode(createNode('4'));
+
+    graph.addEdge(f, c); // 5,2
+    graph.addEdge(f, a); // 5,0
+    graph.addEdge(e, a); // 4,0
+    graph.addEdge(e, b); // 4,1
+    graph.addEdge(c, d); // 2,3
+    graph.addEdge(d, b); // 3,1
+
+    // We expect a leaf-to-root output.
+    const expected = ['1', '3', '2', '0', '5', '4'];
+    const nodes = graph.topSort(c);
     const actual = nodes.map((node) => node.content.key);
     expect(actual).toEqual(expected);
   });

--- a/packages/migration-graph/src/migration-strategy.ts
+++ b/packages/migration-graph/src/migration-strategy.ts
@@ -80,7 +80,6 @@ export function getMigrationStrategy(
 
   projectGraph.graph
     .topSort()
-    .reverse() // Reverse the graph order to ensure leaf package first.
     // Iterate through each package
     .forEach((packageNode: GraphNode<PackageNode>) => {
       const packagePath = packageNode.content?.pkg?.packagePath;


### PR DESCRIPTION
A couple of issues were fixed:

*`graph.topSort(...)` now takes an optional argument for a `rootNode`*
This will allow for get the order of an app's migration relative to a given package, specifically fixing a bug where I thought the order was in root to leaf and reversing it. It actually was a bug because I was always printing from the first added package of the graph.

*backfill services when an org is used on packageName that doesn't match moduleName*
- In some cases an ember-addon may have a moduleName that differs from packageJson.name
- This is a problem in the project-graph because we use the packageName as a key.
- Now we store multiple lookup entries in the graph registry so `some-addon` and `@some-org/some-addon` will map to the same package.