### PR TITLE
feat: include exclude patterns from module graph

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -38,8 +38,8 @@
     "winston": "^3.6.0"
   },
   "devDependencies": {
-    "vitest": "^0.23.4",
-    "listr2": "^5.0.5"
+    "listr2": "^5.0.5",
+    "vitest": "^0.23.4"
   },
   "peerDependencies": {
     "typescript": ">4.0"

--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -18,17 +18,7 @@ export class EmberAddonPackage extends EmberAppPackage {
   #addonName: string | undefined;
 
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    super(pathToPackage, options);
-    this.isAddon = true;
-  }
-
-  get isEngine(): boolean {
-    return isEngine(readPackageJson(this.path));
-  }
-
-  get excludePatterns(): Array<string> {
-    // TODO Determine ember-config from package.json entry
-    return [
+    const excludePatterns = [
       'dist',
       'config',
       'ember-config',
@@ -38,11 +28,15 @@ export class EmberAddonPackage extends EmberAppPackage {
       'public',
       './package',
     ];
+
+    const includePatterns = ['index.js', 'addon/', 'app/'];
+
+    super(pathToPackage, { excludePatterns, includePatterns, ...options });
+    this.isAddon = true;
   }
 
-  get includePatterns(): Array<string> {
-    // TODO Determine ember-config from package.json entry
-    return ['index.js', 'addon/', 'app/'];
+  get isEngine(): boolean {
+    return isEngine(readPackageJson(this.path));
   }
 
   /**

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -12,24 +12,26 @@ export type EmberPackageOptions = PackageOptions;
 
 export class EmberAppPackage extends Package implements IPackage {
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    super(pathToPackage, options);
-  }
-
-  get excludePatterns(): Array<string> {
-    // TODO Determine ember-config directory from package.json entry
-    const files = [
+    const excludePatterns = [
+      // files
       '.ember-cli.js',
       'ember-cli-build.js',
       'ember-config.js',
       'index.js',
       'testem.js',
-    ];
-    const directories = ['dist', 'config', 'ember-config', 'tests', '@ember/*', 'public'];
-    return [...directories, ...files];
-  }
 
-  get includePatterns(): Array<string> {
-    return ['app'];
+      // Directories
+      'dist',
+      'config',
+      'ember-config',
+      'tests',
+      '@ember/*',
+      'public',
+    ];
+
+    const includePatterns = ['app'];
+
+    super(pathToPackage, { excludePatterns, includePatterns, ...options });
   }
 
   get addonPaths(): Array<string> {

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -52,8 +52,8 @@ export class PackageGraph {
       ...this.options,
     };
 
-    const include = this.package.includePatterns || ['index.js'];
-    const exclude = this.package.excludePatterns || [];
+    const include = this.package.includePatterns ? Array.from(this.package.includePatterns) : ['index.js'];
+    const exclude = this.package.excludePatterns ? Array.from(this.package.excludePatterns) : [];
 
     const cruiseOptions: ICruiseOptions = {
       baseDir,

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -52,7 +52,9 @@ export class PackageGraph {
       ...this.options,
     };
 
-    const include = this.package.includePatterns ? Array.from(this.package.includePatterns) : ['index.js'];
+    const include = this.package.includePatterns
+      ? Array.from(this.package.includePatterns)
+      : ['index.js'];
     const exclude = this.package.excludePatterns ? Array.from(this.package.excludePatterns) : [];
 
     const cruiseOptions: ICruiseOptions = {

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -25,6 +25,8 @@ export type PackageOptions = {
   packageContainer?: PackageContainer;
   rootPackagePath?: string;
   name?: string;
+  includePatterns?: Array<string>;
+  excludePatterns?: Array<string>;
 };
 
 /**
@@ -59,11 +61,20 @@ export class Package implements IPackage {
 
   #name: string;
 
+  #excludePatterns: Set<string>;
+
+  #includePatterns: Set<string>;
   protected graph: Graph<ModuleNode>;
 
   constructor(
     pathToPackage: string,
-    { type = '', packageContainer, name = '' }: PackageOptions = {}
+    {
+      excludePatterns = ['dist', 'test', 'tests'],
+      includePatterns = ['index.js'],
+      name = '',
+      packageContainer,
+      type = '',
+    }: PackageOptions = {}
   ) {
     this.#path = pathToPackage;
     this.#type = type;
@@ -74,14 +85,17 @@ export class Package implements IPackage {
     } else {
       this.#packageContainer = { isWorkspace: () => false };
     }
+
+    this.#excludePatterns = new Set(excludePatterns);
+    this.#includePatterns = new Set(includePatterns);
   }
 
-  get excludePatterns(): Array<string> {
-    return ['dist', 'test', 'tests'];
+  get excludePatterns(): Set<string> {
+    return this.#excludePatterns;
   }
 
-  get includePatterns(): Array<string> {
-    return ['index.js', 'index.ts', 'lib', 'src'];
+  get includePatterns(): Set<string> {
+    return this.#includePatterns;
   }
 
   set type(_type) {
@@ -178,6 +192,16 @@ export class Package implements IPackage {
       pkg.workspaces = [];
     }
     pkg.workspaces.push(glob);
+    return this;
+  }
+
+  addIncludePattern(pattern: string): this {
+    this.#includePatterns.add(pattern);
+    return this;
+  }
+
+  addExcludePattern(pattern: string): this {
+    this.#excludePatterns.add(pattern);
     return this;
   }
 

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -48,6 +48,36 @@ describe('Unit | Entities | Package', function () {
     });
   });
 
+  describe('includ/exclude patterns', () => {
+    test('defaults', () => {
+      const p = new Package(pathToPackage);
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests']));
+      expect(p.includePatterns).toStrictEqual(new Set(['index.js']));
+    });
+    test('options.excludePatterns ', () => {
+      const p = new Package(pathToPackage, { excludePatterns: ['dist', 'test-packages'] });
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test-packages']));
+    });
+
+    test('options.includePatterns ', () => {
+      const p = new Package(pathToPackage, { includePatterns: ['src/**/*.js'] });
+      expect(p.includePatterns).toStrictEqual(new Set(['src/**/*.js']));
+    });
+
+    test('addExcludePattern', () => {
+      const p = new Package(pathToPackage);
+      p.addExcludePattern('test-packages');
+      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests', 'test-packages']));
+    });
+
+    test('addIncludePattern', () => {
+      const p = new Package(pathToPackage);
+      p.addIncludePattern('foo.js');
+      expect(p.includePatterns.has('foo.js')).toBeTruthy();
+      expect(p.includePatterns).toStrictEqual(new Set(['index.js', 'foo.js']));
+    });
+  });
+
   describe('mutation', function () {
     test('set packageName', () => {
       const p = new Package(pathToPackage);


### PR DESCRIPTION
- This is the minimal set of changes for adding include/exclude patterns API for a Package. 
- Originally landed in #575 before having been reverted.
- This API allows for us to more pragmatically add patterns to the packages as they're instantiated.
- This PR makes no changes in how we crawl a package, just the API.

