### PR TITLE
fix(migration-graph-ember): move super to first line

### DIFF
--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -46,6 +46,9 @@
     "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
+  "engines": {
+    "node": ">=14.16.0"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -11,14 +11,18 @@ import {
 import { type EmberPackageOptions, EmberAppPackage } from './ember-app-package';
 
 export class EmberAddonPackage extends EmberAppPackage {
-  isAddon: boolean;
+  isAddon: boolean = true;
 
   #name: string | undefined;
   #moduleName: string | undefined;
   #addonName: string | undefined;
 
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    const excludePatterns = [
+    super(pathToPackage, {
+      ...options,
+    });
+
+    this.excludePatterns = new Set([
       'dist',
       'config',
       'ember-config',
@@ -27,12 +31,9 @@ export class EmberAddonPackage extends EmberAppPackage {
       '@ember/*',
       'public',
       './package',
-    ];
+    ]);
 
-    const includePatterns = ['index.js', 'addon/', 'app/'];
-
-    super(pathToPackage, { excludePatterns, includePatterns, ...options });
-    this.isAddon = true;
+    this.includePatterns = new Set(['index.js', 'addon', 'app']);
   }
 
   get isEngine(): boolean {

--- a/packages/migration-graph-ember/src/entities/ember-addon-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-project-graph.ts
@@ -4,7 +4,6 @@ export type EmberAddonProjectGraphOptions = EmberAppProjectGraphOptions;
 
 export class EmberAddonProjectGraph extends EmberAppProjectGraph {
   constructor(rootDir: string, options?: EmberAddonProjectGraphOptions) {
-    options = { sourceType: 'Ember Addon', ...options };
-    super(rootDir, options);
+    super(rootDir, { sourceType: 'Ember Addon', ...options });
   }
 }

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -12,14 +12,15 @@ export type EmberPackageOptions = PackageOptions;
 
 export class EmberAppPackage extends Package implements IPackage {
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
-    const excludePatterns = [
+    super(pathToPackage, { ...options });
+
+    this.excludePatterns = new Set([
       // files
       '.ember-cli.js',
       'ember-cli-build.js',
       'ember-config.js',
       'index.js',
       'testem.js',
-
       // Directories
       'dist',
       'config',
@@ -27,11 +28,9 @@ export class EmberAppPackage extends Package implements IPackage {
       'tests',
       '@ember/*',
       'public',
-    ];
+    ]);
 
-    const includePatterns = ['app'];
-
-    super(pathToPackage, { excludePatterns, includePatterns, ...options });
+    this.includePatterns = new Set(['app']);
   }
 
   get addonPaths(): Array<string> {

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -78,11 +78,10 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
 export type EmberAppProjectGraphOptions = ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
-  protected discoveredPackages: Record<string, Package | EmberAddonPackage | EmberAppPackage>;
+  protected discoveredPackages: Record<string, Package | EmberAddonPackage | EmberAppPackage> = {};
 
   constructor(rootDir: string, options?: EmberAppProjectGraphOptions) {
-    options = { sourceType: 'Ember Application', ...options };
-    super(rootDir, options);
+    super(rootDir, { sourceType: 'Ember Application', ...options });
   }
 
   addPackageToGraph(

--- a/packages/migration-graph-ember/src/mappings-container.ts
+++ b/packages/migration-graph-ember/src/mappings-container.ts
@@ -37,8 +37,8 @@ type InternalAddonPackages = MappingsLookup;
 
 interface InternalState {
   addonPackages: any;
-  externalAddonPackages: ExternalAddonPackages;
-  internalAddonPackages: InternalAddonPackages;
+  externalAddonPackages?: ExternalAddonPackages;
+  internalAddonPackages?: InternalAddonPackages;
 }
 
 class InternalState implements InternalState {
@@ -46,15 +46,11 @@ class InternalState implements InternalState {
   moduleName: string | undefined;
   emberAddonName: string | undefined;
   packageMain: string | undefined;
-  externalAddonPackages: ExternalAddonPackages;
-  internalAddonPackages: InternalAddonPackages;
+  externalAddonPackages?: ExternalAddonPackages;
+  internalAddonPackages?: InternalAddonPackages;
 
   constructor() {
     this.addonPackages = {};
-    this.externalAddonPackages = {
-      mappingsByAddonName: {},
-      mappingsByLocation: {},
-    };
   }
 
   reset(): void {
@@ -63,6 +59,10 @@ class InternalState implements InternalState {
     this.emberAddonName = undefined;
     this.addonPackages = {};
     this.externalAddonPackages = {
+      mappingsByAddonName: {},
+      mappingsByLocation: {},
+    };
+    this.internalAddonPackages = {
       mappingsByAddonName: {},
       mappingsByLocation: {},
     };

--- a/packages/migration-graph-ember/src/utils/ember.ts
+++ b/packages/migration-graph-ember/src/utils/ember.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path';
-import { PackageJson, readPackageJson } from '@rehearsal/migration-graph-shared';
+import { type PackageJson, readPackageJson } from '@rehearsal/migration-graph-shared';
 import { writeJsonSync } from 'fs-extra';
 import sortPackageJson from 'sort-package-json';
 
@@ -21,7 +21,7 @@ function hasKeyword(packageJson: PackageJson, keyword: string): boolean {
  * @param {string} pathToPackage - the path to the addon directory
  * @returns {boolean}
  */
-export function isAddon(packageJson: Record<string, any>): boolean {
+export function isAddon(packageJson: PackageJson): boolean {
   return hasKeyword(packageJson, 'ember-addon');
 }
 

--- a/packages/migration-graph-ember/tsconfig.json
+++ b/packages/migration-graph-ember/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "skipLibCheck": true,
-    "strictPropertyInitialization": false
+    "outDir": "dist"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "../migration-graph-shared"

--- a/packages/migration-graph-shared/src/entities/project-graph.ts
+++ b/packages/migration-graph-shared/src/entities/project-graph.ts
@@ -4,7 +4,7 @@ import { sync as fastGlobSync } from 'fast-glob';
 import { Graph, GraphNode } from '../graph';
 import { isWorkspace } from '../../src/utils/workspace';
 import { RootPackage } from './root-package';
-import { Package, PackageOptions } from './package';
+import { Package } from './package';
 
 import type { PackageNode } from '../types';
 
@@ -144,14 +144,12 @@ export class ProjectGraph {
   }
 
   discover(): Array<Package> {
-    const rootOptions: PackageOptions = {};
+    // Add root package to graph
+    const rootPackage = new RootPackage(this.rootDir);
 
     if (this.#entrypoint) {
-      rootOptions.includePatterns = [this.#entrypoint];
+      rootPackage.includePatterns = new Set([this.#entrypoint]);
     }
-
-    // Add root package to graph
-    const rootPackage = new RootPackage(this.rootDir, rootOptions);
 
     const rootPackageNode = this.addPackageToGraph(rootPackage, false);
 

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -54,13 +54,16 @@ describe('Unit | Entities | Package', function () {
       expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests']));
       expect(p.includePatterns).toStrictEqual(new Set(['index.js']));
     });
+
     test('options.excludePatterns ', () => {
-      const p = new Package(pathToPackage, { excludePatterns: ['dist', 'test-packages'] });
+      const p = new Package(pathToPackage);
+      p.excludePatterns = new Set(['dist', 'test-packages']);
       expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test-packages']));
     });
 
     test('options.includePatterns ', () => {
-      const p = new Package(pathToPackage, { includePatterns: ['src/**/*.js'] });
+      const p = new Package(pathToPackage);
+      p.includePatterns = new Set(['src/**/*.js']);
       expect(p.includePatterns).toStrictEqual(new Set(['src/**/*.js']));
     });
 
@@ -68,6 +71,11 @@ describe('Unit | Entities | Package', function () {
       const p = new Package(pathToPackage);
       p.addExcludePattern('test-packages');
       expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests', 'test-packages']));
+
+      p.addExcludePattern('file1', 'file2');
+      expect(p.excludePatterns).toStrictEqual(
+        new Set(['dist', 'test', 'tests', 'test-packages', 'file1', 'file2'])
+      );
     });
 
     test('addIncludePattern', () => {
@@ -75,6 +83,9 @@ describe('Unit | Entities | Package', function () {
       p.addIncludePattern('foo.js');
       expect(p.includePatterns.has('foo.js')).toBeTruthy();
       expect(p.includePatterns).toStrictEqual(new Set(['index.js', 'foo.js']));
+
+      p.addIncludePattern('file1', 'file2');
+      expect(p.includePatterns).toStrictEqual(new Set(['index.js', 'foo.js', 'file1', 'file2']));
     });
   });
 

--- a/packages/migration-graph-shared/tsconfig.json
+++ b/packages/migration-graph-shared/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "skipLibCheck": true,
-    "strictPropertyInitialization": false
+    "outDir": "dist"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "../test-support"

--- a/packages/migration-graph/tsconfig.json
+++ b/packages/migration-graph/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "../migration-graph-ember"


### PR DESCRIPTION
* Fix for "TS2376: A 'super' call must be the first statement in the constructor when a class contains initialized properties, parameter properties, or private identifiers."
* This bug was only found when building the `cli` package and not from the root build.
* Refactor include/exclude API to use getters and setters that can be called after super.
* Removed unnecessary build flags in `migration-graph-shared` and `migration-graph-ember` packages.
* Refactored some types to reduce warnings.