### PR TITLE
chore(migration-graph): test for loose files in a package

### DIFF
--- a/packages/migration-graph/test/migration-graph.test.ts
+++ b/packages/migration-graph/test/migration-graph.test.ts
@@ -35,6 +35,25 @@ describe('migration-graph', () => {
       ).toStrictEqual(['lib/a.js', 'index.js']);
     });
 
+    test('library with loose files in root', () => {
+      const baseDir = getLibrary('library-with-loose-files');
+      const { projectGraph, sourceType } = buildMigrationGraph(baseDir);
+
+      expect(projectGraph.graph.hasNode('my-package-with-loose-files')).toBe(true);
+      expect(projectGraph.sourceType).toBe(SourceType.Library);
+      expect(sourceType).toBe(SourceType.Library);
+      expect(flatten(projectGraph.graph.topSort())).toStrictEqual(['my-package-with-loose-files']);
+      expect(
+        flatten(projectGraph.graph.topSort()[0].content.pkg.getModuleGraph().topSort())
+      ).toStrictEqual([
+        'Events.js',
+        'utils/Defaults.js',
+        'State.js',
+        'Widget.js',
+        'WidgetManager.js',
+      ]);
+    });
+
     test('workspace', () => {
       const baseDir = getLibrary('library-with-workspaces');
       const { projectGraph, sourceType } = buildMigrationGraph(baseDir);

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -16,6 +16,7 @@ type LibraryVariants =
   | 'simple'
   | 'library-with-css-imports'
   | 'library-with-entrypoint'
+  | 'library-with-loose-files'
   | 'library-with-workspaces';
 
 export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
@@ -51,6 +52,41 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             // a.js
             console.log('foo');
            `,
+        },
+      };
+      break;
+    case 'library-with-loose-files':
+      files = {
+        'WidgetManager.js': `
+          import './Widget';
+          import './Events'
+        `,
+        'package.json': `
+          {
+            "name": "my-package-with-loose-files",
+            "main": "index.js",
+            "files": [
+              "*.js",
+              "*.lock",
+              "utils/**/*",
+              "dist/**/*"
+            ],
+            "dependencies": {
+            },
+            "devDependencies": {
+              "typescript": "^4.8.3"
+            }
+
+          }
+        `,
+        'Events.js': '',
+        'State.js': `import './utils/Defaults';`,
+        'Widget.js': `import './State';`,
+        utils: {
+          'Defaults.js': ``,
+        },
+        dist: {
+          'ignore-this.js': '',
         },
       };
       break;


### PR DESCRIPTION
Add a test in the `migration-graph` package and add a fixture in `test-support` for a project where a package has loose files in the rootDir.