### PR TITLE
chore(migration-graph): improve workspace test with out-of-scope file

### DIFF
--- a/packages/migration-graph/test/migration-graph.test.ts
+++ b/packages/migration-graph/test/migration-graph.test.ts
@@ -64,12 +64,13 @@ describe('migration-graph', () => {
 
       expect(flatten(package0.getModuleGraph().topSort())).toStrictEqual([]);
       expect(flatten(package1.getModuleGraph().topSort())).toStrictEqual([
+        'build.js',
         'lib/impl.js',
         'index.js',
       ]);
       expect(flatten(package2.getModuleGraph().topSort())).toStrictEqual([]);
       expect(flatten(package3.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
-      expect(flatten(package4.getModuleGraph().topSort())).toStrictEqual([]);
+      expect(flatten(package4.getModuleGraph().topSort())).toStrictEqual(['some-util.js']);
     });
   });
 

--- a/packages/migration-graph/test/migration-strategy.test.ts
+++ b/packages/migration-graph/test/migration-strategy.test.ts
@@ -18,6 +18,7 @@ describe('migration-strategy', () => {
       const strategy = getMigrationStrategy(rootDir, { entrypoint: 'depends-on-foo.js' });
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
+      // Should not include index.js as it is not in the entrypoint's import graph.
       expect(relativePaths).toStrictEqual(['foo.js', 'depends-on-foo.js']);
       expect(strategy.sourceType).toBe(SourceType.Library);
     });
@@ -28,10 +29,12 @@ describe('migration-strategy', () => {
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const relativePaths: Array<string> = files.map((f) => f.relativePath);
       expect(relativePaths).toStrictEqual([
+        'packages/blorp/build.js',
         'packages/blorp/lib/impl.js',
         'packages/blorp/index.js',
         'packages/foo/lib/a.js',
         'packages/foo/index.js',
+        'some-util.js',
       ]);
       expect(strategy.sourceType).toBe(SourceType.Library);
     });

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -131,6 +131,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
               "version": "1.0.0",
               "main": "index.js"
             }`,
+            'build.js': `import '../../some-shared-util';`,
             'index.js': `
               import './lib/impl';
             `,
@@ -152,6 +153,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             ]
           }    
         `,
+        'some-util.js': '// Some useful util file shared across packages.',
       };
       break;
     case 'library-with-entrypoint':


### PR DESCRIPTION
Additional test at the `migration-graph` package for a workspace with an out-of-scope file.