### PR TITLE
feat: add dry run option in migrate CLI

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -37,6 +37,7 @@ migrateCommand
   .option('-u, --userConfig <custom json config for migrate command>', 'path to rehearsal config')
   .option('-i, --interactive', 'interactive mode')
   .option('-v, --verbose', 'print debugging logs')
+  .option('-d, --dryRun', 'print files that will be attempted to migrate', false)
   .action(async (options: MigrateCommandOptions) => {
     await migrate(options);
   });
@@ -49,12 +50,14 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
 
   console.log(`@rehearsal/migrate ${version.trim()}`);
 
-  const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
-  if (hasUncommittedFiles) {
-    logger.warn(
-      'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'
-    );
-    process.exit(0);
+  if (!options.dryRun) {
+    const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
+    if (hasUncommittedFiles) {
+      logger.warn(
+        'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'
+      );
+      process.exit(0);
+    }
   }
 
   const defaultListrOption = {

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -37,7 +37,7 @@ migrateCommand
   .option('-u, --userConfig <custom json config for migrate command>', 'path to rehearsal config')
   .option('-i, --interactive', 'interactive mode')
   .option('-v, --verbose', 'print debugging logs')
-  .option('-d, --dryRun', 'print files that will be attempted to migrate', false)
+  .option('--checkFiles', 'print files that will be attempted to migrate', false)
   .action(async (options: MigrateCommandOptions) => {
     await migrate(options);
   });
@@ -50,7 +50,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
 
   console.log(`@rehearsal/migrate ${version.trim()}`);
 
-  if (!options.dryRun) {
+  if (!options.checkFiles) {
     const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
     if (hasUncommittedFiles) {
       logger.warn(

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -37,7 +37,7 @@ migrateCommand
   .option('-u, --userConfig <custom json config for migrate command>', 'path to rehearsal config')
   .option('-i, --interactive', 'interactive mode')
   .option('-v, --verbose', 'print debugging logs')
-  .option('--checkFiles', 'print files that will be attempted to migrate', false)
+  .option('-d, --dryRun', 'print files that will be attempted to migrate', false)
   .action(async (options: MigrateCommandOptions) => {
     await migrate(options);
   });
@@ -50,7 +50,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
 
   console.log(`@rehearsal/migrate ${version.trim()}`);
 
-  if (!options.checkFiles) {
+  if (!options.dryRun) {
     const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
     if (hasUncommittedFiles) {
       logger.warn(

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -22,7 +22,7 @@ const COMPLETION_MARK = '✅';
 
 export async function initTask(options: MigrateCommandOptions): Promise<ListrTask> {
   return {
-    title: 'Initialize',
+    title: `Initialize${options.dryRun ? ' -- Dry Run Mode' : ''}`,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // get custom config
       const userConfig = options.userConfig
@@ -119,21 +119,18 @@ export async function initTask(options: MigrateCommandOptions): Promise<ListrTas
       ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);
       ctx.sourceFilesWithRelativePath = files.map((f) => f.relativePath);
 
-      if (options.checkFiles) {
+      if (options.dryRun) {
         // Skip the rest of tasks
         task.output = `List of files will be attempted to migrate:\n ${ctx.sourceFilesWithRelativePath.join(
           '\n'
         )}`;
-        // The reason to set skip here instead of using "skip => !option.checkFiles"
-        // in other tasks is that we may have more complex logic to control skip in tasks
-        // in different scenario in the future
         ctx.skip = true;
       }
     },
     options: {
       // options for dryRun, since we need to keep the output to see the list of files
-      bottomBar: options.checkFiles ? true : false,
-      persistentOutput: options.checkFiles ? true : false,
+      bottomBar: options.dryRun ? true : false,
+      persistentOutput: options.dryRun ? true : false,
     },
   };
 }

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -22,7 +22,7 @@ const COMPLETION_MARK = '✅';
 
 export async function initTask(options: MigrateCommandOptions): Promise<ListrTask> {
   return {
-    title: 'Initialize',
+    title: `Initialize${options.dryRun ? ' -- Dry Run Mode' : ''}`,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // get custom config
       const userConfig = options.userConfig
@@ -118,6 +118,19 @@ export async function initTask(options: MigrateCommandOptions): Promise<ListrTas
       ctx.strategy = strategy;
       ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);
       ctx.sourceFilesWithRelativePath = files.map((f) => f.relativePath);
+
+      if (options.dryRun) {
+        // Skip the rest of tasks
+        task.output = `List of files will be attempted to migrate:\n ${ctx.sourceFilesWithRelativePath.join(
+          '\n'
+        )}`;
+        ctx.skip = true;
+      }
+    },
+    options: {
+      // options for dryRun, since we need to keep the output to see the list of files
+      bottomBar: options.dryRun ? true : false,
+      persistentOutput: options.dryRun ? true : false,
     },
   };
 }

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -22,7 +22,7 @@ const COMPLETION_MARK = '✅';
 
 export async function initTask(options: MigrateCommandOptions): Promise<ListrTask> {
   return {
-    title: `Initialize${options.dryRun ? ' -- Dry Run Mode' : ''}`,
+    title: 'Initialize',
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // get custom config
       const userConfig = options.userConfig
@@ -119,18 +119,21 @@ export async function initTask(options: MigrateCommandOptions): Promise<ListrTas
       ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);
       ctx.sourceFilesWithRelativePath = files.map((f) => f.relativePath);
 
-      if (options.dryRun) {
+      if (options.checkFiles) {
         // Skip the rest of tasks
         task.output = `List of files will be attempted to migrate:\n ${ctx.sourceFilesWithRelativePath.join(
           '\n'
         )}`;
+        // The reason to set skip here instead of using "skip => !option.checkFiles"
+        // in other tasks is that we may have more complex logic to control skip in tasks
+        // in different scenario in the future
         ctx.skip = true;
       }
     },
     options: {
       // options for dryRun, since we need to keep the output to see the list of files
-      bottomBar: options.dryRun ? true : false,
-      persistentOutput: options.dryRun ? true : false,
+      bottomBar: options.checkFiles ? true : false,
+      persistentOutput: options.checkFiles ? true : false,
     },
   };
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -14,6 +14,7 @@ export type MigrateCommandOptions = {
   verbose: boolean | undefined;
   userConfig: string | undefined;
   interactive: boolean | undefined;
+  dryRun: boolean;
 };
 
 export type MigrateCommandContext = {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -14,7 +14,7 @@ export type MigrateCommandOptions = {
   verbose: boolean | undefined;
   userConfig: string | undefined;
   interactive: boolean | undefined;
-  dryRun: boolean;
+  checkFiles: boolean;
 };
 
 export type MigrateCommandContext = {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -14,7 +14,7 @@ export type MigrateCommandOptions = {
   verbose: boolean | undefined;
   userConfig: string | undefined;
   interactive: boolean | undefined;
-  checkFiles: boolean;
+  dryRun: boolean;
 };
 
 export type MigrateCommandContext = {

--- a/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1
 
-exports[`migrate - initialization > print files will be attempted to migrate with --dryRun 1`] = `
+exports[`migrate - initialization > print files will be attempted to migrate with --checkFiles 1`] = `
 "@rehearsal/migrate 0.0.39
-[STARTED] Initialize -- Dry Run Mode
+[STARTED] Initialize
 [DATA] Running migration on basic
 [DATA] List of files will be attempted to migrate:
 [DATA]  foo.js
 [DATA] index.js
-[SUCCESS] Initialize -- Dry Run Mode"
+[SUCCESS] Initialize"
 `;

--- a/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1
+
+exports[`migrate - initialization > print files will be attempted to migrate with --dryRun 1`] = `
+"@rehearsal/migrate 0.0.39
+[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on basic
+[DATA] List of files will be attempted to migrate:
+[DATA]  foo.js
+[DATA] index.js
+[SUCCESS] Initialize -- Dry Run Mode"
+`;

--- a/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/migrate.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1
 
-exports[`migrate - initialization > print files will be attempted to migrate with --checkFiles 1`] = `
+exports[`migrate - initialization > print files will be attempted to migrate with --dryRun 1`] = `
 "@rehearsal/migrate 0.0.39
-[STARTED] Initialize
+[STARTED] Initialize -- Dry Run Mode
 [DATA] Running migration on basic
 [DATA] List of files will be attempted to migrate:
 [DATA]  foo.js
 [DATA] index.js
-[SUCCESS] Initialize"
+[SUCCESS] Initialize -- Dry Run Mode"
 `;

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -81,7 +81,7 @@ describe('migrate - check repo status', async () => {
     );
   });
 
-  test('pass in a dirty git project with --dryRun', async () => {
+  test('pass in a dirty git project with --checkFiles', async () => {
     // simulate clean git project
     const git: SimpleGit = simpleGit({
       baseDir: basePath,
@@ -91,11 +91,11 @@ describe('migrate - check repo status', async () => {
     await git.init();
     await git.add('package.json');
 
-    const { stdout } = await runBin('migrate', ['-d'], {
+    const { stdout } = await runBin('migrate', ['--checkFiles'], {
       cwd: basePath,
     });
 
-    expect(stdout).toContain('Initialize -- Dry Run Mode');
+    expect(stdout).toContain('Initialize');
     expect(stdout).toContain('List of files will be attempted to migrate:');
   });
 });
@@ -107,8 +107,8 @@ describe('migrate - initialization', async () => {
     basePath = prepareTmpDir('basic');
   });
 
-  test('print files will be attempted to migrate with --dryRun', async () => {
-    const result = await runBin('migrate', ['-d'], {
+  test('print files will be attempted to migrate with --checkFiles', async () => {
+    const result = await runBin('migrate', ['--checkFiles'], {
       cwd: basePath,
     });
 

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -80,6 +80,43 @@ describe('migrate - check repo status', async () => {
       'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'
     );
   });
+
+  test('pass in a dirty git project with --dryRun', async () => {
+    // simulate clean git project
+    const git: SimpleGit = simpleGit({
+      baseDir: basePath,
+      binary: 'git',
+      maxConcurrentProcesses: 6,
+    } as Partial<SimpleGitOptions>);
+    await git.init();
+    await git.add('package.json');
+
+    const { stdout } = await runBin('migrate', ['-d'], {
+      cwd: basePath,
+    });
+
+    expect(stdout).toContain('Initialize -- Dry Run Mode');
+    expect(stdout).toContain('List of files will be attempted to migrate:');
+  });
+});
+
+describe('migrate - initialization', async () => {
+  let basePath = '';
+
+  beforeAll(() => {
+    basePath = prepareTmpDir('basic');
+  });
+
+  test('print files will be attempted to migrate with --dryRun', async () => {
+    const result = await runBin('migrate', ['-d'], {
+      cwd: basePath,
+    });
+
+    expect(result.stdout).toMatchSnapshot();
+  });
+
+  // TODO: add tests for other cases
+  // figure out a way to test the ctx result in other scenario during initialization
 });
 
 describe('migrate - install dependencies', async () => {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -81,7 +81,7 @@ describe('migrate - check repo status', async () => {
     );
   });
 
-  test('pass in a dirty git project with --checkFiles', async () => {
+  test('pass in a dirty git project with --dryRun', async () => {
     // simulate clean git project
     const git: SimpleGit = simpleGit({
       baseDir: basePath,
@@ -91,11 +91,11 @@ describe('migrate - check repo status', async () => {
     await git.init();
     await git.add('package.json');
 
-    const { stdout } = await runBin('migrate', ['--checkFiles'], {
+    const { stdout } = await runBin('migrate', ['-d'], {
       cwd: basePath,
     });
 
-    expect(stdout).toContain('Initialize');
+    expect(stdout).toContain('Initialize -- Dry Run Mode');
     expect(stdout).toContain('List of files will be attempted to migrate:');
   });
 });
@@ -107,8 +107,8 @@ describe('migrate - initialization', async () => {
     basePath = prepareTmpDir('basic');
   });
 
-  test('print files will be attempted to migrate with --checkFiles', async () => {
-    const result = await runBin('migrate', ['--checkFiles'], {
+  test('print files will be attempted to migrate with --dryRun', async () => {
+    const result = await runBin('migrate', ['-d'], {
       cwd: basePath,
     });
 


### PR DESCRIPTION
For #601

Adding `-d`/`--dryRun` option in migrate CLI, which will print all the files that will be attempted to be migrated, and skip all the other tasks.

![Screenshot 2023-01-12 at 11 43 11](https://user-images.githubusercontent.com/2744803/212166470-53bca207-8c16-40a9-b8e1-27fd93ff4052.png)


![Screenshot 2023-01-12 at 11 42 31](https://user-images.githubusercontent.com/2744803/212166395-21074231-b5e4-4809-91dc-485f3e40d571.png)
