### PR TITLE
fix: perf when crawling deps

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
@@ -159,7 +159,10 @@ export class EmberAppPackageGraph extends PackageGraph {
         // Lookup the addonName in the package graph
         const maybeAddonPackageNode: GraphNode<PackageNode> | undefined =
           this.findPackageNodeByAddonName(s.addonName);
-        DEBUG_CALLBACK('findPackageNodeByAddonName: %O', maybeAddonPackageNode);
+
+        if (maybeAddonPackageNode) {
+          DEBUG_CALLBACK('findPackageNodeByAddonName: %O', maybeAddonPackageNode);
+        }
 
         if (maybeAddonPackageNode) {
           // We've found a package in the migration graph that has the addonName

--- a/packages/migration-graph/src/migration-graph.ts
+++ b/packages/migration-graph/src/migration-graph.ts
@@ -22,11 +22,11 @@ function buildMigrationGraphForLibrary(
   options?: MigrationGraphOptions
 ): ProjectGraph {
   const rootDir = projectGraph.rootDir;
-  const pkg = new Package(rootDir);
+  const p = new Package(rootDir);
 
-  projectGraph.addPackageToGraph(pkg);
+  projectGraph.addPackageToGraph(p);
 
-  pkg.getModuleGraph({
+  p.getModuleGraph({
     entrypoint: options?.entrypoint,
   });
 
@@ -65,7 +65,6 @@ function buildMigrationGraphForEmber(
     DEBUG_CALLBACK(`Total Filtered Packages: ${filtered.length}`);
 
     counter = 1;
-
     filtered.forEach((p) => DEBUG_CALLBACK(` ${counter++}. ${p.packageName}: ${p.path}`));
     filtered.forEach((p) => {
       projectGraph.addPackageToGraph(p);

--- a/packages/migration-graph/src/util/printer.ts
+++ b/packages/migration-graph/src/util/printer.ts
@@ -1,0 +1,22 @@
+import type { GraphNode, PackageNode, ProjectGraph } from '@rehearsal/migration-graph-shared';
+
+function printRelationship(source: GraphNode<PackageNode>, dest: GraphNode<PackageNode>): string {
+  return `"${source.content.key}" -> "${dest.content.key}";`;
+}
+
+export function printDirectedGraph(name: string, projectGraph: ProjectGraph): string {
+  const rootNode = projectGraph.graph.getNode(name);
+
+  const nodes = projectGraph.graph.topSort(rootNode);
+
+  const entries = Array.from(nodes).map((p) => {
+    return Array.from(p.adjacent).map((dest) => {
+      const source = p;
+      return printRelationship(source, dest);
+    });
+  });
+
+  const output = [`digraph "${name}" {`, ...entries.flat().map((s) => `  ${s}`), '}'];
+
+  return output.join('\n');
+}


### PR DESCRIPTION
**Summary**
Root caused performance bug in rehearsal/migration-graph when running against our large internal ember app. 

This issue was “fixed” was #450, how opened back up in #470.

**Details**
When we create a graph for an ember app, we `fastglob` all package.json’s from the directory first, then packages entities to the graph `EmberAppProjectGraph.addPackageToGraph()`.

This is sufficient enough to find all nodes.

Now we have to create edges.

After we add a package to the graph, we follow-up with looking at it's dep and devDeps and inner joining that data the manifest of in-repo addons defined in the project root `package.json`.  This method was renamed from ~EmberAppProjectGraph.buildAnalyzedPackageTree~  to`EmberAppProjectGraph.discoverEdgesFromDependencies()`.

Previously, there was some sort of escape hatch depth check in this process, but I don’t think it worked because we never looked at the depth or decremented the counter.

This was broken prior to #450 because I had some bad logic that would break out of the recursion, so it would skip the this crawling/discovery of a dependencies explicit in-repo dependencies.

So in my last PR #470 I re-exposed the perf bug, because of code refactoring and better tests.

**Root Cause**
Currently, in a large repo (voyager-web) we may have some cyclical dependencies, and thus during this discovery process we recurse through this process causing these cycles. Having no escape hatch would cause a long running process.
It broke because we didn’t do a depth check for recursion, or cycles of dependencies.

**Fix**
- I am removing the recursive crawl of dependencies after `addPackageToGraph`. 
- Evaluated the output from recursive discovery or not, and the dot-viz graph output was identical.
- Added a vistor Set to the EmberAppProjectGraph to ensure any node we try and discover dependencies on we don't do twice. This is now logged. 


**Other things**
The `module-mappings.ts` file can be refactored dramatically as we don't use all of its features.