### PR TITLE
fix: remove sarif property bag

### DIFF
--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -93,7 +93,7 @@ export class SarifFormatter {
   }
 
   private buildResult(item: ReportItem): Result {
-    const { locations, relatedLocations, fixes } = this.getFilesData(
+    const { locations, relatedLocations, codeFix } = this.getFilesData(
       item.files,
       item.analysisTarget
     );
@@ -115,7 +115,7 @@ export class SarifFormatter {
       relatedLocations,
       properties: {
         fixed: item.fixed || false,
-        fixes,
+        codeFix,
       },
     };
   }
@@ -124,7 +124,7 @@ export class SarifFormatter {
     let locations: Location[] = [];
     let relatedLocations: Location[] = [];
 
-    let fixes: { [key: string]: string | undefined }[] = [];
+    let codeFix: { [key: string]: string | undefined } | undefined;
     Object.values(files).forEach((file) => {
       if (file.fileName === entryFileName) {
         locations = [...locations, this.buildLocation(file)];
@@ -132,22 +132,19 @@ export class SarifFormatter {
         relatedLocations = [...relatedLocations, this.buildLocation(file)];
       }
       if (file.fixed) {
-        fixes = [
-          ...fixes,
-          {
-            fileName: file.fileName,
-            newCode: file.newCode,
-            oldCode: file.oldCode,
-            codeFixAction: file.codeFixAction || undefined,
-          },
-        ];
+        codeFix = {
+          fileName: file.fileName,
+          newCode: file.newCode,
+          oldCode: file.oldCode,
+          codeFixAction: file.codeFixAction || undefined,
+        };
       }
     });
 
     return {
       locations,
       relatedLocations,
-      fixes,
+      codeFix,
     };
   }
 

--- a/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
@@ -115,14 +115,12 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     \\"relatedLocations\\": [],
     \\"properties\\": {
       \\"fixed\\": true,
-      \\"fixes\\": [
-        {
-          \\"fileName\\": \\"add-result-1.ts\\",
-          \\"newCode\\": \\"\\",
-          \\"oldCode\\": \\"import react from 'react';\\",
-          \\"codeFixAction\\": \\"delete\\"
-        }
-      ]
+      \\"codeFix\\": {
+        \\"fileName\\": \\"add-result-1.ts\\",
+        \\"newCode\\": \\"\\",
+        \\"oldCode\\": \\"import react from 'react';\\",
+        \\"codeFixAction\\": \\"delete\\"
+      }
     }
   },
   {
@@ -163,8 +161,7 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     ],
     \\"relatedLocations\\": [],
     \\"properties\\": {
-      \\"fixed\\": false,
-      \\"fixes\\": []
+      \\"fixed\\": false
     }
   },
   {
@@ -203,8 +200,7 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     ],
     \\"relatedLocations\\": [],
     \\"properties\\": {
-      \\"fixed\\": false,
-      \\"fixes\\": []
+      \\"fixed\\": false
     }
   }
 ]"


### PR DESCRIPTION
[#496](https://github.com/rehearsal-js/rehearsal-js/issues/496) 

Tried using the Fixes property of sarif, but Fixes won't show in sarif reader. So I am sticking to property bag, which is more straightforward. 

Please refer to the attachments for "after" and "before" screenshots.