### PR TITLE
chore: remove `src` from tarballs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,7 @@
   },
   "files": [
     "bin",
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -18,8 +18,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,8 +17,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -6,8 +6,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -6,8 +6,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -17,8 +17,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -15,8 +15,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -17,8 +17,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -17,8 +17,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,8 +19,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
We don't need `src` folder to be published, [package-json#files](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files)