### PR TITLE
fix: use relative paths in reports

### DIFF
--- a/packages/plugins/src/data/utils.ts
+++ b/packages/plugins/src/data/utils.ts
@@ -5,9 +5,10 @@ import type { FileRole, Location, ProcessedFile } from '@rehearsal/reporter';
 export function getFilesData(
   fixedFiles: FixedFile[],
   diagnostic: DiagnosticWithLocation,
-  hint = ''
+  hint = '',
+  basePath: string = process.cwd()
 ): { [fileName: string]: ProcessedFile } {
-  const entryFileName = diagnostic.file.fileName;
+  const entryFileName = diagnostic.file.fileName.replace(basePath, '');
 
   let filesData: { [fileName: string]: ProcessedFile } = {
     [entryFileName]: getInitialEntryFileData(diagnostic),

--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -82,7 +82,7 @@ export class DiagnosticFixPlugin extends Plugin {
 
       const fixed = fix !== undefined;
       const helpUrl = hints.getHelpUrl(diagnostic);
-      const processedFiles = getFilesData(fixedFiles, diagnostic, hint);
+      const processedFiles = getFilesData(fixedFiles, diagnostic, hint, this.reporter?.basePath);
       const triggeringLocation = getTriggeringNodeLocation(diagnostic, processedFiles);
 
       this.reporter?.addItem(

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -133,7 +133,7 @@ export class SarifFormatter {
       }
       if (file.fixed) {
         codeFix = {
-          fileName: file.fileName,
+          fileName: file.fileName.replace(this.report.summary.basePath, ''),
           newCode: file.newCode,
           oldCode: file.oldCode,
           codeFixAction: file.codeFixAction || undefined,

--- a/packages/reporter/src/formatters/sonarqube-formatter.ts
+++ b/packages/reporter/src/formatters/sonarqube-formatter.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from 'path';
+import { relative } from 'path';
 import { PhysicalLocation, Result } from 'sarif';
 
 import { SarifFormatter } from './sarif-formatter';
@@ -40,7 +40,7 @@ export function sonarqubeFormatter(report: Report): string {
     for (const result of results) {
       const physicalLocation = getPhysicalLocation(result);
       const filePath = physicalLocation ? getFilePath(physicalLocation) : '';
-      const absolutePath = isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath);
+      const relativePath = relative(report.summary.basePath, filePath);
 
       issues.push({
         engineId: 'rehearsal-ts',
@@ -49,7 +49,7 @@ export function sonarqubeFormatter(report: Report): string {
         type: SONARQUBE_TYPE[result.level as ErrorLevel],
         primaryLocation: {
           message: result.message.text ?? '',
-          filePath: absolutePath,
+          filePath: relativePath,
           textRange: {
             startLine: physicalLocation?.region?.startLine ?? 0,
             startColumn: physicalLocation?.region?.startColumn ?? 0,

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -80,7 +80,7 @@ export class Reporter {
     helpUrl = ''
   ): void {
     this.report.items.push({
-      analysisTarget: diagnostic.file.fileName,
+      analysisTarget: diagnostic.file.fileName.replace(this.report.summary.basePath, ''),
       files,
       errorCode: diagnostic.code,
       category: DiagnosticCategory[diagnostic.category],

--- a/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
@@ -10,7 +10,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"The declaration 'react' is never read or used. Remove the declaration or use it.\\",
-        \\"filePath\\": \\"/base/path/file1.ts\\",
+        \\"filePath\\": \\"file1.ts\\",
         \\"textRange\\": {
           \\"startLine\\": 1,
           \\"startColumn\\": 1,
@@ -26,7 +26,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"The variable 'a' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.\\",
-        \\"filePath\\": \\"/base/path/file1.ts\\",
+        \\"filePath\\": \\"file1.ts\\",
         \\"textRange\\": {
           \\"startLine\\": 1,
           \\"startColumn\\": 10,
@@ -42,7 +42,7 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
       \\"type\\": \\"BUG\\",
       \\"primaryLocation\\": {
         \\"message\\": \\"Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.\\",
-        \\"filePath\\": \\"/base/path/file1.ts\\",
+        \\"filePath\\": \\"file1.ts\\",
         \\"textRange\\": {
           \\"startLine\\": 1,
           \\"startColumn\\": 10,


### PR DESCRIPTION
We have to use relative paths from the `basePath` so that we don't capture filesystem paths. Also systems like SonarQube wants relative paths so that we can associate issues related to a given path.
