### PR TITLE
feat: use esModuleInterop

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -357,6 +357,7 @@ export function writeTSConfig(basePath: string, fileList: string[]): void {
     $schema: 'https://json.schemastore.org/tsconfig',
     compilerOptions: {
       strict: true,
+      esModuleInterop: true,
       noUncheckedIndexedAccess: true,
       module: 'es2020',
       moduleResolution: 'node',


### PR DESCRIPTION
This flag allows us to emit code written in ES modules if it finds code written in CJS.

https://www.typescriptlang.org/tsconfig#esModuleInterop

Prior to this change when we ran across a `require` it would convert it to:

Given:

```js
const Foo = require("foo");
```

It would be converted to the following which is a non standard import only available in TS.

```ts
import Foo = require("foo");
```

With this flag it will be turned into what we would expect

```ts
import Foo from "foo";
```
