### PR TITLE
fix(migration-graph-ember): addon, ignore app and index.js

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -22,7 +22,7 @@ export class EmberAddonPackage extends EmberAppPackage {
       ...options,
     });
 
-    this.excludePatterns = new Set([
+    const excludeDirs = [
       'dist',
       'config',
       'ember-config',
@@ -31,9 +31,16 @@ export class EmberAddonPackage extends EmberAppPackage {
       '@ember/*',
       'public',
       './package',
-    ]);
+      'app', // Addons app/ folder should not be converted to TS. https://docs.ember-cli-typescript.com/ts/with-addons#key-differences-from-apps
+    ];
 
-    this.includePatterns = new Set(['index.js', 'addon', 'app']);
+    const excludeFiles = [
+      'index.js', // Ignore index.js because it's a CJS use to interact with the build pipeline.
+    ];
+
+    this.excludePatterns = new Set([...excludeDirs, ...excludeFiles]);
+
+    this.includePatterns = new Set(['addon']);
   }
 
   get isEngine(): boolean {

--- a/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
@@ -4,18 +4,16 @@ import { EmberAddonPackage } from '../../src/entities/ember-addon-package';
 import { EmberAddonPackageGraph } from '../../src/entities/ember-addon-package-graph';
 
 describe('EmberAddonPackageGraph', () => {
-  test('should create an edge between app/components/<file>.js and addon/components/<file>.js', async () => {
+  test('should create an edge between app/ files in addons module graph', async () => {
     const project = getEmberProject('addon');
 
     await setupProject(project);
 
     const addonPackage = new EmberAddonPackage(project.baseDir);
-
     const addonPackageGraph = new EmberAddonPackageGraph(addonPackage);
     addonPackageGraph.discover();
 
-    const implNode = addonPackageGraph.graph.getNode('addon/components/greet.js');
-    const interfaceNode = addonPackageGraph.graph.getNode('app/components/greet.js');
-    expect(interfaceNode.adjacent.has(implNode)).toBe(true);
+    expect(addonPackageGraph.graph.hasNode('addon/components/greet.js')).toBeTruthy();
+    expect(addonPackageGraph.graph.hasNode('app/components/greet.js')).toBeFalsy();
   });
 });

--- a/packages/migration-graph/test/migration-graph.test.ts
+++ b/packages/migration-graph/test/migration-graph.test.ts
@@ -138,7 +138,7 @@ describe('migration-graph', () => {
       expect(
         flatten(filter(orderedPackages[0].content.pkg.getModuleGraph().topSort())),
         'expected migraiton order for addon'
-      ).toStrictEqual(['addon/components/greet.js', 'app/components/greet.js', 'index.js']);
+      ).toStrictEqual(['addon/components/greet.js']);
 
       expect(
         flatten(filter(orderedPackages[1].content.pkg.getModuleGraph().topSort())),
@@ -159,7 +159,7 @@ describe('migration-graph', () => {
       expect(
         flatten(filter(orderedPackages[0].content.pkg.getModuleGraph().topSort())),
         'expected migraiton order for in-repo-engine'
-      ).toStrictEqual(['addon/resolver.js', 'addon/engine.js', 'addon/routes.js', 'index.js']);
+      ).toStrictEqual(['addon/resolver.js', 'addon/engine.js', 'addon/routes.js']);
 
       expect(
         flatten(filter(orderedPackages[1].content.pkg.getModuleGraph().topSort())),
@@ -179,7 +179,7 @@ describe('migration-graph', () => {
       expect(flatten(orderedPackages)).toStrictEqual(['addon-template']);
       expect(
         flatten(filter(orderedPackages[0].content.pkg.getModuleGraph().topSort()))
-      ).toStrictEqual(['addon/components/greet.js', 'app/components/greet.js', 'index.js']);
+      ).toStrictEqual(['addon/components/greet.js']);
     });
     test('should create a dependency between an app using a service from an in-repo addon', async () => {
       const project = getEmberProject('app-with-in-repo-addon');
@@ -244,9 +244,6 @@ describe('migration-graph', () => {
       expect(allFiles).toStrictEqual([
         'addon/components/greet.js',
         'addon/services/date.js',
-        'app/components/greet.js',
-        'app/services/date.js',
-        'index.js',
         'app/app.js',
         'app/components/obtuse.js',
         'app/services/locale.js',

--- a/packages/migration-graph/test/migration-strategy.test.ts
+++ b/packages/migration-graph/test/migration-strategy.test.ts
@@ -65,8 +65,6 @@ describe('migration-strategy', () => {
       const actual: Array<string> = files.map((f) => f.relativePath);
       expect(actual).toStrictEqual([
         'lib/some-addon/addon/components/greet.js',
-        'lib/some-addon/app/components/greet.js',
-        'lib/some-addon/index.js',
         ...EXPECTED_APP_FILES,
       ]);
       expect(strategy.sourceType).toBe(SourceType.EmberApp);
@@ -82,7 +80,6 @@ describe('migration-strategy', () => {
         'lib/some-engine/addon/resolver.js',
         'lib/some-engine/addon/engine.js',
         'lib/some-engine/addon/routes.js',
-        'lib/some-engine/index.js',
         ...EXPECTED_APP_FILES,
       ]);
       expect(strategy.sourceType).toBe(SourceType.EmberApp);
@@ -94,11 +91,7 @@ describe('migration-strategy', () => {
       const strategy = getMigrationStrategy(project.baseDir);
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const actual: Array<string> = files.map((f) => f.relativePath);
-      expect(actual).toStrictEqual([
-        'addon/components/greet.js',
-        'app/components/greet.js',
-        'index.js',
-      ]);
+      expect(actual).toStrictEqual(['addon/components/greet.js']);
       expect(strategy.sourceType).toBe(SourceType.EmberAddon);
     });
   });


### PR DESCRIPTION
Initially created this PR to ignore `index.js` but found another issue #533 that had a similar problem.

* For an ember addon, omit the `app` dir and `index.js` from the migration-graph.
* Updated tests.