### PR TITLE
fix: reset files when cli falis

### DIFF
--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -82,7 +82,7 @@ migrateCommand
 
     console.log(`@rehearsal/migrate ${version.trim()}`);
 
-    const hasUncommittedFiles = await gitIsRepoDirty();
+    const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
     if (hasUncommittedFiles) {
       logger.warn(
         'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { existsSync, writeJSONSync, readJSONSync, readFileSync, mkdirSync } from 'fs-extra';
-import execa from 'execa';
+
+import { git } from '../utils';
 
 // The reaosn to have packageMap is getting all files in a package faster
 // than loop through everyhing in the files
@@ -143,12 +144,8 @@ export class State {
   }
 
   async addStateFileToGit(): Promise<void> {
-    try {
-      // check if git history exists
-      await execa('git', ['status']);
-      await execa('git', ['add', this.configPath]);
-    } catch (e) {
-      // no ops
+    if (await git.checkIsRepo()) {
+      git.add(['add', this.configPath]);
     }
   }
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -395,3 +395,16 @@ export function addPackageJsonScripts(basePath: string, scriptMap: ScriptMap): v
   packageJSON.scripts = { ...packageJSON.scripts, ...scriptMap };
   writeJSONSync(packageJSONPath, packageJSON, { spaces: 2 });
 }
+
+/**
+ * Run git reset to get all file changes to the previous state
+ */
+export async function resetFiles(): Promise<void> {
+  try {
+    // check if git history exists
+    await execa('git', ['status']);
+    await execa('git', ['reset', '--hard']);
+  } catch (e) {
+    // no ops
+  }
+}

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -50,6 +50,9 @@ describe('migrate - check repo status', async () => {
     } as Partial<SimpleGitOptions>);
     await git.init();
     await git.add('package.json');
+    // GH CI would require git name and email
+    await git.addConfig('user.name', 'tester');
+    await git.addConfig('user.email', 'tester@tester.com');
     await git.commit('test');
 
     const { stdout } = await runBin('migrate', [], {


### PR DESCRIPTION
For #480.
This issue should be fixed by https://github.com/rehearsal-js/rehearsal-js/pull/501, since the CLI would exit on error during installation and would not continue to do the conversion. However, I brought `exitOnError: false` in again from https://github.com/rehearsal-js/rehearsal-js/pull/502 by accident.

This PR:
- Set `exitOnError` back to `true`
- Add a check for uncommitted files before proceeding
- Reset all files changed by the CLI to the previous state if there is any error