### PR TITLE
fix: migrate cli should stop on failure

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -282,7 +282,7 @@ migrateCommand
           },
         },
       ],
-      { concurrent: false, exitOnError: false }
+      { concurrent: false, exitOnError: true }
     );
     try {
       await tasks.run();


### PR DESCRIPTION
For #481: update `exitOnError` to `true` in `rehearsal migrate`, in order to hard stop the CLI if there is any issue. The reason we had it on `false` was that we don't want to quit the CLI if there we got non 0 exit during `tsc` check.