### PR TITLE
chore(migration-graph-ember): tidy types

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -6,6 +6,7 @@ import {
   ModuleNode,
   IPackage,
 } from '@rehearsal/migration-graph-shared';
+import { EmberProjectPackage } from '../types';
 import { EmberAppPackageGraph, EmberAppPackageGraphOptions } from './ember-app-package-graph';
 
 export type EmberPackageOptions = PackageOptions;
@@ -44,24 +45,20 @@ export class EmberAppPackage extends Package implements IPackage {
   }
 
   /**
-   * The `packageInstance` is package representing the desired in-repo addon to add
+   * `p` package representing the desired in-repo addon to add
    * to `ember-addon.paths` of the current package. It will add the relative path
    * between this location and the desired package to `ember-addon.paths`.
    *
-   * @param {EmberAddonPackage} packageInstance The `EmberAddonPackage` instance
-   * @return instance of EmberPackage
+   * @param {EmberProjectPackage} p The `EmberAppPackage` or `EmberAddonPackage` instance
+   * @return this EmberAppPackage
    */
-  addAddonPath(packageInstance: Package): this {
-    if (!packageInstance) {
-      throw new Error('`packageInstance` must be provided as an argument to `addAddonPath`');
-    }
-
+  addAddonPath(p: EmberProjectPackage): EmberAppPackage {
     if (!this.addonPaths) {
       this.addPackageJsonKey('ember-addon.paths', []);
     }
 
-    if (!this.hasAddonPath(packageInstance)) {
-      this.addonPaths.push(relative(this.path, packageInstance.path));
+    if (!this.hasAddonPath(p)) {
+      this.addonPaths.push(relative(this.path, p.path));
     }
 
     return this;

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -79,7 +79,7 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
 export type EmberAppProjectGraphOptions = ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
-  protected discoveredPackages: Record<string, EmberProjectPackage>;
+  protected discoveredPackages: Record<string, EmberProjectPackage> = {};
 
   constructor(rootDir: string, options?: EmberAppProjectGraphOptions) {
     super(rootDir, { sourceType: 'Ember Application', ...options });

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -13,6 +13,7 @@ import { getInternalPackages } from '../mappings-container';
 import { discoverEmberPackages } from '../utils/discover-ember-packages';
 import { EmberAppPackage } from './ember-app-package';
 import { EmberAddonPackage } from './ember-addon-package';
+import type { EmberProjectPackage } from '../types';
 
 const EXCLUDED_PACKAGES = ['test-harness'];
 
@@ -78,16 +79,13 @@ function debugAnalysis(entry: GraphNode<PackageNode>): void {
 export type EmberAppProjectGraphOptions = ProjectGraphOptions;
 
 export class EmberAppProjectGraph extends ProjectGraph {
-  protected discoveredPackages: Record<string, Package | EmberAddonPackage | EmberAppPackage> = {};
+  protected discoveredPackages: Record<string, EmberProjectPackage>;
 
   constructor(rootDir: string, options?: EmberAppProjectGraphOptions) {
     super(rootDir, { sourceType: 'Ember Application', ...options });
   }
 
-  addPackageToGraph(
-    p: EmberAppPackage | EmberAddonPackage | Package,
-    crawl = true
-  ): GraphNode<PackageNode> {
+  addPackageToGraph(p: EmberProjectPackage, crawl = true): GraphNode<PackageNode> {
     DEBUG_CALLBACK('addPackageToGraph: "%s"', p.packageName);
 
     if (p instanceof EmberAddonPackage) {
@@ -182,7 +180,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
     });
   }
 
-  discover(): Array<Package | EmberAppPackage | EmberAddonPackage> {
+  discover(): Array<EmberProjectPackage> {
     const entities = discoverEmberPackages(this.rootDir);
 
     this.discoveredPackages = entities.reduce((acc: Record<string, Package>, pkg: Package) => {

--- a/packages/migration-graph-ember/src/mappings-container.ts
+++ b/packages/migration-graph-ember/src/mappings-container.ts
@@ -15,14 +15,14 @@ import { EmberAppPackage } from './entities/ember-app-package';
 
 import { isAddon, isApp } from './utils/ember';
 import { getInternalAddonTestFixtures } from './utils/environment';
-import type { EmberPackageContainer as PackageContainer } from './types/package-container';
+import type { EmberPackageContainer as PackageContainer, EmberProjectPackage } from './types';
 
 const DEBUG_CALLBACK = debug('rehearsal:migration-graph-ember:mappings-container');
 
 type AddonName = string;
 type AddonLocation = string;
-type MappingsByAddonName = Record<AddonName, Package>;
-type MappingsByLocation = Record<AddonLocation, Package>;
+type MappingsByAddonName = Record<AddonName, EmberProjectPackage>;
+type MappingsByLocation = Record<AddonLocation, EmberProjectPackage>;
 
 type MappingsLookup = {
   mappingsByAddonName: MappingsByAddonName;
@@ -88,7 +88,7 @@ type EntityFactoryOptions = {
 export function entityFactory(
   pathToPackage: string,
   options: EntityFactoryOptions
-): EmberAppPackage | EmberAddonPackage | Package {
+): EmberProjectPackage {
   let Klass;
   try {
     const packageJson = readPackageJson(pathToPackage);

--- a/packages/migration-graph-ember/src/types.ts
+++ b/packages/migration-graph-ember/src/types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type PackageContainer } from '@rehearsal/migration-graph-shared';
+import type { Package, PackageContainer } from '@rehearsal/migration-graph-shared';
+import type { EmberAddonPackage } from './entities/ember-addon-package';
+import type { EmberAppPackage } from './entities/ember-app-package';
 
 export type EmberPackageContainer = {
   getInternalPackages?: (...args: any) => unknown;
@@ -9,3 +11,5 @@ export type EmberPackageContainer = {
   getAddonPackages?: (...args: any) => unknown;
   getRootPackage?: (...args: any) => unknown;
 } & PackageContainer;
+
+export type EmberProjectPackage = Package | EmberAddonPackage | EmberAppPackage;

--- a/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-packages.ts
@@ -1,11 +1,7 @@
 import { getInternalPackages } from '../mappings-container';
-import type { Package } from '@rehearsal/migration-graph-shared';
-import type { EmberAddonPackage } from '../entities/ember-addon-package';
-import type { EmberAppPackage } from '..//entities/ember-app-package';
 
-export function discoverEmberPackages(
-  rootDir: string
-): Array<Package | EmberAppPackage | EmberAddonPackage> {
+import type { EmberProjectPackage } from '../types';
+export function discoverEmberPackages(rootDir: string): Array<EmberProjectPackage> {
   const { mappingsByAddonName } = getInternalPackages(rootDir);
   return Array.from(Object.values(mappingsByAddonName));
 }

--- a/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
@@ -13,7 +13,7 @@ import {
   resetInternalAddonTestFixtures,
 } from '../../src/utils/environment';
 import { FIXTURE_NAMES, FIXTURES } from '../fixtures/package-fixtures';
-import type { EmberPackageContainer } from '../../src/types/package-container';
+import type { EmberPackageContainer } from '../../src/types';
 
 setGracefulCleanup();
 


### PR DESCRIPTION
- Creates a type `EmberProjectPackage` which is `EmberAppPackage | EmberAddonPackage | Package`.
- Helps reduce misuse around the code base.
- Consolidate types to a single file. 