### PR TITLE
refactor: migrate as pull based gen and itr

### DIFF
--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -28,12 +28,11 @@ export type MigrateOutput = {
   migratedFiles: Array<string>;
 };
 
-type MigratePlugins = Array<
-  | typeof LintFixPlugin
-  | typeof DiagnosticFixPlugin
-  | typeof DiagnosticCheckPlugin
-  | typeof LintCheckPlugin
->;
+type MigratePlugins =
+  | typeof LintFixPlugin[]
+  | typeof DiagnosticFixPlugin[]
+  | typeof LintCheckPlugin[]
+  | typeof DiagnosticCheckPlugin[];
 
 type ProcessFilesInput = {
   fileNames: string[];


### PR DESCRIPTION
This PR is a refactor of migrate and implements pull based plugins and file iteration via generators/iterators. 

The initial goal was this would mitigate the SIGINT issue with the prev blocking implementation, however doesn't appear to resolve it.