### PR TITLE
fix: control-c during git mv

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -93,8 +93,9 @@ export function getReportSummary(report: Report, migratedFileCount: number): str
     }
   });
   const totalErrorCount = report.items.length;
-  return `Migration Complete. ${migratedFileCount} JS ${
-    migratedFileCount === 1 ? 'file' : 'files'
-  } has been converted to TS. There are ${totalErrorCount} errors caught by rehearsal.\n
-  ${hintAddedCount} have been updated with @ts-expect-error @rehearsal TODO which need further manual check.`;
+
+  return `Migration Complete\n\n
+  ${migratedFileCount} JS ${migratedFileCount === 1 ? 'file' : 'files'} converted to TS\n
+  ${totalErrorCount} errors caught by rehearsal\n
+  ${hintAddedCount} @ts-expect-error @rehearsal TODO which need further manual check`;
 }

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -158,7 +158,7 @@ describe('migrate - JS to TS conversion', async () => {
     });
 
     // Test summary message
-    expect(result.stdout).toContain(`2 JS files has been converted to TS`);
+    expect(result.stdout).toContain(`2 JS files converted to TS`);
 
     expect(readdirSync(basePath)).toContain('index.ts');
     expect(readdirSync(basePath)).toContain('foo.ts');
@@ -176,7 +176,7 @@ describe('migrate - JS to TS conversion', async () => {
       cwd: basePath,
     });
 
-    expect(result.stdout).toContain(`2 JS files has been converted to TS`);
+    expect(result.stdout).toContain(`2 JS files converted to TS`);
     expect(readdirSync(basePath)).toContain('depends-on-foo.ts');
     expect(readdirSync(basePath)).toContain('foo.ts');
 
@@ -261,7 +261,7 @@ describe('migrate - handle custom basePath', async () => {
     expect(result.stdout).toContain('Create tsconfig.json');
     expect(readdirSync(customBasePath)).toContain('tsconfig.json');
 
-    expect(result.stdout).toContain(`1 JS file has been converted to TS`);
+    expect(result.stdout).toContain(`1 JS file converted to TS`);
     expect(readdirSync(customBasePath)).toContain('index.ts');
     expect(readdirSync(customBasePath)).not.toContain('index.js');
 

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'fs';
 import { dirname, extname, resolve } from 'path';
+import { execSync } from 'child_process';
 import { RehearsalService } from '@rehearsal/service';
 import { DiagnosticFixPlugin, LintPlugin, DiagnosticCheckPlugin } from '@rehearsal/plugins';
 import { findConfigFile, parseJsonConfigFileContent, readConfigFile, sys } from 'typescript';
-import { sync as execaSync } from 'execa';
 import type { Reporter } from '@rehearsal/reporter';
 import type { Logger } from 'winston';
-import type { ListrTaskWrapper, ListrContext, ListrRendererFactory } from 'listr2';
+import type { ListrContext } from 'listr2';
 
 export type MigrateInput = {
   basePath: string;
@@ -14,7 +14,7 @@ export type MigrateInput = {
   configName?: string;
   reporter: Reporter; // Reporter
   logger?: Logger;
-  task?: ListrTaskWrapper<ListrContext, ListrRendererFactory>;
+  task?: ListrContext;
 };
 
 export type MigrateOutput = {
@@ -38,41 +38,7 @@ export async function migrate(input: MigrateInput): Promise<MigrateOutput> {
   logger?.debug(`Base path: ${basePath}`);
   logger?.debug(`sourceFiles: ${JSON.stringify(sourceFiles)}`);
 
-  // Rename files to TS extension.
-
-  const targetFiles = sourceFiles.map((sourceFile) => {
-    const ext = extname(sourceFile);
-    const pos = sourceFile.lastIndexOf(ext);
-    const destFile = `${sourceFile.substring(0, pos)}`;
-    const tsFile = `${destFile}.ts`;
-    const dtsFile = `${destFile}.d.ts`;
-
-    if (sourceFile === tsFile) {
-      logger?.debug(`no-op ${sourceFile} is a .ts file`);
-    } else if (existsSync(tsFile)) {
-      logger?.debug(`Found ${tsFile} ???`);
-    } else if (existsSync(dtsFile)) {
-      logger?.debug(`Found ${dtsFile} ???`);
-      // Should prepend d.ts file if it exists to the new ts file.
-    } else {
-      const destFile = tsFile;
-
-      try {
-        // use git mv to keep the commit history in each file
-        // would fail if the file is not been tracked
-        execaSync('git', ['mv', sourceFile, destFile]);
-      } catch (e) {
-        // use simple mv if git mv fails
-        execaSync('mv', [sourceFile, destFile]);
-      }
-      listrTask.output = `git mv ${sourceFile.replace(basePath, '')} to ${destFile.replace(
-        basePath,
-        ''
-      )}`;
-    }
-
-    return tsFile;
-  });
+  const targetFiles = gitMove(sourceFiles, listrTask, basePath, logger);
 
   const configFile = findConfigFile(basePath, sys.fileExists, configName);
 
@@ -120,4 +86,46 @@ export async function migrate(input: MigrateInput): Promise<MigrateOutput> {
     configFile,
     migratedFiles: fileNames,
   };
+}
+
+// Rename files to TS extension.
+export function gitMove(
+  sourceFiles: string[],
+  listrTask: ListrContext,
+  basePath: string,
+  logger?: Logger
+): string[] {
+  return sourceFiles.map((sourceFile) => {
+    const ext = extname(sourceFile);
+    const pos = sourceFile.lastIndexOf(ext);
+    const destFile = `${sourceFile.substring(0, pos)}`;
+    const tsFile = `${destFile}.ts`;
+    const dtsFile = `${destFile}.d.ts`;
+
+    if (sourceFile === tsFile) {
+      logger?.debug(`no-op ${sourceFile} is a .ts file`);
+    } else if (existsSync(tsFile)) {
+      logger?.debug(`Found ${tsFile} ???`);
+    } else if (existsSync(dtsFile)) {
+      logger?.debug(`Found ${dtsFile} ???`);
+      // Should prepend d.ts file if it exists to the new ts file.
+    } else {
+      const destFile = tsFile;
+
+      try {
+        // use git mv to keep the commit history in each file
+        // would fail if the file is not been tracked
+        execSync(`git mv ${sourceFile} ${tsFile}`);
+      } catch (e) {
+        // use simple mv if git mv fails
+        execSync(`mv ${sourceFile} ${tsFile}`);
+      }
+      listrTask.output = `git mv ${sourceFile.replace(basePath, '')} to ${destFile.replace(
+        basePath,
+        ''
+      )}`;
+    }
+
+    return tsFile;
+  });
 }


### PR DESCRIPTION
This PR fixes 1 of 2 issues with SIGINT being ignored by a child process. This specific issue being fixed is around execa child process, which it would ignore SIGINT with `git mv`. By leveraging native `execSync` this issue is resolved.

Follow-Up PR for issue 2 of 2 which appears to be coming from here at a top level: https://github.com/rehearsal-js/rehearsal-js/blob/master/packages/migrate/src/migrate.ts#L110