### PR TITLE
fix: correct use of sarif kind

### DIFF
--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -97,14 +97,11 @@ export class SarifFormatter {
       item.files,
       item.analysisTarget
     );
-    const baselineState = item.fixed ? 'updated' : 'unchanged';
-    const kind = item.fixed ? 'review' : 'informational';
     return {
       ruleId: `TS${item.errorCode}`,
       ruleIndex: this.ruleIndexMap[`TS${item.errorCode}`],
       level: levelConverter(item.category),
-      baselineState,
-      kind,
+      kind: kindConverter(item.category),
       message: {
         text: item.hint,
       },
@@ -203,6 +200,16 @@ function buildArtifact(file: ProcessedFile): Artifact {
       hintAdded: file.hintAdded,
     },
   };
+}
+function kindConverter(category: string): Result.kind {
+  switch (category) {
+    case 'Warning':
+    case 'Suggestion':
+    case 'Message':
+      return 'review';
+    default:
+      return 'fail';
+  }
 }
 
 function levelConverter(category: string): Result.level {

--- a/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
@@ -79,8 +79,7 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     \\"ruleId\\": \\"TS6133\\",
     \\"ruleIndex\\": 0,
     \\"level\\": \\"error\\",
-    \\"baselineState\\": \\"updated\\",
-    \\"kind\\": \\"review\\",
+    \\"kind\\": \\"fail\\",
     \\"message\\": {
       \\"text\\": \\"The declaration 'react' is never read or used. Remove the declaration or use it.\\"
     },
@@ -127,8 +126,7 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     \\"ruleId\\": \\"TS2322\\",
     \\"ruleIndex\\": 1,
     \\"level\\": \\"error\\",
-    \\"baselineState\\": \\"unchanged\\",
-    \\"kind\\": \\"informational\\",
+    \\"kind\\": \\"fail\\",
     \\"message\\": {
       \\"text\\": \\"The variable 'a' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.\\"
     },
@@ -168,8 +166,7 @@ exports[`Test sarif-formatter > should have the correct number of results in ord
     \\"ruleId\\": \\"TS2345\\",
     \\"ruleIndex\\": 2,
     \\"level\\": \\"error\\",
-    \\"baselineState\\": \\"unchanged\\",
-    \\"kind\\": \\"informational\\",
+    \\"kind\\": \\"fail\\",
     \\"message\\": {
       \\"text\\": \\"Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.\\"
     },

--- a/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
     {
       \\"engineId\\": \\"rehearsal-ts\\",
       \\"ruleId\\": \\"TS6133\\",
-      \\"severity\\": \\"CRITICAL\\",
+      \\"severity\\": \\"BLOCKER\\",
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"The declaration 'react' is never read or used. Remove the declaration or use it.\\",
@@ -22,7 +22,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
     {
       \\"engineId\\": \\"rehearsal-ts\\",
       \\"ruleId\\": \\"TS2322\\",
-      \\"severity\\": \\"INFO\\",
+      \\"severity\\": \\"BLOCKER\\",
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"The variable 'a' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.\\",
@@ -38,7 +38,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
     {
       \\"engineId\\": \\"rehearsal-ts\\",
       \\"ruleId\\": \\"TS2345\\",
-      \\"severity\\": \\"INFO\\",
+      \\"severity\\": \\"BLOCKER\\",
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.\\",


### PR DESCRIPTION
#498 

The misuse of sarif kind causes the level field not to display correctly. In the sarif reader, the display of sarif level is determined by sarif kind, in other words, sarif kind overwrites the value of the sarif level. 

Also changed to use sarif baselineState default value, which better suits our context. 