### PR TITLE
feat(migration-graph): ignore more files

### DIFF
--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -79,7 +79,25 @@ export class Package implements IPackage {
       this.#packageContainer = { isWorkspace: () => false };
     }
 
-    this.#excludePatterns = new Set(['dist', 'test', 'tests']);
+    const excludeDirs = [
+      '.yarn', // yarn3 directory
+      'dist',
+      'test',
+      'tests',
+    ];
+
+    const excludeFiles = [
+      '.eslintrc.*',
+      '.babelrc.*',
+      'babel.config.*', // Babel configs
+      'Brocfile.js',
+      'prettier.config.*', // Prettier configs
+      'karma.config.*',
+      'webpack.config.js',
+      'vite.config.ts',
+    ];
+
+    this.#excludePatterns = new Set([...excludeDirs, ...excludeFiles]);
     this.#includePatterns = new Set(['.']);
   }
 

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -51,7 +51,22 @@ describe('Unit | Entities | Package', function () {
   describe('include/exclude patterns', () => {
     test('defaults', () => {
       const p = new Package(pathToPackage);
-      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests']));
+      expect(p.excludePatterns).toStrictEqual(
+        new Set([
+          '.yarn',
+          'dist',
+          'test',
+          'tests',
+          '.eslintrc.*',
+          '.babelrc.*',
+          'babel.config.*',
+          'Brocfile.js',
+          'prettier.config.*',
+          'karma.config.*',
+          'webpack.config.js',
+          'vite.config.ts',
+        ])
+      );
       expect(p.includePatterns).toStrictEqual(new Set(['.']));
     });
 
@@ -70,11 +85,22 @@ describe('Unit | Entities | Package', function () {
     test('addExcludePattern', () => {
       const p = new Package(pathToPackage);
       p.addExcludePattern('test-packages');
-      expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test', 'tests', 'test-packages']));
-
-      p.addExcludePattern('file1', 'file2');
       expect(p.excludePatterns).toStrictEqual(
-        new Set(['dist', 'test', 'tests', 'test-packages', 'file1', 'file2'])
+        new Set([
+          '.yarn',
+          'dist',
+          'test',
+          'tests',
+          '.eslintrc.*',
+          '.babelrc.*',
+          'babel.config.*',
+          'Brocfile.js',
+          'prettier.config.*',
+          'karma.config.*',
+          'webpack.config.js',
+          'vite.config.ts',
+          'test-packages',
+        ])
       );
     });
 

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -59,7 +59,7 @@ describe('project-graph', () => {
     expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
   });
 
-  test.only('should ignore .lock files', () => {
+  test('should ignore .lock files', () => {
     const baseDir = getLibrary('library-with-ignored-files');
 
     // Add dummy lock files package-lock.json, npm-shrinkwrap.json package-lock.json, yarn.lock, pnpm-lock.yaml

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -48,6 +48,41 @@ describe('project-graph', () => {
 
     expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
   });
+  test('should ignore `.<name>.js files (eg. .babelrc.js or .eslintrc.js)', () => {
+    const baseDir = getLibrary('simple');
+
+    const projectGraph = new ProjectGraph(baseDir);
+    const somePackage = new Package(baseDir);
+    projectGraph.addPackageToGraph(somePackage);
+    projectGraph.discover();
+
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
+  });
+
+  test.only('should ignore .lock files', () => {
+    const baseDir = getLibrary('library-with-ignored-files');
+
+    // Add dummy lock files package-lock.json, npm-shrinkwrap.json package-lock.json, yarn.lock, pnpm-lock.yaml
+
+    const projectGraph = new ProjectGraph(baseDir);
+    projectGraph.discover();
+
+    const somePackage = projectGraph.graph.topSort()[0].content.pkg;
+
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['lib/a.js', 'index.js']);
+  });
+
+  test('library should ignore files', () => {
+    const baseDir = getLibrary('library-with-ignored-files');
+    const projectGraph = new ProjectGraph(baseDir);
+    projectGraph.discover();
+
+    const somePackage = projectGraph.graph.topSort()[0].content.pkg;
+
+    const files = flatten(somePackage.getModuleGraph().topSort());
+
+    expect(files).toStrictEqual(['lib/a.js', 'index.js']);
+  });
   test('options.eager', () => {
     const baseDir = getLibrary('simple');
 

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -14,10 +14,53 @@ type FixtureDir = string;
 
 type LibraryVariants =
   | 'simple'
+  | 'library-with-ignored-files'
   | 'library-with-css-imports'
   | 'library-with-entrypoint'
   | 'library-with-loose-files'
   | 'library-with-workspaces';
+
+const DIRS_TO_IGNORE = ['.yarn'];
+
+const FILES_TO_IGNORE = [
+  '.babelrc.js',
+  '.babelrc.json',
+  '.babelrc.cjs',
+  '.babelrc.mjs',
+  'babel.config.js',
+  'babel.config.json',
+  'babel.config.cjs',
+  'babel.config.mjs',
+  '.eslintrc.js',
+  'package-lock.json',
+  'yarn.lock',
+  'npm-shrinkwrap.json',
+  'webpack.config.js',
+  'prettier.config.js',
+  'prettier.config.cjs',
+  'karma.config.js',
+  'yarn.lock',
+];
+
+function getIgnoredFilesFixture(): fixturify.DirJSON {
+  const fixtureDir: fixturify.DirJSON = {};
+
+  FILES_TO_IGNORE.forEach((filename) => {
+    fixtureDir[filename] = '';
+  });
+
+  return fixtureDir;
+}
+
+function getIgnoredDirectoriesFixture(): fixturify.DirJSON {
+  const fixtureDir: fixturify.DirJSON = {};
+
+  DIRS_TO_IGNORE.forEach((dirname) => {
+    fixtureDir[dirname] = { 'should-not-include.js': '// Should not be included' };
+  });
+
+  return fixtureDir;
+}
 
 export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
   let files: fixturify.DirJSON;
@@ -52,6 +95,34 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             // a.js
             console.log('foo');
            `,
+        },
+      };
+      break;
+    case 'library-with-ignored-files':
+      files = {
+        'index.js': `
+          import './lib/a';
+          console.log(path.join('foo', 'bar', 'baz'));
+          console.log(parser, chalk);
+        `,
+        ...getIgnoredFilesFixture(),
+        ...getIgnoredDirectoriesFixture(),
+        config: {
+          ...getIgnoredFilesFixture(),
+        },
+        'package.json': `
+          {
+            "name": "my-package",
+            "main": "index.js",
+            "dependencies": {
+            },
+            "devDependencies": {
+              "typescript": "^4.8.3"
+            }
+          }
+        `,
+        lib: {
+          'a.js': '',
         },
       };
       break;


### PR DESCRIPTION
When regressing migration graph against our internal list of JS libaries, these were the common files that should be ignored from the graph when we forgo passing an `--entrypoint` argument.

The following will be ignored by default

**Directories**
```
.yarn // yarn3 directory
dist
test
tests
```

```
.eslintrc.*
.babelrc.*
babel.config.* // Babel configs
Brocfile.js 
prettier.config.* // Prettier configs
karma.config.*
webpack.config.js
vite.config.ts
```

This is ultimately a short term fix until this lands: https://github.com/rehearsal-js/rehearsal-js/issues/602