### PR TITLE
Fix: terminal based editor in interactive mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "@rehearsal/migration-graph": "workspace:*",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/upgrade": "workspace:*",
+    "chalk": "^4.1.2",
     "commander": "^9.4.0",
     "compare-versions": "^5.0.1",
     "debug": "^4.3.2",

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -57,21 +57,42 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
     process.exit(0);
   }
 
+  const defaultListrOption = {
+    concurrent: false,
+    exitOnError: true,
+  };
+
   try {
-    await new Listr(
-      [
-        await initTask(options),
-        await depInstallTask(options),
-        await tsConfigTask(options),
-        await lintConfigTask(),
-        await createScriptsTask(options),
-        await convertTask(options, logger),
-      ],
-      {
-        concurrent: false,
-        exitOnError: true,
-      }
-    ).run();
+    if (options.interactive) {
+      const ctx = await new Listr(
+        [
+          await initTask(options),
+          await depInstallTask(options),
+          await tsConfigTask(options),
+          await lintConfigTask(),
+          await createScriptsTask(options),
+        ],
+        defaultListrOption
+      ).run();
+      // For issue #549, have to use simple renderer for the interactive edit flow
+      // previous ctx is needed for the isolated convertTask
+      await new Listr([await convertTask(options, logger, ctx)], {
+        renderer: 'simple',
+        ...defaultListrOption,
+      }).run();
+    } else {
+      await new Listr(
+        [
+          await initTask(options),
+          await depInstallTask(options),
+          await tsConfigTask(options),
+          await lintConfigTask(),
+          await createScriptsTask(options),
+          await convertTask(options, logger),
+        ],
+        defaultListrOption
+      ).run();
+    }
   } catch (e) {
     await resetFiles();
     logger.error(`${e}`);

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -15,12 +15,17 @@ const DEBUG_CALLBACK = debug('rehearsal:migrate:convert');
 
 export async function convertTask(
   options: MigrateCommandOptions,
-  logger: Logger
+  logger: Logger,
+  context?: MigrateCommandContext
 ): Promise<ListrTask> {
   return {
     title: 'Convert JS files to TS',
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
+      // During interactive mode, if context is provide via external parameter, merge with existed
+      if (context) {
+        ctx = { ...ctx, ...context };
+      }
       const projectName = determineProjectName() || '';
       const { basePath } = options;
       const tscPath = await getPathToBinary('tsc');

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -3,10 +3,11 @@ import { Logger } from 'winston';
 import { debug } from 'debug';
 import { Reporter } from '@rehearsal/reporter';
 import { migrate } from '@rehearsal/migrate';
+import chalk from 'chalk';
 import execa = require('execa');
 
 import { generateReports, getReportSummary } from '../../../helpers/report';
-import { determineProjectName, openInEditor, getPathToBinary } from '../../../utils';
+import { determineProjectName, openInEditor, getPathToBinary, prettyGitDiff } from '../../../utils';
 import type { ListrTask } from 'listr2';
 
 import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
@@ -58,7 +59,9 @@ export async function convertTask(
             const { stdout: diffOutput } = await execa('git', ['diff', tsFilePath]);
 
             // TODO: better diff with colors instead of using the output straight from git diff
-            const message = `Please view the migration changes for ${f} and select an option to continue:\n${diffOutput}`;
+            const message = `${chalk.yellow(
+              `Please view the migration changes for ${f} and select an option to continue:`
+            )}\n${prettyGitDiff(diffOutput)}`;
 
             while (!completed) {
               ctx.input = await task.prompt([

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -6,6 +6,7 @@ import { valid } from 'semver';
 import { type SimpleGit, type SimpleGitOptions, simpleGit } from 'simple-git';
 import which from 'which';
 import { InvalidArgumentError } from 'commander';
+import chalk from 'chalk';
 
 import findup = require('findup-sync');
 import execa = require('execa');
@@ -460,4 +461,21 @@ export async function openInEditor(filePath: string): Promise<void> {
       'Cannot find default editor in environment variables, please set $EDITOR and try again.'
     );
   }
+}
+
+/**
+ * Simple git diff prettier, red for deletion and green for addition
+ */
+export function prettyGitDiff(text: string): string {
+  const lines = text.split('\n');
+  return lines
+    .map((line) => {
+      if (line[0] === '+') {
+        return chalk.bgGreen(line);
+      } else if (line[0] === '-') {
+        return chalk.bgRed(line);
+      }
+      return line;
+    })
+    .join('\n');
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,7 @@ importers:
       '@rehearsal/reporter': workspace:*
       '@rehearsal/upgrade': workspace:*
       '@types/which': ^2.0.1
+      chalk: ^4.1.2
       commander: ^9.4.0
       compare-versions: ^5.0.1
       debug: ^4.3.2
@@ -133,6 +134,7 @@ importers:
       '@rehearsal/migration-graph': link:../migration-graph
       '@rehearsal/reporter': link:../reporter
       '@rehearsal/upgrade': link:../upgrade
+      chalk: 4.1.2
       commander: 9.4.0
       compare-versions: 5.0.1
       debug: 4.3.4


### PR DESCRIPTION
This is PR fixes #579 by isolating `convertTask` with `simple` renderer in interactive mode.
Also added a simple git diff prettier for better display, using red BG for deletion and greed BG for addition.

See the video demo for how it works:


https://user-images.githubusercontent.com/2744803/211660015-4af29cfd-02bb-43d3-b72b-5a20b6a6f892.mov

