### PR TITLE
chore: remove baseurl

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -9,7 +9,7 @@ import {
   sarifFormatter,
   ReportFormatter,
 } from '@rehearsal/reporter';
-import { CliCommand, Formats, MigrationSummary } from 'src/types';
+import { CliCommand, Formats, MigrationSummary } from '../types';
 
 export function generateReports(
   command: CliCommand,

--- a/packages/cli/test/fixtures/app/tsconfig.json
+++ b/packages/cli/test/fixtures/app/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
-    "baseUrl": ".",
+
     "paths": {
       "*": ["types/*"]
     },

--- a/packages/cli/test/fixtures/app_for_migrate/tsconfig.json
+++ b/packages/cli/test/fixtures/app_for_migrate/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
+
     "outDir": "dist",
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/packages/cli/test/fixtures/app_with_comments/tsconfig.json
+++ b/packages/cli/test/fixtures/app_with_comments/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
-    "baseUrl": ".",
+
     "paths": {
       "*": ["types/*"]
     },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+
     "outDir": "dist"
   },
   "include": ["src", "package.json"],

--- a/packages/codefixes/tsconfig.json
+++ b/packages/codefixes/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../utils" }
+    {
+      "path": "../utils"
+    }
   ]
 }

--- a/packages/migrate/tsconfig.json
+++ b/packages/migrate/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
     {
       "path": "../plugins",

--- a/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
@@ -1,6 +1,6 @@
 import { Package } from '@rehearsal/migration-graph-shared';
-import { EmberAddonPackage } from 'src/entities/ember-addon-package';
-import { EmberAppPackage } from 'src/entities/ember-app-package';
+import { EmberAddonPackage } from '../entities/ember-addon-package';
+import { EmberAppPackage } from '../entities/ember-app-package';
 import { getInternalPackages } from '../mappings-container';
 
 export function discoverEmberPackages(

--- a/packages/migration-graph-ember/tsconfig.json
+++ b/packages/migration-graph-ember/tsconfig.json
@@ -1,14 +1,19 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
     "skipLibCheck": true,
     "strictPropertyInitialization": false
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../migration-graph-shared" },
-    { "path": "../test-support" }
+    {
+      "path": "../migration-graph-shared"
+    },
+    {
+      "path": "../test-support"
+    }
   ]
 }

--- a/packages/migration-graph-shared/tsconfig.json
+++ b/packages/migration-graph-shared/tsconfig.json
@@ -1,13 +1,16 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
     "skipLibCheck": true,
     "strictPropertyInitialization": false
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../test-support" }
+    {
+      "path": "../test-support"
+    }
   ]
 }

--- a/packages/migration-graph/tsconfig.json
+++ b/packages/migration-graph/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../migration-graph-ember" },
-    { "path": "../migration-graph-shared" }
+    {
+      "path": "../migration-graph-ember"
+    },
+    {
+      "path": "../migration-graph-shared"
+    }
   ]
 }

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
     {
       "path": "../codefixes"
@@ -20,4 +21,3 @@
     }
   ]
 }
-

--- a/packages/reporter/tsconfig.json
+++ b/packages/reporter/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/packages/service/tsconfig.json
+++ b/packages/service/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../reporter" }
+    {
+      "path": "../reporter"
+    }
   ]
 }

--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -1,15 +1,26 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../codefixes" },
-    { "path": "../plugins" },
-    { "path": "../reporter" },
-    { "path": "../service" },
-    { "path": "../utils" }
+    {
+      "path": "../codefixes"
+    },
+    {
+      "path": "../plugins"
+    },
+    {
+      "path": "../reporter"
+    },
+    {
+      "path": "../service"
+    },
+    {
+      "path": "../utils"
+    }
   ]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
     "jsx": "react"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Removes `baseURL` config in tsconfig. It's not necessary and causes import codeactions to prefix with `src/`.