### PR TITLE
feat: root package

### DIFF
--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -55,6 +55,7 @@ export class PackageGraph {
     const include = this.package.includePatterns
       ? Array.from(this.package.includePatterns)
       : ['index.js'];
+
     const exclude = this.package.excludePatterns ? Array.from(this.package.excludePatterns) : [];
 
     const cruiseOptions: ICruiseOptions = {

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -70,7 +70,7 @@ export class Package implements IPackage {
     pathToPackage: string,
     {
       excludePatterns = ['dist', 'test', 'tests'],
-      includePatterns = ['index.js'],
+      includePatterns = ['index.js'], // TODO Update to '.' for root files
       name = '',
       packageContainer,
       type = '',

--- a/packages/migration-graph-shared/src/entities/root-package.ts
+++ b/packages/migration-graph-shared/src/entities/root-package.ts
@@ -1,0 +1,24 @@
+import { relative } from 'path';
+import { getWorkspaceGlobs } from '../utils/workspace';
+import { Package, PackageOptions } from './package';
+
+export class RootPackage extends Package {
+  #globs: Array<string>;
+
+  constructor(rootDir: string, options?: PackageOptions) {
+    super(rootDir, options);
+
+    // Determine if this package.json has a workspace entry
+    const globs = getWorkspaceGlobs(this.packagePath);
+
+    // Add the workspace globs to the exclude pattern for the root package
+    // so it doesn't attempt to add them to the root package's graph.
+    globs.forEach((glob) => this.addExcludePattern(relative(this.packagePath, glob)));
+
+    this.#globs = globs;
+  }
+
+  get globs(): Array<string> {
+    return this.#globs;
+  }
+}

--- a/packages/migration-graph/src/migration-graph.ts
+++ b/packages/migration-graph/src/migration-graph.ts
@@ -1,4 +1,4 @@
-import { Package, ProjectGraph, readPackageJson } from '@rehearsal/migration-graph-shared';
+import { ProjectGraph, readPackageJson } from '@rehearsal/migration-graph-shared';
 import {
   EmberAddonProjectGraph,
   EmberAppProjectGraph,
@@ -16,24 +16,6 @@ export type MigrationGraphOptions = {
   entrypoint?: string;
   filterByPackageName?: Array<string>;
 };
-
-function buildMigrationGraphForLibrary(
-  projectGraph: ProjectGraph,
-  options?: MigrationGraphOptions
-): ProjectGraph {
-  const rootDir = projectGraph.rootDir;
-  const p = new Package(rootDir);
-
-  projectGraph.addPackageToGraph(p);
-
-  p.getModuleGraph({
-    entrypoint: options?.entrypoint,
-  });
-
-  projectGraph.discover();
-
-  return projectGraph;
-}
 
 function buildMigrationGraphForEmber(
   projectGraph: EmberAppProjectGraph | EmberAddonProjectGraph,
@@ -108,10 +90,8 @@ export function buildMigrationGraph(
     );
   } else {
     sourceType = SourceType.Library;
-    projectGraph = buildMigrationGraphForLibrary(
-      new ProjectGraph(rootDir, { sourceType }),
-      options
-    );
+    projectGraph = new ProjectGraph(rootDir, { sourceType, ...options });
+    projectGraph.discover();
   }
 
   return { projectGraph, sourceType };

--- a/packages/migration-graph/test/migration-graph.test.ts
+++ b/packages/migration-graph/test/migration-graph.test.ts
@@ -51,24 +51,25 @@ describe('migration-graph', () => {
       const sortedPackages = projectGraph.graph.topSort();
 
       expect(flatten(sortedPackages)).toStrictEqual([
-        'some-library-with-workspace',
         '@something/baz',
         '@something/blorp',
         '@something/bar',
         '@something/foo',
+        'some-library-with-workspace', // Root Pacakge is last.
       ]);
 
-      expect(flatten(sortedPackages[0].content.pkg.getModuleGraph().topSort())).toStrictEqual([]);
-      expect(flatten(sortedPackages[1].content.pkg.getModuleGraph().topSort())).toStrictEqual([]);
-      expect(flatten(sortedPackages[2].content.pkg.getModuleGraph().topSort())).toStrictEqual([
+      const [package0, package1, package2, package3, package4] = sortedPackages.map(
+        (node) => node.content.pkg
+      );
+
+      expect(flatten(package0.getModuleGraph().topSort())).toStrictEqual([]);
+      expect(flatten(package1.getModuleGraph().topSort())).toStrictEqual([
         'lib/impl.js',
         'index.js',
       ]);
-      expect(flatten(sortedPackages[3].content.pkg.getModuleGraph().topSort())).toStrictEqual([]);
-      expect(flatten(sortedPackages[4].content.pkg.getModuleGraph().topSort())).toStrictEqual([
-        'lib/a.js',
-        'index.js',
-      ]);
+      expect(flatten(package2.getModuleGraph().topSort())).toStrictEqual([]);
+      expect(flatten(package3.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
+      expect(flatten(package4.getModuleGraph().topSort())).toStrictEqual([]);
     });
   });
 


### PR DESCRIPTION
Creates a `RootPackage` for a project is the root package.json excluding workspaces. Allfound packages in project will have an edge/dependency on this package.

- Updated tests.
- Root package should come last.
- Moves all root package instantiation into `.discover()` methods in the `ProjectGraph` implementations.

This package requires #588 to land first.