### PR TITLE
fix: detailed console message during JS->TS conversion

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -76,11 +76,11 @@ migrateCommand
       transports: [new transports.Console({ format: format.cli(), level: loggerLevel })],
     });
 
-    const tasks = new Listr<MigrateCommandContext>(
+    const tasks = new Listr(
       [
         {
           title: 'Initialization',
-          task: async (_ctx, task) => {
+          task: async (_ctx: MigrateCommandContext, task) => {
             // get custom config
             const userConfig = options.userConfig
               ? new UserConfig(options.basePath, options.userConfig, 'migrate')
@@ -180,8 +180,8 @@ migrateCommand
         },
         {
           title: 'Installing dependencies',
-          enabled: (ctx): boolean => !ctx.skip,
-          task: async (_ctx, task) => {
+          enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+          task: async (_ctx: MigrateCommandContext, task) => {
             // install custom dependencies
             if (_ctx.userConfig?.hasDependencies) {
               task.title = `Installing custom dependencies`;
@@ -193,8 +193,8 @@ migrateCommand
         },
         {
           title: 'Creating tsconfig.json',
-          enabled: (ctx): boolean => !ctx.skip,
-          task: async (_ctx, task) => {
+          enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+          task: async (_ctx: MigrateCommandContext, task) => {
             if (_ctx.userConfig?.hasTsSetup) {
               task.title = `Creating tsconfig from custom config.`;
               await _ctx.userConfig.tsSetup();
@@ -217,8 +217,8 @@ migrateCommand
         },
         {
           title: 'Converting JS files to TS',
-          enabled: (ctx): boolean => !ctx.skip,
-          task: async (_ctx, task) => {
+          enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+          task: async (_ctx: MigrateCommandContext, task) => {
             const projectName = determineProjectName() || '';
             const { basePath } = options;
             const tscPath = await getPathToBinary('tsc');
@@ -234,7 +234,7 @@ migrateCommand
               const input = {
                 basePath: _ctx.targetPackagePath,
                 sourceFiles: _ctx.sourceFilesWithAbsolutePath,
-                logger: options.verbose ? logger : undefined,
+                logger: logger,
                 reporter,
               };
 
@@ -271,8 +271,8 @@ migrateCommand
         },
         {
           title: 'Creating eslint config',
-          enabled: (ctx): boolean => !ctx.skip,
-          task: async (_ctx, task) => {
+          enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+          task: async (_ctx: MigrateCommandContext, task) => {
             if (_ctx.userConfig?.hasLintSetup) {
               task.title = `Creating .eslintrc.js from custom config.`;
               await _ctx.userConfig.lintSetup();
@@ -282,7 +282,11 @@ migrateCommand
           },
         },
       ],
-      { concurrent: false, exitOnError: false }
+      {
+        concurrent: false,
+        exitOnError: false,
+        renderer: 'simple',
+      }
     );
     try {
       await tasks.run();

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -118,11 +118,19 @@ describe('migrate - JS to TS conversion', async () => {
   });
 
   test('able to migrate from default index.js', async () => {
-    const result = await runBin('migrate', ['-v'], {
+    const result = await runBin('migrate', [], {
       cwd: basePath,
     });
 
+    // Test logger messages from package/migrate
+    expect(result.stdout).toContain('info');
+    expect(result.stdout).toContain('Moving /foo.js to /foo.ts');
+    expect(result.stdout).toContain('Moving /index.js to /index.ts');
+    expect(result.stdout).toContain('Processing file:');
+
+    // Test summary message
     expect(result.stdout).toContain(`2 JS files has been converted to TS`);
+
     expect(readdirSync(basePath)).toContain('index.ts');
     expect(readdirSync(basePath)).toContain('foo.ts');
 


### PR DESCRIPTION
For #489.

Showing the logger `info` message in `migrate.run()` during the JS->TS conversion phase. I also updated the default `listr2` renderer from `default` to `simple`, since I figured the default renderer hijacks the stdout and when something writes to it, as in this case the logger, and it would corrupts the output. Now in the CLI we are having:

```
rehearsal migrate
✔ Initialization Completed! Running migration on foo
✔ Installing dependencies
✔ <path-to-foo>/tsconfig.json already exists, ensuring strict mode is enabled.
info:    Migration started.
info:    Base path: <path-to-foo>
info:    Moving <path-to-foo>/bar.js to <path-to-foo>/bar.ts
info:    Config file found: <path-to-foo>/tsconfig.json
info:    Processing file: <path-to-foo>/bar.ts
info:    Conversion finished.
✔ 1 JS files has been converted to TS. There are 1 errors caught by rehearsal
                - 0 have been fixed automatically by rehearsal
                - 1 have been updated with @ts-ignore @rehearsal TODO which need further manual check
```

Quick note:

We cannot do `new Listr<MigrateCommandContext>` if we need to change the default `renderer`, since `Listr<MigrateCommandContext>` would inject/override the option and make `option.renderer` unavailable.

@lynchbomb This is a much faster solution than using a `stream` ish way to update the task tile, I'll let you decide if this would work for now.
