### PR TITLE
refactor: replace @ts-ignore with @ts-expect-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "git+https://github.com/rehearsal-js/rehearsal-js.git"
   },
   "scripts": {
+    "build": "pnpm recursive run build",
     "lint": "pnpm lint:package-json && pnpm recursive run lint",
     "lint:package-json": "sort-package-json package.json packages/*/package.json",
     "prepare": "pnpm recursive run prepare && husky install",

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -77,7 +77,6 @@ migrateCommand
       transports: [new transports.Console({ format: format.cli(), level: loggerLevel })],
     });
 
-
     console.log(`@rehearsal/migrate ${version.trim()}`);
 
     const tasks = new Listr(
@@ -128,7 +127,7 @@ migrateCommand
                 let isOptionDisabled = false;
                 if (totalFileCount !== 0) {
                   // has previous migratoin
-                  progressText = `${migratedFileCount} of ${totalFileCount} files migrated, ${errorCount} @ts-ignore(s) need to be fixed`;
+                  progressText = `${migratedFileCount} of ${totalFileCount} files migrated, ${errorCount} @ts-expect-error(s) need to be fixed`;
                   icon = IN_PROGRESS_MARK;
 
                   if (isCompleted && errorCount === 0) {
@@ -265,7 +264,7 @@ migrateCommand
                 migratedFileCount === 1 ? 'file' : 'files'
               } has been converted to TS. There are ${totalErrorCount} errors caught by rehearsal:
                 - ${errorFixedCount} have been fixed automatically by rehearsal.
-                - ${hintAddedCount} have been updated with @ts-ignore @rehearsal TODO which need further manual check.`;
+                - ${hintAddedCount} have been updated with @ts-expect-error @rehearsal TODO which need further manual check.`;
             } else {
               task.skip(
                 `Skipping JS -> TS conversion task, since there is no JS file to be converted to TS.`

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -80,7 +80,7 @@ export class State {
         // if a ts file in state doesn't exist on disk, mark it as un-migrated
         store.files[f].current = null;
       }
-      // update ts-ignore count
+      // update ts-expect-error count
       store.files[f].errorCount = calculateTSIgnoreCount(f);
     }
     return store;

--- a/packages/codefixes/src/2322/fixtures/2322.ts.output
+++ b/packages/codefixes/src/2322/fixtures/2322.ts.output
@@ -1,16 +1,16 @@
 // Test cases for TS2322
 
-/* @ts-ignore @rehearsal TODO TS2322: The variable 'dummy_const' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type. */
+/* @ts-expect-error @rehearsal TODO TS2322: The variable 'dummy_const' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type. */
 const dummy_const: number = 'string';
 
 let dummy_var = 0;
-/* @ts-ignore @rehearsal TODO TS2322: The variable 'dummy_var' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type. */
+/* @ts-expect-error @rehearsal TODO TS2322: The variable 'dummy_var' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type. */
 dummy_var = 'string';
 
 console.log(dummy_const, dummy_var);
 
 function demo(): void {
-  /* @ts-ignore @rehearsal TODO TS2322: The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type. */
+  /* @ts-expect-error @rehearsal TODO TS2322: The function expects to return 'void', but 'string' is returned. Please convert 'string' value to 'void' or update the function's return type. */
   return 'dummy-string';
 }
 

--- a/packages/codefixes/src/2345/fixtures/2345.ts.output
+++ b/packages/codefixes/src/2345/fixtures/2345.ts.output
@@ -5,9 +5,9 @@ function removeFirstChar(str: string): string | undefined {
 let changeable: unknown;
 changeable = 'yes';
 
-/* @ts-ignore @rehearsal TODO TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'. Consider specifying type of argument to be 'string', using type assertion: '(changeable as string)', or using type guard: 'if (changeable instanceof string) { ... }'. */
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'. Consider specifying type of argument to be 'string', using type assertion: '(changeable as string)', or using type guard: 'if (changeable instanceof string) { ... }'. */
 console.log(removeFirstChar(changeable));
 
 const num = 7;
-/* @ts-ignore @rehearsal TODO TS2345: Argument of type 'number' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '(num as string)', or using type guard: 'if (num instanceof string) { ... }'. */
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'number' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '(num as string)', or using type guard: 'if (num instanceof string) { ... }'. */
 console.log(removeFirstChar(num));

--- a/packages/codefixes/src/2571/fixtures/2571.ts.output
+++ b/packages/codefixes/src/2571/fixtures/2571.ts.output
@@ -29,5 +29,5 @@ function getObject<T>(): T {
 
 const dummy = getObject();
 
-/* @ts-ignore @rehearsal TODO TS2571: Object is of type 'unknown'. Specify a type of dummy, use type assertion: `(dummy as DesiredType)` or type guard: `if (dummy instanceof DesiredType) { ... }` */
+/* @ts-expect-error @rehearsal TODO TS2571: Object is of type 'unknown'. Specify a type of dummy, use type assertion: `(dummy as DesiredType)` or type guard: `if (dummy instanceof DesiredType) { ... }` */
 dummy.key;

--- a/packages/codefixes/src/hints-codefix-collection.ts
+++ b/packages/codefixes/src/hints-codefix-collection.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 /**
- * Don't actually fix the issue but adds a @ts-ignore comments instead
+ * Don't actually fix the issue but adds a @ts-expect-error comments instead
  */
 export class HintCodeFixCollection implements CodeFixCollection {
   readonly list: CodeHintList;
@@ -19,7 +19,7 @@ export class HintCodeFixCollection implements CodeFixCollection {
 
   getFixForDiagnostic(diagnostic: DiagnosticWithContext): CodeFixAction | undefined {
     const hint = this.getHint(diagnostic);
-    const comment = `@ts-ignore @rehearsal TODO TS${diagnostic.code}: ${hint}`;
+    const comment = `@ts-expect-error @rehearsal TODO TS${diagnostic.code}: ${hint}`;
 
     console.log(diagnostic.node?.getText());
     console.log(diagnostic.node?.getStart());

--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -103,7 +103,7 @@ export class DiagnosticFixPlugin extends Plugin {
 
     const diagnostics = [
       ...this.service.getSemanticDiagnosticsWithLocation(fileName),
-      ...this.service.getSuggestionDiagnostics(fileName)
+      ...this.service.getSuggestionDiagnostics(fileName),
     ];
 
     diagnostics.sort((a, b) => a.start - b.start);
@@ -184,7 +184,7 @@ export class DiagnosticFixPlugin extends Plugin {
     const node = findNodeAtPosition(diagnostic.file, diagnostic.start, diagnostic.length)!;
 
     // TODO: Pass a comment template in config
-    let comment = `@ts-ignore ${tag} TODO TS${diagnostic.code}: ${hint}`;
+    let comment = `@ts-expect-error ${tag} TODO TS${diagnostic.code}: ${hint}`;
     comment = isNodeInsideJsx(node) ? `{/* ${comment} */}` : `/* ${comment} */`;
 
     // Make sure the comment is a single because we have to place @ tags right above the issue
@@ -202,9 +202,9 @@ export class DiagnosticFixPlugin extends Plugin {
     const startColumn = character + 1; //bump character 0 to character 1, so on and so forth
     const newCode = textChange.newText;
     const oldCode = sourceFile.text.substring(
-          textChange.span.start,
-          textChange.span.start + textChange.span.length
-        ) ;
+      textChange.span.start,
+      textChange.span.start + textChange.span.length
+    );
 
     const getActionKind = (textChange: TextChange): CodeFixKind => {
       if (textChange.span.length === 0) {

--- a/packages/upgrade/src/upgrade.ts
+++ b/packages/upgrade/src/upgrade.ts
@@ -22,7 +22,7 @@ export type UpgradeOutput = {
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
 
 /**
- * Provides semantic diagnostic information in @ts-ignore comments and in a JSON report
+ * Provides semantic diagnostic information in @ts-expect-error comments and in a JSON report
  */
 export async function upgrade(input: UpgradeInput): Promise<UpgradeOutput> {
   const basePath = resolve(input.basePath);

--- a/packages/upgrade/test/fixtures/upgrade/react-processed.tsx.input
+++ b/packages/upgrade/test/fixtures/upgrade/react-processed.tsx.input
@@ -21,7 +21,7 @@ export function Component() {
 
   console.log(element1, element2);
 
-  /* @ts-ignore @rehearsal TODO TS2304: ... */
+  /* @ts-expect-error @rehearsal TODO TS2304: ... */
   return <NonExistingFragment />;
 }
 

--- a/packages/upgrade/test/fixtures/upgrade/react-processed.tsx.output
+++ b/packages/upgrade/test/fixtures/upgrade/react-processed.tsx.output
@@ -3,28 +3,28 @@ import React from 'react';
 export function test() {}
 
 export function Component() {
-  /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */
+  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */
   const element1 = <NonExistingElement />;
 
   const element2 = (
     <h1>
       The Very-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y Long Title
-      {/* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */}
+      {/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */}
       <NonExistingElement>...</NonExistingElement>
-      {/* @ts-ignore @rehearsal TODO TS2322: Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode' */}
+      {/* @ts-expect-error @rehearsal TODO TS2322: Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode' */}
       <p>{{ $notExistingVariable }}</p>
     </h1>
   );
 
   console.log(element1, element2);
 
-  /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingFragment'. */
+  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingFragment'. */
   return <NonExistingFragment />;
 }
 
 export function Test2() {
   const someBoolean = true;
 
-  /* @ts-ignore @rehearsal TODO TS2322: The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type. */
+  /* @ts-expect-error @rehearsal TODO TS2322: The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type. */
   return someBoolean ? <br doesNotExist="fail" /> : <br />;
 }

--- a/packages/upgrade/test/fixtures/upgrade/react.tsx.output
+++ b/packages/upgrade/test/fixtures/upgrade/react.tsx.output
@@ -3,28 +3,28 @@ import React from 'react';
 export function test() {}
 
 export function Component() {
-  /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */
+  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */
   const element1 = <NonExistingElement />;
 
   const element2 = (
     <h1>
       The Very-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y-y Long Title
-      {/* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */}
+      {/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingElement'. */}
       <NonExistingElement>...</NonExistingElement>
-      {/* @ts-ignore @rehearsal TODO TS2322: Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode' */}
+      {/* @ts-expect-error @rehearsal TODO TS2322: Type 'notExistingVariable: any' is being returned or assigned, but type 'ReactNode' is expected. Please convert type 'notExistingVariable: any' to type 'ReactNode', or return or assign a variable of type 'ReactNode' */}
       <p>{{ $notExistingVariable }}</p>
     </h1>
   );
 
   console.log(element1, element2);
 
-  /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'NonExistingFragment'. */
+  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'NonExistingFragment'. */
   return <NonExistingFragment />;
 }
 
 export function Test2() {
   const someBoolean = true;
 
-  /* @ts-ignore @rehearsal TODO TS2322: The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type. */
+  /* @ts-expect-error @rehearsal TODO TS2322: The variable 'doesNotExist' has type 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement', but 'doesNotExist: string' is assigned. Please convert 'doesNotExist: string' to 'DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement' or change variable's type. */
   return someBoolean ? <br doesNotExist="fail" /> : <br />;
 }

--- a/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.output
@@ -8,7 +8,7 @@ export function usesMissingVariable(): boolean {
   const something = true;
   const existingVar = true;
 
-  /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
+  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
   return something ? missingVar : existingVar;
 }
 
@@ -16,9 +16,9 @@ export function usesMissingVarWithLongName(): boolean {
   const something = true;
 
   return something
-    ? /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
+    ? /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'missingVar'. */
       missingVar
-    : /* @ts-ignore @rehearsal TODO TS2304: Cannot find name 'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'. */
+    : /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'. */
       missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;
 }
 

--- a/packages/upgrade/test/fixtures/upgrade/ts-multiline-hint.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-multiline-hint.ts.output
@@ -37,11 +37,11 @@ export class Foo {
   fooMethod(size: string): boolean {
     const nextBreakpointIndex =
       orderedBreakpointsLongNameConstant.indexOf(
-        /* @ts-ignore @rehearsal TODO TS2345: Argument of type 'string, number] | undefined' is not assignable to parameter of type 'string, number'. Consider verifying both types, using type assertion: '(         orderedBreakpointsLongNameConstant.find(([key]) => key === size) as string)', or using type guard: 'if (         orderedBreakpointsLongNameConstant.find(([key]) => key === size) instanceof string) { ... }'. */
+        /* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string, number] | undefined' is not assignable to parameter of type 'string, number'. Consider verifying both types, using type assertion: '(         orderedBreakpointsLongNameConstant.find(([key]) => key === size) as string)', or using type guard: 'if (         orderedBreakpointsLongNameConstant.find(([key]) => key === size) instanceof string) { ... }'. */
         orderedBreakpointsLongNameConstant.find(([key]) => key === size)
       ) + 1;
     if (nextBreakpointIndex < orderedBreakpointsLongNameConstant.length) {
-      /* @ts-ignore @rehearsal TODO TS2532: Object is possibly 'undefined'. */
+      /* @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'. */
       return this.viewportWidth >= orderedBreakpointsLongNameConstant[nextBreakpointIndex][1];
     }
 
@@ -63,7 +63,7 @@ export class Foo {
    * @returns {boolean}
    */
   isLess(size: string): boolean {
-    /* @ts-ignore @rehearsal TODO TS2532: Object is possibly 'undefined'. */
+    /* @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'. */
     return this.viewportWidth < breakpointMap[size];
   }
 }

--- a/packages/upgrade/test/fixtures/upgrade/ts-processed.ts.input
+++ b/packages/upgrade/test/fixtures/upgrade/ts-processed.ts.input
@@ -35,8 +35,8 @@ const resultValue = something
 try {
   console.log('success');
 } catch (e) {
-  /* @ts-ignore @rehearsal Object is of type '{0}'. Specify a type of variable, use type assertion: `(variable as DesiredType)` or type guard: `if (variable instanceof DesiredType) { ... }` */
+  /* @ts-expect-error @rehearsal Object is of type '{0}'. Specify a type of variable, use type assertion: `(variable as DesiredType)` or type guard: `if (variable instanceof DesiredType) { ... }` */
   console.log(e.message);
-  /* @ts-ignore @rehearsal Object is of type '{0}'. Specify a type of variable, use type assertion: `(variable as DesiredType)` or type guard: `if (variable instanceof DesiredType) { ... }` */
+  /* @ts-expect-error @rehearsal Object is of type '{0}'. Specify a type of variable, use type assertion: `(variable as DesiredType)` or type guard: `if (variable instanceof DesiredType) { ... }` */
   console.log(e.notErrorMember);
 }

--- a/packages/upgrade/test/fixtures/upgrade/ts-types.ts.input
+++ b/packages/upgrade/test/fixtures/upgrade/ts-types.ts.input
@@ -24,7 +24,7 @@ export function test3(me: number): string {
   return me.toString();
 }
 
-/* @ts-ignore @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'. */
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'. */
 test3('O');
 
 export class A {

--- a/packages/upgrade/test/fixtures/upgrade/ts-types.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-types.ts.output
@@ -24,7 +24,7 @@ export function test3(me: number): string {
   return me.toString();
 }
 
-/* @ts-ignore @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'. */
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'. */
 test3('O');
 
 export class A {


### PR DESCRIPTION
Closes #495 

This PR can optionally be merged; however I would recommend we move away from @ts-ignore. The API for @ts-ignore and @ts-expect-error are nearly identical. A key delta for @ts-expect-error, in that the compiler will throw if Rehearsal has inlined a TODO when there isn't actually a compiler error. This is super helpful for when folks are cleaning up Rehearsal TODO's and forget to delete the Rehearsal comment after fixing the error.