### PR TITLE
feat: ignore more known files; add logging for out of package files

### DIFF
--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -40,7 +40,7 @@ export class PackageGraph {
 
   constructor(p: Package, options: PackageGraphOptions = {}) {
     this.package = p;
-    this.baseDir = p.path;
+    this.baseDir = p.packagePath;
     this.options = options || {};
     this.#graph = new Graph<ModuleNode>();
   }
@@ -96,8 +96,10 @@ export class PackageGraph {
       const sourcePath = resolveRelative(baseDir, m.source);
 
       if (this.isFileExternalToPackage(sourcePath)) {
-        DEBUG_CALLBACK(`${sourcePath} is out of package, not adding to module graph.`);
-        // Should resolve path completely relativeto the project and find which package it belongs to.
+        console.warn(
+          `The import path "${sourcePath}" is external to package "${this.package.packageName}" (${baseDir}), ommitting form package-graph. `
+        );
+        // Should resolve path completely relative to the project and find which package it belongs to.
         // Ask project which package does this belong maybe create an edge?
         return;
       }

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -70,7 +70,17 @@ export class Package implements IPackage {
   constructor(
     pathToPackage: string,
     {
-      excludePatterns = ['dist', 'test', 'tests'],
+      excludePatterns = [
+        'dist',
+        'test',
+        'tests',
+        'babel.config.*', // Babel configs
+        'prettier.config.*', // Prettier configs
+        'karma.config.*',
+        'webpack.config.js',
+        'package-lock.json',
+        'yarn.lock',
+      ],
       includePatterns = ['**/*.js'],
       name = '',
       packageContainer,

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -51,7 +51,19 @@ describe('Unit | Entities | Package', function () {
   describe('includ/exclude patterns', () => {
     test('defaults', () => {
       const p = new Package(pathToPackage);
-      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests']));
+      expect(p.excludePatterns).toStrictEqual(
+        new Set([
+          'dist',
+          'test',
+          'tests',
+          'babel.config.*',
+          'prettier.config.*',
+          'karma.config.*',
+          'webpack.config.js',
+          'package-lock.json',
+          'yarn.lock',
+        ])
+      );
       expect(p.includePatterns).toStrictEqual(new Set(['**/*.js']));
     });
     test('options.excludePatterns ', () => {
@@ -67,7 +79,20 @@ describe('Unit | Entities | Package', function () {
     test('addExcludePattern', () => {
       const p = new Package(pathToPackage);
       p.addExcludePattern('test-packages');
-      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests', 'test-packages']));
+      expect(p.excludePatterns).toStrictEqual(
+        new Set([
+          'dist',
+          'test',
+          'tests',
+          'babel.config.*',
+          'prettier.config.*',
+          'karma.config.*',
+          'webpack.config.js',
+          'package-lock.json',
+          'yarn.lock',
+          'test-packages',
+        ])
+      );
     });
 
     test('addIncludePattern', () => {

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -58,6 +58,32 @@ describe('project-graph', () => {
 
     expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
   });
+
+  test('should ignore .lock files', () => {
+    const baseDir = getLibrary('library-with-ignored-files');
+
+    // Add dummy lock files package-lock.json, npm-shrinkwrap.json package-lock.json, yarn.lock, pnpm-lock.yaml
+
+    const projectGraph = new ProjectGraph(baseDir);
+    projectGraph.discover();
+
+    const somePackage = projectGraph.graph.topSort()[0].content.pkg;
+
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
+  });
+
+  test('library should ignore files', () => {
+    const baseDir = getLibrary('library-with-ignored-files');
+    const projectGraph = new ProjectGraph(baseDir);
+    projectGraph.discover();
+
+    const somePackage = projectGraph.graph.topSort()[0].content.pkg;
+
+    const files = flatten(somePackage.getModuleGraph().topSort());
+
+    expect(files).toStrictEqual(['lib/a.js', 'index.js']);
+  });
+
   test('options.eager', () => {
     const baseDir = getLibrary('simple');
 

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -14,11 +14,41 @@ type FixtureDir = string;
 
 type LibraryVariants =
   | 'simple'
+  | 'library-with-ignored-files'
   | 'library-with-css-imports'
   | 'library-with-entrypoint'
   | 'library-with-loose-files'
   | 'library-with-workspaces';
 
+const FILES_TO_IGNORE = [
+  '.babelrc.js',
+  '.babelrc.json',
+  '.babelrc.cjs',
+  '.babelrc.mjs',
+  'babel.config.js',
+  'babel.config.json',
+  'babel.config.cjs',
+  'babel.config.mjs',
+  '.eslint.config.js',
+  'package-lock.json',
+  'yarn.lock',
+  'npm-shrinkwrap.json',
+  'webpack.config.js',
+  'prettier.config.js',
+  'prettier.config.cjs',
+  'karma.config.js',
+  'yarn.lock',
+];
+
+function getIgnoredFilesFixtureDirectory(): Record<string, string> {
+  const fixtureDir: Record<string, string> = {};
+
+  FILES_TO_IGNORE.forEach((filename) => {
+    fixtureDir[filename] = '';
+  });
+
+  return fixtureDir;
+}
 export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
   let files: fixturify.DirJSON;
 
@@ -34,8 +64,6 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
           console.log(path.join('foo', 'bar', 'baz'));
           console.log(parser, chalk);
         `,
-        '.babelrc.js': '',
-        '.eslint.config.js': '',
         'package.json': `
           {
             "name": "my-package",
@@ -52,8 +80,35 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
         lib: {
           'a.js': `
             // a.js
-            console.log('foo');        
+            console.log('foo');
            `,
+        },
+      };
+      break;
+    case 'library-with-ignored-files':
+      files = {
+        'index.js': `
+          import './lib/a';
+          console.log(path.join('foo', 'bar', 'baz'));
+          console.log(parser, chalk);
+        `,
+        ...getIgnoredFilesFixtureDirectory,
+        config: {
+          ...getIgnoredFilesFixtureDirectory,
+        },
+        'package.json': `
+          {
+            "name": "my-package",
+            "main": "index.js",
+            "dependencies": {
+            },
+            "devDependencies": {
+              "typescript": "^4.8.3"
+            }
+          }
+        `,
+        lib: {
+          'a.js': '',
         },
       };
       break;
@@ -111,7 +166,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
         lib: {
           'a.js': `
             // a.js
-            console.log('foo');        
+            console.log('foo');
            `,
         },
         styles: {
@@ -137,7 +192,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             lib: {
               'a.js': `
               // a.js
-              console.log('foo');        
+              console.log('foo');
              `,
             },
           },


### PR DESCRIPTION
- Improve error message for out of package files.
- Ignore lock files e.g. babel,webpack,prettier,karma,eslint configs