### PR TITLE
fix: display version for migrate and upgrade

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -22,6 +22,7 @@ import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
 import { debug } from 'debug';
 import execa = require('execa');
+import { version } from '../../package.json';
 
 import { generateReports, getReportSummary } from '../helpers/report';
 import {
@@ -75,6 +76,8 @@ migrateCommand
     const logger = createLogger({
       transports: [new transports.Console({ format: format.cli(), level: loggerLevel })],
     });
+
+    console.log(`@rehearsal/migrate ${version.trim()}`);
 
     const tasks = new Listr<MigrateCommandContext>(
       [

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -11,6 +11,7 @@ import { createLogger, format, transports } from 'winston';
 
 import execa = require('execa');
 
+import { version } from '../../package.json';
 import { generateReports, reportFormatter } from '../helpers/report';
 import { UpgradeCommandContext, UpgradeCommandOptions } from '../types';
 import {
@@ -28,7 +29,6 @@ import {
 } from '../utils';
 
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
-
 export const upgradeCommand = new Command();
 
 upgradeCommand
@@ -56,6 +56,8 @@ upgradeCommand
     });
 
     basePath = resolve(basePath);
+
+    console.log(`@rehearsal/upgrade ${version.trim()}`);
 
     // WARN: is git dirty check and exit if dirty
     if (!options.dryRun) {


### PR DESCRIPTION
For [#484 ](https://github.com/rehearsal-js/rehearsal-js/issues/484)

1. Displays version at the start of either migrate or upgrade.
2. Displays version for "rehearsal --version"/"rehearsal -V".
3. Displays version for"rehearsal migrate --version"/"rehearsal migrate -V".
4. Displays version for "rehearsal upgrade --version"/ "rehearsal upgrade -V".
