### PR TITLE
fix: issue with custom config

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -17,19 +17,20 @@ export async function lintConfigTask(options: MigrateCommandOptions): Promise<Li
       if (_ctx.userConfig?.hasLintSetup) {
         task.output = `Create .eslintrc.js from config`;
         await _ctx.userConfig.lintSetup();
-      }
-
-      createRehearsalConfig(options.basePath);
-
-      const configPath = resolve(options.basePath, CONFIG_FILENAME);
-
-      if (configExists(configPath)) {
-        task.output = `${configPath} already exists, extending Rehearsal default typescript-related config`;
-        task.title = `Update eslintrc.js`;
-        await extendsRehearsalInCurrentConfig(configPath, REHEARSAL_CONFIG_RELATIVE_PATH);
       } else {
-        task.output = `Create .eslintrc.js, extending Rehearsal default typescript-related config`;
-        extendsRehearsalInNewConfig(configPath, REHEARSAL_CONFIG_RELATIVE_PATH);
+        // only run the default process with no custom config provided
+        createRehearsalConfig(options.basePath);
+
+        const configPath = resolve(options.basePath, CONFIG_FILENAME);
+
+        if (configExists(configPath)) {
+          task.output = `${configPath} already exists, extending Rehearsal default typescript-related config`;
+          task.title = `Update eslintrc.js`;
+          await extendsRehearsalInCurrentConfig(configPath, REHEARSAL_CONFIG_RELATIVE_PATH);
+        } else {
+          task.output = `Create .eslintrc.js, extending Rehearsal default typescript-related config`;
+          extendsRehearsalInNewConfig(configPath, REHEARSAL_CONFIG_RELATIVE_PATH);
+        }
       }
     },
   };

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -35,11 +35,11 @@ export class UserConfig {
   async install(): Promise<void> {
     if (this.config && this.config.install) {
       const { dependencies, devDependencies } = this.config.install;
-      if (dependencies) {
+      if (dependencies && dependencies.length) {
         await addDep(dependencies, false, { cwd: this.basePath });
       }
 
-      if (devDependencies) {
+      if (devDependencies && devDependencies.length) {
         await addDep(devDependencies, true, { cwd: this.basePath });
       }
     }

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -138,6 +138,26 @@ describe('migrate - install dependencies', async () => {
     expect(result.stdout).toContain('Install dependencies');
     expect(Object.keys(devDeps).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
   });
+
+  test('Install custom dependencies', async () => {
+    createUserConfig(basePath, {
+      migrate: {
+        install: {
+          dependencies: [],
+          devDependencies: ['fs-extra'],
+        },
+      },
+    });
+    const result = await runBin('migrate', ['-u', 'rehearsal-config.json'], {
+      cwd: basePath,
+    });
+
+    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const devDeps = packageJson.devDependencies;
+
+    expect(result.stdout).toContain('Install dependencies from config');
+    expect(devDeps).toHaveProperty('fs-extra');
+  });
 });
 
 describe('migrate - generate tsconfig', async () => {
@@ -169,7 +189,7 @@ describe('migrate - generate tsconfig', async () => {
     expect(tsConfig.compilerOptions.strict).toBeTruthy;
   });
 
-  test('runBin custom ts config command with user config provided', async () => {
+  test('Custom ts config command with user config provided', async () => {
     basePath = prepareTmpDir('initialization');
     createUserConfig(basePath, {
       migrate: {


### PR DESCRIPTION
For #624.

- Fixed installation bug if dependencies/devDependencies in custom config is empty
- Added condition to not run default eslint config if custom lint config is provided