### PR TITLE
chore: import type module

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -3,17 +3,19 @@
 import { Command } from 'commander';
 import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
+
 import { version } from '../../../package.json';
-
-import { MigrateCommandOptions } from '../../types';
 import { parseCommaSeparatedList, gitIsRepoDirty, resetFiles } from '../../utils';
+import {
+  initTask,
+  depInstallTask,
+  convertTask,
+  tsConfigTask,
+  lintConfigTask,
+  createScriptsTask,
+} from './tasks';
 
-import { initTask } from './tasks/init';
-import { depInstallTask } from './tasks/depInstall';
-import { convertTask } from './tasks/convert';
-import { tsConfigTask } from './tasks/tsConfig';
-import { lintConfigTask } from './tasks/lintConfig';
-import { createScriptsTask } from './tasks/createScripts';
+import type { MigrateCommandOptions } from '../../types';
 
 export const migrateCommand = new Command();
 
@@ -23,22 +25,23 @@ process.on('SIGINT', () => {
 
 migrateCommand
   .name('migrate')
-  .description('Migrate Javascript project to Typescript')
-  .option('-p, --basePath <project base path>', 'Base dir path of your project.', process.cwd())
+  .description('migrate a javascript project to typescript')
+  .option(
+    '-p, --basePath <project base path>',
+    'base directory path of your project',
+    process.cwd()
+  )
   .option('-e, --entrypoint <entrypoint>', 'entrypoint js file for your project')
   .option(
     '-f, --format <format>',
-    'Report format separated by comma, e.g. -f json,sarif,md,sonarqube',
+    'report format separated by comma, e.g. -f json,sarif,md,sonarqube',
     parseCommaSeparatedList,
     ['sarif']
   )
-  .option('-o, --outputPath <outputPath>', 'Reports output path', '.rehearsal')
-  .option(
-    '-u, --userConfig <custom json config for migrate command>',
-    'File path for custom config'
-  )
-  .option('-i, --interactive', 'Interactive mode to help migrate part of large apps')
-  .option('-v, --verbose', 'Print more logs to debug.')
+  .option('-o, --outputPath <outputPath>', 'reports output path', '.rehearsal')
+  .option('-u, --userConfig <custom json config for migrate command>', 'path to a custom config')
+  .option('-i, --interactive', 'interactive mode')
+  .option('-v, --verbose', 'print all logs for debugging')
   .action(async (options: MigrateCommandOptions) => {
     const loggerLevel = options.verbose ? 'debug' : 'info';
     const logger = createLogger({

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -1,6 +1,5 @@
-import { ListrTask } from 'listr2';
-
-import { MigrateCommandContext } from '../../../types';
+import type { ListrTask } from 'listr2';
+import type { MigrateCommandContext } from '../../../types';
 
 export function lintConfigTask(): ListrTask {
   return {

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -2,8 +2,9 @@ import { resolve } from 'path';
 import { ListrTask } from 'listr2';
 import { existsSync, writeJSONSync } from 'fs-extra';
 
-import { MigrateCommandContext, MigrateCommandOptions, TSConfig } from '../../../types';
 import { readJSON, writeTSConfig } from '../../../utils';
+
+import type { MigrateCommandContext, MigrateCommandOptions, TSConfig } from '../../../types';
 
 export function tsConfigTask(options: MigrateCommandOptions): ListrTask {
   return {

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -7,10 +7,11 @@ import { migrate } from '@rehearsal/migrate';
 import execa = require('execa');
 
 import { generateReports, getReportSummary } from '../../../helpers/report';
-import { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 import { determineProjectName, getPathToBinary, openInEditor } from '../../../utils';
 
-const DEBUG_CALLBACK = debug('rehearsal:migrate');
+import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
+
+const DEBUG_CALLBACK = debug('rehearsal:migrate:convert');
 
 export function convertTask(options: MigrateCommandOptions, logger: Logger): ListrTask {
   return {

--- a/packages/cli/src/commands/migrate/tasks/create-scripts.ts
+++ b/packages/cli/src/commands/migrate/tasks/create-scripts.ts
@@ -1,7 +1,7 @@
 import { ListrTask } from 'listr2';
 
-import { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 import { addPackageJsonScripts } from '../../../utils';
+import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 
 export function createScriptsTask(options: MigrateCommandOptions): ListrTask {
   return {

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -1,7 +1,7 @@
 import { ListrTask } from 'listr2';
 
-import { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 import { addDep } from '../../../utils';
+import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 
 export function depInstallTask(options: MigrateCommandOptions): ListrTask {
   return {

--- a/packages/cli/src/commands/migrate/tasks/index.ts
+++ b/packages/cli/src/commands/migrate/tasks/index.ts
@@ -1,0 +1,6 @@
+export * from './config-lint';
+export * from './convert';
+export * from './dependency-install';
+export * from './initialize';
+export * from './config-ts';
+export * from './create-scripts';

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -6,17 +6,17 @@ import {
 } from '@rehearsal/migration-graph';
 import { debug } from 'debug';
 
-import {
+import { UserConfig } from '../../../user-config';
+import { determineProjectName } from '../../../utils';
+import { State } from '../../../helpers/state';
+import type {
   MigrateCommandContext,
   MigrateCommandOptions,
   PackageSelection,
   MenuMap,
 } from '../../../types';
-import { UserConfig } from '../../../userConfig';
-import { determineProjectName } from '../../../utils';
-import { State } from '../../../helpers/state';
 
-const DEBUG_CALLBACK = debug('rehearsal:migrate');
+const DEBUG_CALLBACK = debug('rehearsal:migrate:initialize');
 const IN_PROGRESS_MARK = '🚧';
 const COMPLETION_MARK = '✅';
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -13,7 +13,6 @@ import execa = require('execa');
 
 import { version } from '../../package.json';
 import { generateReports } from '../helpers/report';
-import { UpgradeCommandContext, UpgradeCommandOptions } from '../types';
 import {
   addDep,
   determineProjectName,
@@ -27,6 +26,7 @@ import {
   parseCommaSeparatedList,
   parseTsVersion,
 } from '../utils';
+import type { UpgradeCommandContext, UpgradeCommandOptions } from '../types';
 
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
 export const upgradeCommand = new Command();

--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -9,7 +9,7 @@ import {
   sarifFormatter,
   ReportFormatter,
 } from '@rehearsal/reporter';
-import { CliCommand, Formats, MigrationSummary } from '../types';
+import type { CliCommand, Formats, MigrationSummary } from '../types';
 
 export function generateReports(
   command: CliCommand,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,7 +1,6 @@
-import { MigrationStrategy } from '@rehearsal/migration-graph';
-
-import { UserConfig } from './userConfig';
-import { State } from './helpers/state';
+import type { MigrationStrategy } from '@rehearsal/migration-graph';
+import type { UserConfig } from './user-config';
+import type { State } from './helpers/state';
 
 export type CliCommand = 'upgrade' | 'migrate';
 export type Formats = 'sarif' | 'json' | 'sonarqube' | 'md';

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -2,8 +2,8 @@ import { resolve } from 'path';
 import execa from 'execa';
 import { readJSONSync } from 'fs-extra';
 
-import { CliCommand, CustomCommandConfig, CustomConfig } from './types';
 import { addDep } from './utils';
+import type { CliCommand, CustomCommandConfig, CustomConfig } from './types';
 
 // Storage and runner for user custom cli config
 export class UserConfig {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,7 +10,7 @@ import { InvalidArgumentError } from 'commander';
 import findup = require('findup-sync');
 import execa = require('execa');
 
-import { ScriptMap } from './types';
+import type { ScriptMap } from './types';
 import type { GitDescribe } from './interfaces';
 
 export const VERSION_PATTERN = /_(\d+\.\d+\.\d+)/;

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -4,8 +4,8 @@ import { dirSync, setGracefulCleanup } from 'tmp';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import { type SimpleGit, type SimpleGitOptions, simpleGit } from 'simple-git';
 
-import { CustomConfig } from '../../src/types';
 import { runBin } from '../test-helpers';
+import type { CustomConfig } from '../../src/types';
 
 setGracefulCleanup();
 

--- a/packages/codefixes/src/2571/index.ts
+++ b/packages/codefixes/src/2571/index.ts
@@ -1,6 +1,7 @@
 import { ChangesFactory, findNodeAtPosition, isVariableOfCatchClause } from '@rehearsal/utils';
-import { CodeFixAction, isIdentifier, isPropertyAccessExpression, Node } from 'typescript';
-import { CodeFix, createCodeFixAction, DiagnosticWithContext } from '../types';
+import { type CodeFixAction, isIdentifier, isPropertyAccessExpression, Node } from 'typescript';
+import { createCodeFixAction } from '../hints-codefix-collection';
+import type { CodeFix, DiagnosticWithContext } from '../types';
 
 export class Fix2571 implements CodeFix {
   getCodeAction(diagnostic: DiagnosticWithContext): CodeFixAction | undefined {

--- a/packages/codefixes/src/2790/index.ts
+++ b/packages/codefixes/src/2790/index.ts
@@ -10,14 +10,11 @@ import {
   getTypeDeclarationFromTypeSymbol,
   getTypeNameFromType,
 } from '@rehearsal/utils';
-import {
-  CodeFixAction,
-  isDeleteExpression,
-  isInterfaceDeclaration,
-  isPropertyAccessExpression,
-} from 'typescript';
-import { CodeFix, createCodeFixAction, DiagnosticWithContext } from '../types';
+import { isDeleteExpression, isInterfaceDeclaration, isPropertyAccessExpression } from 'typescript';
+import { createCodeFixAction } from '../hints-codefix-collection';
+import type { CodeFix, DiagnosticWithContext } from '../types';
 import type {
+  CodeFixAction,
   InterfaceDeclaration,
   PropertyDeclaration,
   PropertySignature,

--- a/packages/codefixes/src/4082/index.ts
+++ b/packages/codefixes/src/4082/index.ts
@@ -6,13 +6,14 @@ import {
   isTypeMatched,
 } from '@rehearsal/utils';
 import {
-  CodeFixAction,
   flattenDiagnosticMessageText,
   isExportAssignment,
   isObjectLiteralExpression,
 } from 'typescript';
-import { CodeFix, createCodeFixAction, DiagnosticWithContext } from '../types';
+import { createCodeFixAction } from '../hints-codefix-collection';
+import type { CodeFix, DiagnosticWithContext } from '../types';
 import type {
+  CodeFixAction,
   ExportAssignment,
   Node,
   ObjectLiteralExpression,

--- a/packages/codefixes/src/codefixes-provider.ts
+++ b/packages/codefixes/src/codefixes-provider.ts
@@ -1,5 +1,5 @@
-import { CodeFixAction } from 'typescript';
-import { CodeFixCollection, DiagnosticWithContext } from './types';
+import type { CodeFixAction } from 'typescript';
+import type { CodeFixCollection, DiagnosticWithContext } from './types';
 
 /**
  * Provides

--- a/packages/codefixes/src/hints-codefix-collection.ts
+++ b/packages/codefixes/src/hints-codefix-collection.ts
@@ -1,11 +1,11 @@
-import { CodeFixAction, DiagnosticWithLocation, flattenDiagnosticMessageText } from 'typescript';
-import { ChangesFactory } from '@rehearsal/utils';
 import {
-  CodeFixCollection,
-  CodeHintList,
-  createCodeFixAction,
-  type DiagnosticWithContext,
-} from './types';
+  type CodeFixAction,
+  type DiagnosticWithLocation,
+  type FileTextChanges,
+  flattenDiagnosticMessageText,
+} from 'typescript';
+import { ChangesFactory } from '@rehearsal/utils';
+import type { CodeFixCollection, CodeHintList, DiagnosticWithContext } from './types';
 
 /**
  * Don't actually fix the issue but adds a @ts-expect-error comments instead
@@ -85,4 +85,16 @@ export class HintCodeFixCollection implements CodeFixCollection {
 
     return hint;
   }
+}
+
+export function createCodeFixAction(
+  fixName: string,
+  changes: FileTextChanges[],
+  description: string
+): CodeFixAction {
+  return {
+    fixName,
+    description,
+    changes,
+  };
 }

--- a/packages/codefixes/src/hints-provider.ts
+++ b/packages/codefixes/src/hints-provider.ts
@@ -1,6 +1,6 @@
 import { type DiagnosticWithLocation, flattenDiagnosticMessageText } from 'typescript';
 
-import { CodeHintList, DiagnosticWithContext } from './types';
+import type { CodeHintList, DiagnosticWithContext } from './types';
 
 /**
  * Provides access to useful hints for Diagnostics

--- a/packages/codefixes/src/types.ts
+++ b/packages/codefixes/src/types.ts
@@ -1,7 +1,6 @@
-import {
+import type {
   CodeFixAction,
   DiagnosticWithLocation,
-  FileTextChanges,
   LanguageService,
   Node,
   Program,
@@ -36,16 +35,4 @@ export interface CodeFixCollection {
 
 export interface CodeFix {
   getCodeAction: (diagnostic: DiagnosticWithContext) => CodeFixAction | undefined;
-}
-
-export function createCodeFixAction(
-  fixName: string,
-  changes: FileTextChanges[],
-  description: string
-): CodeFixAction {
-  return {
-    fixName,
-    description,
-    changes,
-  };
 }

--- a/packages/codefixes/src/typescript-codefix-collection.ts
+++ b/packages/codefixes/src/typescript-codefix-collection.ts
@@ -6,8 +6,8 @@ import {
   type UserPreferences,
   type FormatCodeSettings,
 } from 'typescript';
-import { type Options as PrettierOptions } from 'prettier';
-import { CodeFixCollection, type DiagnosticWithContext } from './types';
+import type { Options as PrettierOptions } from 'prettier';
+import type { CodeFixCollection, DiagnosticWithContext } from './types';
 
 /**
  * Provides code fixes based on the Typescript's codefix collection.

--- a/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
@@ -8,12 +8,12 @@ import walkSync from 'walk-sync';
 import { EmberAppPackage } from '../../src/entities/ember-app-package';
 // import the container so it can be called with the correct root
 import { getInternalAddonPackages } from '../../src/index';
-import { type EmberPackageContainer } from '../../src/types/package-container';
 import {
   registerInternalAddonTestFixtures,
   resetInternalAddonTestFixtures,
 } from '../../src/utils/environment';
 import { FIXTURE_NAMES, FIXTURES } from '../fixtures/package-fixtures';
+import type { EmberPackageContainer } from '../../src/types/package-container';
 
 setGracefulCleanup();
 

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -11,8 +11,8 @@ import {
   IResolveOptions,
 } from 'dependency-cruiser';
 import { Graph, GraphNode } from '../graph';
-import { ModuleNode } from '../types';
 import { Package } from './package';
+import type { ModuleNode } from '../types';
 
 const DEBUG_CALLBACK = debug('rehearsal:migration-graph-shared:package-graph');
 

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import path, { resolve } from 'path';
+import { resolve, join } from 'path';
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 import sortPackageJson from 'sort-package-json';
 import { sync as fastGlobSync } from 'fast-glob';
@@ -8,7 +8,7 @@ import { removeNestedPropertyValue, setNestedPropertyValue } from '../utils/pojo
 import { getWorkspaceGlobs } from '../utils/workspace';
 import { PackageGraph } from './package-graph';
 
-import { IPackage } from './IPackage';
+import type { IPackage } from './IPackage';
 import type { Graph } from '../graph';
 import type { ModuleNode } from '../types';
 
@@ -242,7 +242,7 @@ export class Package implements IPackage {
    */
   writePackageJsonToDisk(): void {
     const sorted: Record<any, any> = sortPackageJson(this.packageJson);
-    const pathToPackageJson = path.join(this.path, 'package.json');
+    const pathToPackageJson = join(this.path, 'package.json');
     writeJsonSync(pathToPackageJson, sorted, { spaces: 2 });
   }
 

--- a/packages/migration-graph-shared/test/entities/package-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/package-graph.test.ts
@@ -6,9 +6,9 @@ import { mkdirSync } from 'fs-extra';
 import rimraf from 'rimraf';
 import { dirSync, setGracefulCleanup } from 'tmp';
 import { Package } from '../../src/entities/package';
-import { ModuleNode, PackageNode } from '../../src/types';
 import { Graph, GraphNode } from '../../src/graph';
 import { PackageGraph } from '../../src/entities/package-graph';
+import type { ModuleNode, PackageNode } from '../../src/types';
 
 setGracefulCleanup();
 

--- a/packages/migration-graph-shared/test/graph/graph.test.ts
+++ b/packages/migration-graph-shared/test/graph/graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { UniqueNode } from '../../src/types';
 import { Graph } from '../../src/graph';
+import type { UniqueNode } from '../../src/types';
 
 export function createNode(key = 'some-name'): UniqueNode {
   return {

--- a/packages/reporter/src/formatters/json-formatter.ts
+++ b/packages/reporter/src/formatters/json-formatter.ts
@@ -1,4 +1,4 @@
-import { Report } from '../types';
+import type { Report } from '../types';
 
 export function jsonFormatter(report: Report): string {
   return JSON.stringify(report, null, 2);

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -1,4 +1,4 @@
-import { Report } from '../types';
+import type { Report } from '../types';
 
 export function mdFormatter(report: Report): string {
   const fileNames = [...new Set(report.items.map((item) => item.analysisTarget))];

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -1,6 +1,5 @@
-import { Artifact, Location, Log, ReportingDescriptor, Result, Run } from 'sarif';
-
-import { Report, ReportItem } from '../types';
+import type { Artifact, Location, Log, ReportingDescriptor, Result, Run } from 'sarif';
+import type { Report, ReportItem } from '../types';
 
 export class SarifFormatter {
   private report: Report;

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { DiagnosticCategory, flattenDiagnosticMessageText, SyntaxKind } from 'typescript';
-import { type Report, type ReportFormatter, type ReportItem, type Location } from './types';
 import { normalizeFilePath } from './normalize-paths';
+import type { Report, ReportFormatter, ReportItem, Location } from './types';
 import type { DiagnosticWithLocation, Node } from 'typescript';
 import type { Logger } from 'winston';
 


### PR DESCRIPTION
This chore PR:
- modifies imports which should only be importing a type module
- minor copy changes to the migrate help text
- convert migrate cli tasks filename from camel to kabob