### PR TITLE
fix: file extension name replacement bug

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -35,7 +35,7 @@ export function convertTask(options: MigrateCommandOptions, logger: Logger): Lis
           // and ask user for actions: Accept/Edit/Discard
           for (const f of ctx.sourceFilesWithAbsolutePath) {
             const jsFilePath = f;
-            const tsFilePath = f.replace('js', 'ts');
+            const tsFilePath = f.replace(/js$/g, 'ts');
             let completed = false;
 
             const input = {


### PR DESCRIPTION
For #570 

There is a bug during replace `js` file extension name with `ts`. When a file path contains `js` in the middle of the string, the code would replace that `js` instead of the actual file extension. This PR uses regex to detect and replace the actual file extension.