### PR TITLE
chore: refactor to use Package.path

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
@@ -18,7 +18,7 @@ export class EmberAddonPackageGraph extends EmberAppPackageGraph {
   }
 
   get resolveOptions(): IResolveOptions {
-    const addonName = getEmberAddonName(this.package.packagePath);
+    const addonName = getEmberAddonName(this.package.path);
 
     if (!addonName) {
       console.warn('addonName is undefined, unable to create alias from app directory');

--- a/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
@@ -173,7 +173,7 @@ export class EmberAppPackageGraph extends PackageGraph {
 
             const key = `app/services/${s.serviceName}.js`;
 
-            const someServiceInAnInRepoAddon = join(emberAddonPackage.packagePath, key);
+            const someServiceInAnInRepoAddon = join(emberAddonPackage.path, key);
 
             DEBUG_CALLBACK(emberAddonPackage.path);
             DEBUG_CALLBACK(someServiceInAnInRepoAddon);

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -6,6 +6,7 @@ import {
   ModuleNode,
   IPackage,
 } from '@rehearsal/migration-graph-shared';
+import { EmberProjectPackage } from '../types';
 import { EmberAppPackageGraph, EmberAppPackageGraphOptions } from './ember-app-package-graph';
 
 export type EmberPackageOptions = PackageOptions;
@@ -44,24 +45,20 @@ export class EmberAppPackage extends Package implements IPackage {
   }
 
   /**
-   * The `packageInstance` is package representing the desired in-repo addon to add
+   * `p` package representing the desired in-repo addon to add
    * to `ember-addon.paths` of the current package. It will add the relative path
    * between this location and the desired package to `ember-addon.paths`.
    *
-   * @param {EmberAddonPackage} packageInstance The `EmberAddonPackage` instance
-   * @return instance of EmberPackage
+   * @param {EmberProjectPackage} p The `EmberAppPackage` or `EmberAddonPackage` instance
+   * @return this EmberAppPackage
    */
-  addAddonPath(packageInstance: Package): this {
-    if (!packageInstance) {
-      throw new Error('`packageInstance` must be provided as an argument to `addAddonPath`');
-    }
-
+  addAddonPath(p: EmberProjectPackage): EmberAppPackage {
     if (!this.addonPaths) {
       this.addPackageJsonKey('ember-addon.paths', []);
     }
 
-    if (!this.hasAddonPath(packageInstance)) {
-      this.addonPaths.push(relative(this.path, packageInstance.path));
+    if (!this.hasAddonPath(p)) {
+      this.addonPaths.push(relative(this.path, p.path));
     }
 
     return this;

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -40,7 +40,7 @@ export class EmberAppPackage extends Package implements IPackage {
 
   hasAddonPath(packageInstance: Package): string | undefined {
     return this.addonPaths?.find(
-      (addonPath: string) => packageInstance.packagePath === resolve(this.path, addonPath)
+      (addonPath: string) => packageInstance.path === resolve(this.path, addonPath)
     );
   }
 
@@ -88,7 +88,7 @@ export class EmberAppPackage extends Package implements IPackage {
         (addonPath) =>
           // get absolute path of desired package (desiredPackage.location)
           // /some/path/to/your-app/lib/msg-data === resolve('/some/path/to/your-app/lib/msg-overlay', '../lib/msg-data'))
-          packageInstance.packagePath === resolve(this.path, addonPath)
+          packageInstance.path === resolve(this.path, addonPath)
       ),
       1
     );

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -79,7 +79,7 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
 export type EmberAppProjectGraphOptions = ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
-  protected discoveredPackages: Record<string, EmberProjectPackage>;
+  protected discoveredPackages: Record<string, EmberProjectPackage> = {};
 
   constructor(rootDir: string, options?: EmberAppProjectGraphOptions) {
     super(rootDir, { sourceType: 'Ember Application', ...options });

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -13,6 +13,7 @@ import { getInternalPackages } from '../mappings-container';
 import { discoverEmberPackages } from '../utils/discover-ember-packages';
 import { EmberAppPackage } from './ember-app-package';
 import { EmberAddonPackage } from './ember-addon-package';
+import type { EmberProjectPackage } from '../types';
 
 const EXCLUDED_PACKAGES = ['test-harness'];
 
@@ -78,16 +79,13 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
 export type EmberAppProjectGraphOptions = ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
-  protected discoveredPackages: Record<string, Package | EmberAddonPackage | EmberAppPackage> = {};
+  protected discoveredPackages: Record<string, EmberProjectPackage>;
 
   constructor(rootDir: string, options?: EmberAppProjectGraphOptions) {
     super(rootDir, { sourceType: 'Ember Application', ...options });
   }
 
-  addPackageToGraph(
-    p: EmberAppPackage | EmberAddonPackage | Package,
-    crawl = true
-  ): GraphNode<PackageNode> {
+  addPackageToGraph(p: EmberProjectPackage, crawl = true): GraphNode<PackageNode> {
     DEBUG_CALLBACK('addPackageToGraph: "%s"', p.packageName);
 
     if (p instanceof EmberAddonPackage) {
@@ -182,7 +180,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
     });
   }
 
-  discover(): Array<Package | EmberAppPackage | EmberAddonPackage> {
+  discover(): Array<EmberProjectPackage> {
     const entities = discoverEmberPackages(this.rootDir);
 
     this.discoveredPackages = entities.reduce((acc: Record<string, Package>, pkg: Package) => {

--- a/packages/migration-graph-ember/src/mappings-container.ts
+++ b/packages/migration-graph-ember/src/mappings-container.ts
@@ -156,11 +156,11 @@ class MappingsContainer {
     return this.internalState?.rootPackage;
   }
 
-  public isWorkspace(pathToPackage: string): boolean {
+  public isWorkspace(packagePath: string): boolean {
     if (!this.internalState?.rootPackage) {
       throw new Error('Unable check isWorkspace; rootPackage is not defined');
     }
-    return isWorkspace(this.internalState.rootPackage.path, pathToPackage);
+    return isWorkspace(this.internalState.rootPackage.path, packagePath);
   }
 
   public addWorkspaceGlob(glob: string): MappingsContainer {
@@ -228,7 +228,7 @@ class MappingsContainer {
       for (const emberAddonPackage of emberAddons) {
         if (emberAddonPackage) {
           mappingsByAddonName[emberAddonPackage.packageName] = emberAddonPackage;
-          mappingsByLocation[emberAddonPackage.packagePath] = emberAddonPackage;
+          mappingsByLocation[emberAddonPackage.path] = emberAddonPackage;
         }
       }
 
@@ -280,7 +280,7 @@ class MappingsContainer {
       for (const emberAddonPackage of emberAddons) {
         if (emberAddonPackage) {
           mappingsByAddonName[emberAddonPackage.packageName] = emberAddonPackage;
-          mappingsByLocation[emberAddonPackage.packagePath] = emberAddonPackage;
+          mappingsByLocation[emberAddonPackage.path] = emberAddonPackage;
         }
       }
 
@@ -365,7 +365,7 @@ class MappingsContainer {
 
       for (const emberAddonPackage of internalEmberAddons) {
         mappingsByAddonName[emberAddonPackage.packageName] = emberAddonPackage;
-        mappingsByLocation[emberAddonPackage.packagePath] = emberAddonPackage;
+        mappingsByLocation[emberAddonPackage.path] = emberAddonPackage;
       }
 
       this.internalState.internalAddonPackages = {
@@ -404,7 +404,7 @@ class MappingsContainer {
 
       for (const emberAddonPackage of internalEmberAddons) {
         mappingsByAddonName[emberAddonPackage.packageName] = emberAddonPackage;
-        mappingsByLocation[emberAddonPackage.packagePath] = emberAddonPackage;
+        mappingsByLocation[emberAddonPackage.path] = emberAddonPackage;
       }
       this.internalState.internalAddonPackages = {
         mappingsByAddonName,

--- a/packages/migration-graph-ember/src/mappings-container.ts
+++ b/packages/migration-graph-ember/src/mappings-container.ts
@@ -15,14 +15,14 @@ import { EmberAppPackage } from './entities/ember-app-package';
 
 import { isAddon, isApp } from './utils/ember';
 import { getInternalAddonTestFixtures } from './utils/environment';
-import type { EmberPackageContainer as PackageContainer } from './types/package-container';
+import type { EmberPackageContainer as PackageContainer, EmberProjectPackage } from './types';
 
 const DEBUG_CALLBACK = debug('rehearsal:migration-graph-ember:mappings-container');
 
 type AddonName = string;
 type AddonLocation = string;
-type MappingsByAddonName = Record<AddonName, Package>;
-type MappingsByLocation = Record<AddonLocation, Package>;
+type MappingsByAddonName = Record<AddonName, EmberProjectPackage>;
+type MappingsByLocation = Record<AddonLocation, EmberProjectPackage>;
 
 type MappingsLookup = {
   mappingsByAddonName: MappingsByAddonName;
@@ -88,7 +88,7 @@ type EntityFactoryOptions = {
 export function entityFactory(
   pathToPackage: string,
   options: EntityFactoryOptions
-): EmberAppPackage | EmberAddonPackage | Package {
+): EmberProjectPackage {
   let Klass;
   try {
     const packageJson = readPackageJson(pathToPackage);

--- a/packages/migration-graph-ember/src/types.ts
+++ b/packages/migration-graph-ember/src/types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type PackageContainer } from '@rehearsal/migration-graph-shared';
+import type { Package, PackageContainer } from '@rehearsal/migration-graph-shared';
+import type { EmberAddonPackage } from './entities/ember-addon-package';
+import type { EmberAppPackage } from './entities/ember-app-package';
 
 export type EmberPackageContainer = {
   getInternalPackages?: (...args: any) => unknown;
@@ -9,3 +11,5 @@ export type EmberPackageContainer = {
   getAddonPackages?: (...args: any) => unknown;
   getRootPackage?: (...args: any) => unknown;
 } & PackageContainer;
+
+export type EmberProjectPackage = Package | EmberAddonPackage | EmberAppPackage;

--- a/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
@@ -1,11 +1,7 @@
 import { getInternalPackages } from '../mappings-container';
-import type { Package } from '@rehearsal/migration-graph-shared';
-import type { EmberAddonPackage } from '../entities/ember-addon-package';
-import type { EmberAppPackage } from '..//entities/ember-app-package';
 
-export function discoverEmberPackages(
-  rootDir: string
-): Array<Package | EmberAppPackage | EmberAddonPackage> {
+import type { EmberProjectPackage } from '../types';
+export function discoverEmberPackages(rootDir: string): Array<EmberProjectPackage> {
   const { mappingsByAddonName } = getInternalPackages(rootDir);
   return Array.from(Object.values(mappingsByAddonName));
 }

--- a/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
@@ -13,7 +13,7 @@ import {
   resetInternalAddonTestFixtures,
 } from '../../src/utils/environment';
 import { FIXTURE_NAMES, FIXTURES } from '../fixtures/package-fixtures';
-import type { EmberPackageContainer } from '../../src/types/package-container';
+import type { EmberPackageContainer } from '../../src/types';
 
 setGracefulCleanup();
 

--- a/packages/migration-graph-ember/test/smoke.test.ts
+++ b/packages/migration-graph-ember/test/smoke.test.ts
@@ -52,19 +52,19 @@ describe('Smoke Test', () => {
 
       expect(simpleEngine, `module mappings '${FIXTURE_NAMES.SIMPLE_ENGINE}'`).toBeTruthy();
 
-      expect(simpleAddon, 'to have an associated mapping by location for `foo`').toBe(
-        mappingsByLocation[simpleAddon.location]
+      expect(simpleAddon, 'to have an associated mapping by path for `foo`').toBe(
+        mappingsByLocation[simpleAddon.path]
       );
 
-      expect(simpleEngine, 'to have an associated mapping by location for `bar`').toBe(
-        mappingsByLocation[simpleEngine.location]
+      expect(simpleEngine, 'to have an associated mapping by path for `bar`').toBe(
+        mappingsByLocation[simpleEngine.path]
       );
 
-      expect(simpleAddon.location, `${simpleAddon.packageName}'s location is correct`).toBe(
+      expect(simpleAddon.path, `${simpleAddon.packageName}'s path is correct`).toBe(
         resolve(pathToRoot, FIXTURE_NAMES.SIMPLE_ADDON)
       );
 
-      expect(simpleEngine.location, `${simpleEngine.packageName}'s location is correct`).toBe(
+      expect(simpleEngine.path, `${simpleEngine.packageName}'s path is correct`).toBe(
         resolve(pathToRoot, FIXTURE_NAMES.SIMPLE_ENGINE)
       );
     });
@@ -169,11 +169,11 @@ describe('Smoke Test', () => {
 
       expect(
         fooExternalAddon,
-        'an associated mapping by location exists for `foo-external-addon`'
-      ).toEqual(mappingsByLocation[fooExternalAddon.location]);
+        'an associated mapping by path exists for `foo-external-addon`'
+      ).toEqual(mappingsByLocation[fooExternalAddon.path]);
 
       expect(
-        realpathSync(fooExternalAddon.location),
+        realpathSync(fooExternalAddon.path),
         "`foo-external-addon`'s location is correct"
       ).toEqual(realpathSync(resolve(pathToRoot, 'node_modules', 'foo-external-addon')));
     });

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -130,12 +130,12 @@ export class Package implements IPackage {
       );
     }
 
-    return this.#packageContainer.isWorkspace(this.#packagePath);
+    return this.#packageContainer.isWorkspace(this.path);
   }
 
   get packageJson(): PackageJson {
     if (!this.#packageJson) {
-      const packageJsonPath = resolve(this.#packagePath, 'package.json');
+      const packageJsonPath = resolve(this.path, 'package.json');
       this.#packageJson = readJsonSync(packageJsonPath);
     }
     return this.#packageJson as PackageJson;
@@ -169,7 +169,7 @@ export class Package implements IPackage {
    * Return any workspace globs this package might have.
    */
   get workspaceGlobs(): [string] {
-    return getWorkspaceGlobs(this.#packagePath);
+    return getWorkspaceGlobs(this.path);
   }
 
   addWorkspaceGlob(glob: string): this {
@@ -252,14 +252,14 @@ export class Package implements IPackage {
    */
   writePackageJsonToDisk(): void {
     const sorted: Record<any, any> = sortPackageJson(this.packageJson);
-    const pathToPackageJson = join(this.#packagePath, 'package.json');
+    const pathToPackageJson = join(this.path, 'package.json');
     writeJsonSync(pathToPackageJson, sorted, { spaces: 2 });
   }
 
   isConvertedToTypescript(conversionLevel?: string): boolean {
     const fastGlobConfig = {
       absolute: true,
-      cwd: this.#packagePath,
+      cwd: this.path,
       ignore: ['**/node_modules/**'],
     };
     // ignore a tests directory if we only want to consider the source

--- a/packages/migration-graph-shared/src/entities/project-graph.ts
+++ b/packages/migration-graph-shared/src/entities/project-graph.ts
@@ -52,7 +52,7 @@ export class ProjectGraph {
   }
 
   addPackageToGraph(p: Package, crawl = true): GraphNode<PackageNode> {
-    DEBUG_CALLBACK('addPackageToGraph: name: %s, path: %s', p.packageName, p.packagePath);
+    DEBUG_CALLBACK('addPackageToGraph: name: %s, path: %s', p.packageName, p.path);
 
     const isConverted = p.isConvertedToTypescript('source-only');
 

--- a/packages/migration-graph-shared/src/entities/root-package.ts
+++ b/packages/migration-graph-shared/src/entities/root-package.ts
@@ -5,15 +5,15 @@ import { Package, PackageOptions } from './package';
 export class RootPackage extends Package {
   #globs: Array<string>;
 
-  constructor(rootDir: string, options?: PackageOptions) {
-    super(rootDir, options);
+  constructor(packagePath: string, options?: PackageOptions) {
+    super(packagePath, options);
 
     // Determine if this package.json has a workspace entry
-    const globs = getWorkspaceGlobs(this.packagePath);
+    const globs = getWorkspaceGlobs(this.path);
 
     // Add the workspace globs to the exclude pattern for the root package
     // so it doesn't attempt to add them to the root package's graph.
-    globs.forEach((glob) => this.addExcludePattern(relative(this.packagePath, glob)));
+    globs.forEach((glob) => this.addExcludePattern(relative(this.path, glob)));
 
     this.#globs = globs;
   }

--- a/packages/migration-graph/src/migration-strategy.ts
+++ b/packages/migration-graph/src/migration-strategy.ts
@@ -82,7 +82,7 @@ export function getMigrationStrategy(
     .topSort()
     // Iterate through each package
     .forEach((packageNode: GraphNode<PackageNode>) => {
-      const packagePath = packageNode.content?.pkg?.packagePath;
+      const packagePath = packageNode.content?.pkg?.path;
 
       if (!packagePath) {
         return;


### PR DESCRIPTION
There were three different methods for accessing Package.path. This consolidates everything to the `Package.path` getter.