### PR TITLE
feat: include/exclude patterns; add package scope

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -2,7 +2,7 @@ import { ListrTask } from 'listr2';
 import {
   discoverEmberPackages,
   getMigrationStrategy,
-  SourceFile,
+  type SourceFile,
 } from '@rehearsal/migration-graph';
 import { debug } from 'debug';
 
@@ -32,7 +32,7 @@ export function initTask(options: MigrateCommandOptions): ListrTask {
       ctx.userConfig = userConfig;
 
       const projectName = determineProjectName(options.basePath);
-      const packages = discoverEmberPackages(options.basePath);
+      const packages = discoverEmberPackages(options.basePath); // TODO we should ask the migration-strategy for this data.
       DEBUG_CALLBACK('projectName', projectName);
 
       if (options.interactive) {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -174,7 +174,7 @@ describe('migrate - JS to TS conversion', async () => {
     basePath = prepareTmpDir('basic');
   });
 
-  test('able to migrate from default index.js', async () => {
+  test('able to migrate default most **/*.js files ', async () => {
     const result = await runBin('migrate', [], {
       cwd: basePath,
     });
@@ -182,13 +182,15 @@ describe('migrate - JS to TS conversion', async () => {
     // Test logger messages from package/migrate
     expect(result.stdout).toContain('info');
     expect(result.stdout).toContain('Moving: /foo.js to /foo.ts');
+    expect(result.stdout).toContain('Moving: /depends-on-foo.js to /depends-on-foo.ts');
     expect(result.stdout).toContain('Moving: /index.js to /index.ts');
     expect(result.stdout).toContain('Processing:');
 
     // Test summary message
-    expect(result.stdout).toContain(`2 JS files has been converted to TS`);
+    expect(result.stdout).toContain(`3 JS files has been converted to TS`);
 
     expect(readdirSync(basePath)).toContain('index.ts');
+    expect(readdirSync(basePath)).toContain('depends-on-foo.ts');
     expect(readdirSync(basePath)).toContain('foo.ts');
 
     expect(readdirSync(basePath)).not.toContain('index.js');
@@ -196,6 +198,7 @@ describe('migrate - JS to TS conversion', async () => {
 
     const config = readJSONSync(resolve(basePath, 'tsconfig.json'));
     expect(config.include).toContain('index.ts');
+    expect(config.include).toContain('depends-on-foo.ts');
     expect(config.include).toContain('foo.ts');
   });
 

--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -18,17 +18,7 @@ export class EmberAddonPackage extends EmberAppPackage {
   #addonName: string | undefined;
 
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    super(pathToPackage, options);
-    this.isAddon = true;
-  }
-
-  get isEngine(): boolean {
-    return isEngine(readPackageJson(this.path));
-  }
-
-  get excludePatterns(): Array<string> {
-    // TODO Determine ember-config from package.json entry
-    return [
+    const excludePatterns = [
       'dist',
       'config',
       'ember-config',
@@ -38,11 +28,15 @@ export class EmberAddonPackage extends EmberAppPackage {
       'public',
       './package',
     ];
+
+    const includePatterns = ['index.js', 'addon/', 'app/'];
+
+    super(pathToPackage, { excludePatterns, includePatterns, ...options });
+    this.isAddon = true;
   }
 
-  get includePatterns(): Array<string> {
-    // TODO Determine ember-config from package.json entry
-    return ['index.js', 'addon/', 'app/'];
+  get isEngine(): boolean {
+    return isEngine(readPackageJson(this.path));
   }
 
   /**

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -12,24 +12,26 @@ export type EmberPackageOptions = PackageOptions;
 
 export class EmberAppPackage extends Package implements IPackage {
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    super(pathToPackage, options);
-  }
-
-  get excludePatterns(): Array<string> {
-    // TODO Determine ember-config directory from package.json entry
-    const files = [
+    const excludePatterns = [
+      // files
       '.ember-cli.js',
       'ember-cli-build.js',
       'ember-config.js',
       'index.js',
       'testem.js',
-    ];
-    const directories = ['dist', 'config', 'ember-config', 'tests', '@ember/*', 'public'];
-    return [...directories, ...files];
-  }
 
-  get includePatterns(): Array<string> {
-    return ['app'];
+      // Directories
+      'dist',
+      'config',
+      'ember-config',
+      'tests',
+      '@ember/*',
+      'public',
+    ];
+
+    const includePatterns = ['app'];
+
+    super(pathToPackage, { excludePatterns, includePatterns, ...options });
   }
 
   get addonPaths(): Array<string> {

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -75,7 +75,10 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
   }
 }
 
-export type EmberAppProjectGraphOptions = ProjectGraphOptions;
+export type EmberAppProjectGraphOptions = {
+  // parent: GraphNode<unknown>;
+  // projectGraph: ProjectGraph;
+} & ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
   protected discoveredPackages: Record<string, Package | EmberAddonPackage | EmberAppPackage>;
@@ -103,6 +106,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
         }
       }
     }
+
     const node = super.addPackageToGraph(p, crawl);
 
     DEBUG_CALLBACK('debugAnalysis', debugAnalysis(node));

--- a/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
@@ -1,7 +1,7 @@
-import { Package } from '@rehearsal/migration-graph-shared';
-import { EmberAddonPackage } from '../entities/ember-addon-package';
-import { EmberAppPackage } from '../entities/ember-app-package';
 import { getInternalPackages } from '../mappings-container';
+import type { Package } from '@rehearsal/migration-graph-shared';
+import type { EmberAddonPackage } from '../entities/ember-addon-package';
+import type { EmberAppPackage } from '..//entities/ember-app-package';
 
 export function discoverEmberPackages(
   rootDir: string

--- a/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
@@ -243,7 +243,7 @@ describe('EmberAppPackageGraph', () => {
     expect(appNode.adjacent.has(addonNode)).toBe(true);
   });
 
-  test.only('should stub a GraphNode and backfill for an app and addons ', async () => {
+  test('should stub a GraphNode and backfill for an app and addons ', async () => {
     // app uses a service `date` from `some-addon`
     // └── first-addon exposes `date` and consumes a service `time` from `another-addon`
     //     └── second-addon exposes a service `time`.

--- a/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
@@ -171,7 +171,7 @@ describe('EmberAppPackageGraph', () => {
     const m = new EmberAppProjectGraph(project.baseDir);
     const emberPackage = new EmberAppPackage(project.baseDir);
     const source = m.addPackageToGraph(emberPackage);
-    const options: EmberAppPackageGraphOptions = { parent: source, project: m };
+    const options: EmberAppPackageGraphOptions = { parentNode: source, projectGraph: m };
     emberPackage.getModuleGraph(options);
 
     const dest = m.graph.getNode('some-external');
@@ -226,7 +226,10 @@ describe('EmberAppPackageGraph', () => {
     const emberPackage = new EmberAppPackage(project.baseDir);
     const appNode = projectGraph.addPackageToGraph(emberPackage, false);
 
-    const options: EmberAppPackageGraphOptions = { parent: appNode, project: projectGraph };
+    const options: EmberAppPackageGraphOptions = {
+      parentNode: appNode,
+      projectGraph: projectGraph,
+    };
     emberPackage.getModuleGraph(options);
 
     const node: GraphNode<PackageNode> = projectGraph.graph.getNode('some-addon');
@@ -240,7 +243,7 @@ describe('EmberAppPackageGraph', () => {
     expect(appNode.adjacent.has(addonNode)).toBe(true);
   });
 
-  test('should stub a GraphNode and backfill for an app and addons ', async () => {
+  test.only('should stub a GraphNode and backfill for an app and addons ', async () => {
     // app uses a service `date` from `some-addon`
     // └── first-addon exposes `date` and consumes a service `time` from `another-addon`
     //     └── second-addon exposes a service `time`.
@@ -314,33 +317,36 @@ describe('EmberAppPackageGraph', () => {
 
     await setupProject(project);
 
-    const m = new EmberAppProjectGraph(project.baseDir);
+    const projectGraph = new EmberAppProjectGraph(project.baseDir);
 
     const emberAppPackage = new EmberAppPackage(project.baseDir);
-    const appNode = m.addPackageToGraph(emberAppPackage, false);
+    const appNode = projectGraph.addPackageToGraph(emberAppPackage, false);
 
-    const options: EmberAppPackageGraphOptions = { parent: appNode, project: m };
+    const options: EmberAppPackageGraphOptions = {
+      parentNode: appNode,
+      projectGraph: projectGraph,
+    };
     emberAppPackage.getModuleGraph(options);
 
     // Validate that there is a syntehtic node to firstAddon and that there
     // is an edge between the app and the addon
 
-    let firstAddonNode = m.graph.getNode(firstAddonName);
+    let firstAddonNode = projectGraph.graph.getNode(firstAddonName);
     expect(firstAddonNode?.content.synthetic).toBe(true);
 
     const firstAddonPackage = new EmberAddonPackage(join(project.baseDir, `lib/${firstAddonName}`));
 
     // Add firstAddon
-    firstAddonNode = m.addPackageToGraph(firstAddonPackage);
+    firstAddonNode = projectGraph.addPackageToGraph(firstAddonPackage);
     expect(firstAddonNode.content.synthetic).toBeFalsy();
 
     // Force populate the addon's graph by calling IPackage.getModuleGraph, this will
     // force discovery of the edge between firstAddon and secondAddon.
-    const addonOptions = { parent: firstAddonNode, project: m };
+    const addonOptions = { parentNode: firstAddonNode, projectGraph: projectGraph };
     firstAddonPackage.getModuleGraph(addonOptions);
 
     // Get the synthetic secondAddon, validate it's been added and it stubbed out.
-    let secondAddonNode = m.graph.getNode(secondAddonName);
+    let secondAddonNode = projectGraph.graph.getNode(secondAddonName);
     expect(secondAddonNode?.content.synthetic).toBe(true);
     expect(appNode.adjacent.has(firstAddonNode), 'app should depend on some-addon').toBe(true);
     expect(
@@ -352,7 +358,7 @@ describe('EmberAppPackageGraph', () => {
       join(project.baseDir, `lib/${secondAddonName}`)
     );
 
-    secondAddonNode = m.addPackageToGraph(secondAddonPackage);
+    secondAddonNode = projectGraph.addPackageToGraph(secondAddonPackage);
     expect(secondAddonNode.content.synthetic).toBeFalsy();
 
     expect(
@@ -360,11 +366,10 @@ describe('EmberAppPackageGraph', () => {
       'some-addon should depend on another-addon'
     ).toBe(true);
 
-    expect(flatten(m.graph.topSort()), 'package graph should have another-addon first').toEqual([
-      'second-addon',
-      'first-addon',
-      'app-template',
-    ]);
+    expect(
+      flatten(projectGraph.graph.topSort()),
+      'package graph should have another-addon first'
+    ).toEqual(['second-addon', 'first-addon', 'app-template']);
   });
 
   test('should stub a GraphNode and backfill for only addons', async () => {
@@ -429,12 +434,12 @@ describe('EmberAppPackageGraph', () => {
 
     await setupProject(project);
 
-    const m = new EmberAppProjectGraph(project.baseDir, { eager: false });
+    const projectGraph = new EmberAppProjectGraph(project.baseDir, { eager: false });
 
     const firstAddonPackage = new EmberAddonPackage(join(project.baseDir, `lib/${firstAddonName}`));
 
-    const firstAddonNode = m.addPackageToGraph(firstAddonPackage);
-    const addonOptions = { parent: firstAddonNode, project: m };
+    const firstAddonNode = projectGraph.addPackageToGraph(firstAddonPackage);
+    const addonOptions = { parentNode: firstAddonNode, projectGraph: projectGraph };
     firstAddonPackage.getModuleGraph(addonOptions);
 
     expect(firstAddonNode.content.synthetic).toBeFalsy();
@@ -442,14 +447,14 @@ describe('EmberAppPackageGraph', () => {
       firstAddonNode.content.pkg?.getModuleGraph().getNode('addon/services/date.js')?.content.parsed
     ).toBe(true);
 
-    let secondAddonNode = m.graph.getNode(secondAddonName);
+    let secondAddonNode = projectGraph.graph.getNode(secondAddonName);
     expect(secondAddonNode?.content.synthetic).toBe(true);
 
     const secondAddonPackage = new EmberAddonPackage(
       join(project.baseDir, `lib/${secondAddonName}`)
     );
 
-    secondAddonNode = m.addPackageToGraph(secondAddonPackage);
+    secondAddonNode = projectGraph.addPackageToGraph(secondAddonPackage);
     expect(secondAddonNode.content.synthetic).toBeFalsy();
 
     expect(
@@ -457,10 +462,10 @@ describe('EmberAppPackageGraph', () => {
       'some-addon should depend on another-addon'
     ).toBe(true);
 
-    expect(flatten(m.graph.topSort()), 'package graph should have another-addon first').toEqual([
-      'second-addon',
-      'first-addon',
-    ]);
+    expect(
+      flatten(projectGraph.graph.topSort()),
+      'package graph should have another-addon first'
+    ).toEqual(['second-addon', 'first-addon']);
   });
 
   test('should stub a GraphNode and backfill when moduleName differs from packageName', async () => {
@@ -544,7 +549,10 @@ describe('EmberAppPackageGraph', () => {
     const emberAppPackage = new EmberAppPackage(project.baseDir);
     const appNode = projectGraph.addPackageToGraph(emberAppPackage, false);
 
-    const options: EmberAppPackageGraphOptions = { parent: appNode, project: projectGraph };
+    const options: EmberAppPackageGraphOptions = {
+      parentNode: appNode,
+      projectGraph: projectGraph,
+    };
     emberAppPackage.getModuleGraph(options);
 
     // Validate that there is a syntehtic node to firstAddon and that there

--- a/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
@@ -38,7 +38,7 @@ describe('EmberAppProjectGraph', () => {
   test('options.eager=true should create a synethic node and then backfill when packageName differs from addonName', async () => {
     // If a parent app is crawled first eagerly, it may create some synthetic nodes.
 
-    // Create an app where the app users a service with ambigous coordinates
+    // Create an app where the app uses a service with ambigous coordinates
 
     // package.name is @some-org/some-addon
 

--- a/packages/migration-graph-shared/src/entities/IPackage.ts
+++ b/packages/migration-graph-shared/src/entities/IPackage.ts
@@ -2,5 +2,5 @@ import type { Graph } from '../graph';
 import type { ModuleNode } from '../types';
 
 export interface IPackage {
-  getModuleGraph(): Graph<ModuleNode>;
+  getModuleGraph(options: unknown): Graph<ModuleNode>;
 }

--- a/packages/migration-graph-shared/src/entities/root-package.ts
+++ b/packages/migration-graph-shared/src/entities/root-package.ts
@@ -1,0 +1,24 @@
+import { relative } from 'path';
+import { getWorkspaceGlobs } from '../utils/workspace';
+import { Package, PackageOptions } from './package';
+
+export class RootPackage extends Package {
+  #globs: Array<string>;
+
+  constructor(rootDir: string, options?: PackageOptions) {
+    super(rootDir, options);
+
+    // Determine if this package.json has a workspace entry
+    const globs = getWorkspaceGlobs(this.path);
+
+    // Add the workspace globs to the exclude pattern for the root package
+    // so it doesn't attempt to add them to the root package's graph.
+    globs.forEach((glob) => this.addExcludePattern(relative(this.path, glob)));
+
+    this.#globs = globs;
+  }
+
+  get globs(): Array<string> {
+    return this.#globs;
+  }
+}

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -48,6 +48,36 @@ describe('Unit | Entities | Package', function () {
     });
   });
 
+  describe('includ/exclude patterns', () => {
+    test('defaults', () => {
+      const p = new Package(pathToPackage);
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests']));
+      expect(p.includePatterns).toStrictEqual(new Set(['**/*.js']));
+    });
+    test('options.excludePatterns ', () => {
+      const p = new Package(pathToPackage, { excludePatterns: ['dist', 'test-packages'] });
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test-packages']));
+    });
+
+    test('options.includePatterns ', () => {
+      const p = new Package(pathToPackage, { includePatterns: ['src/**/*.js'] });
+      expect(p.includePatterns).toStrictEqual(new Set(['src/**/*.js']));
+    });
+
+    test('addExcludePattern', () => {
+      const p = new Package(pathToPackage);
+      p.addExcludePattern('test-packages');
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests', 'test-packages']));
+    });
+
+    test('addIncludePattern', () => {
+      const p = new Package(pathToPackage);
+      p.addIncludePattern('foo.js');
+      expect(p.includePatterns.has('foo.js')).toBeTruthy();
+      expect(p.includePatterns).toStrictEqual(new Set(['**/*.js', 'foo.js']));
+    });
+  });
+
   describe('mutation', function () {
     test('set packageName', () => {
       const p = new Package(pathToPackage);

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -48,6 +48,16 @@ describe('project-graph', () => {
 
     expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
   });
+  test('should ignore `.<name>.js files (eg. .babelrc.js or .eslint.config.js)', () => {
+    const baseDir = getLibrary('simple');
+
+    const projectGraph = new ProjectGraph(baseDir);
+    const somePackage = new Package(baseDir);
+    projectGraph.addPackageToGraph(somePackage);
+    projectGraph.discover();
+
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
+  });
   test('options.eager', () => {
     const baseDir = getLibrary('simple');
 

--- a/packages/migration-graph/src/migration-graph.ts
+++ b/packages/migration-graph/src/migration-graph.ts
@@ -1,4 +1,4 @@
-import { Package, ProjectGraph, readPackageJson } from '@rehearsal/migration-graph-shared';
+import { ProjectGraph, readPackageJson } from '@rehearsal/migration-graph-shared';
 import {
   EmberAddonProjectGraph,
   EmberAppProjectGraph,
@@ -16,24 +16,6 @@ export type MigrationGraphOptions = {
   entrypoint?: string;
   filterByPackageName?: Array<string>;
 };
-
-function buildMigrationGraphForLibrary(
-  projectGraph: ProjectGraph,
-  options?: MigrationGraphOptions
-): ProjectGraph {
-  const rootDir = projectGraph.rootDir;
-  const p = new Package(rootDir);
-
-  projectGraph.addPackageToGraph(p);
-
-  p.getModuleGraph({
-    entrypoint: options?.entrypoint,
-  });
-
-  projectGraph.discover();
-
-  return projectGraph;
-}
 
 function buildMigrationGraphForEmber(
   projectGraph: EmberAppProjectGraph | EmberAddonProjectGraph,
@@ -108,10 +90,8 @@ export function buildMigrationGraph(
     );
   } else {
     sourceType = SourceType.Library;
-    projectGraph = buildMigrationGraphForLibrary(
-      new ProjectGraph(rootDir, { sourceType }),
-      options
-    );
+    projectGraph = new ProjectGraph(rootDir, { sourceType, ...options });
+    projectGraph.discover();
   }
 
   return { projectGraph, sourceType };

--- a/packages/migration-graph/test/migration-strategy.test.ts
+++ b/packages/migration-graph/test/migration-strategy.test.ts
@@ -18,6 +18,7 @@ describe('migration-strategy', () => {
       const strategy = getMigrationStrategy(rootDir, { entrypoint: 'depends-on-foo.js' });
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
+      // Should not include index.js as it is not in the entrypoint's import graph.
       expect(relativePaths).toStrictEqual(['foo.js', 'depends-on-foo.js']);
       expect(strategy.sourceType).toBe(SourceType.Library);
     });
@@ -28,10 +29,12 @@ describe('migration-strategy', () => {
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
       expect(relativePaths).toStrictEqual([
+        'packages/blorp/build.js',
         'packages/blorp/lib/impl.js',
         'packages/blorp/index.js',
         'packages/foo/lib/a.js',
         'packages/foo/index.js',
+        'some-util.js',
       ]);
       expect(strategy.sourceType).toBe(SourceType.Library);
     });

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -16,6 +16,7 @@ type LibraryVariants =
   | 'simple'
   | 'library-with-css-imports'
   | 'library-with-entrypoint'
+  | 'library-with-loose-files'
   | 'library-with-workspaces';
 
 export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
@@ -51,6 +52,41 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             // a.js
             console.log('foo');        
            `,
+        },
+      };
+      break;
+    case 'library-with-loose-files':
+      files = {
+        'WidgetManager.js': `
+          import './Widget';
+          import './Events'
+        `,
+        'package.json': `
+          {
+            "name": "my-package-with-loose-files",
+            "main": "index.js",
+            "files": [
+              "*.js",
+              "*.lock",
+              "utils/**/*",
+              "dist/**/*"
+            ],
+            "dependencies": {
+            },
+            "devDependencies": {
+              "typescript": "^4.8.3"
+            }
+
+          }
+        `,
+        'Events.js': '',
+        'State.js': `import './utils/Defaults';`,
+        'Widget.js': `import './State';`,
+        utils: {
+          'Defaults.js': ``,
+        },
+        dist: {
+          'ignore-this.js': '',
         },
       };
       break;
@@ -133,6 +169,9 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             }`,
             'index.js': `
               import './lib/impl';
+            `,
+            'build.js': `
+              import '../../some-util.js';
             `,
             lib: {
               'impl.js': `

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -34,6 +34,8 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
           console.log(path.join('foo', 'bar', 'baz'));
           console.log(parser, chalk);
         `,
+        '.babelrc.js': '',
+        '.eslint.config.js': '',
         'package.json': `
           {
             "name": "my-package",

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -141,6 +141,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             },
           },
         },
+        'some-util.js': '// Shared file',
         'package.json': `
           {
             "name": "some-library-with-workspace",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
       eslint: 8.22.0
       eslint-config-prettier: 8.5.0_eslint@8.22.0
       eslint-plugin-filenames: 1.3.2_eslint@8.22.0
-      eslint-plugin-import: 2.26.0_eslint@8.22.0
+      eslint-plugin-import: 2.26.0_ue6oou5dblwcfz3tzhyts3zecq
       eslint-plugin-prettier: 4.2.1_i2cojdczqdiurzgttlwdgf764e
       fixturify: 2.1.1
       fixturify-project: 5.1.0
@@ -1910,8 +1910,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2000,12 +2000,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -2453,19 +2463,37 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_eslint@8.22.0:
+  /eslint-module-utils/2.7.4_fq3oeln7kc2mor2upj24f7jyyi:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
     peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
       eslint:
         optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 3.2.7
       eslint: 8.22.0
+      eslint-import-resolver-node: 0.3.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-filenames/1.3.2_eslint@8.22.0:
@@ -2480,19 +2508,24 @@ packages:
       lodash.upperfirst: 4.3.1
     dev: true
 
-  /eslint-plugin-import/2.26.0_eslint@8.22.0:
+  /eslint-plugin-import/2.26.0_ue6oou5dblwcfz3tzhyts3zecq:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_eslint@8.22.0
+      eslint-module-utils: 2.7.4_fq3oeln7kc2mor2upj24f7jyyi
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -2500,6 +2533,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-prettier/4.2.1_i2cojdczqdiurzgttlwdgf764e:


### PR DESCRIPTION
* Adding package scope/boundary fixes #439.
  * If a file is out of the package directory is is omitted from the module graph.
* Issue #567 is a problem with the include/exclude patterns for a package. To resolve this we need to always include the package.json files properties, and include all `**/*.js` files for a plain JS library.

