### PR TITLE
feat: commit all the config files during migration

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 import { ESLint } from 'eslint';
 import { existsSync, outputFileSync } from 'fs-extra';
 import defaultConfig from '../../../configs/default-eslint';
+import { gitAddIfInRepo } from '../../../utils';
 import type { ListrTask } from 'listr2';
 import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
 
@@ -31,6 +32,7 @@ export async function lintConfigTask(options: MigrateCommandOptions): Promise<Li
         task.output = `Create .eslintrc.js, extending Rehearsal default typescript-related config`;
         extendsRehearsalInNewConfig(configPath, REHEARSAL_CONFIG_RELATIVE_PATH);
       }
+      gitAddIfInRepo(configPath); // stage .eslintrc.js if in a git repo
     },
   };
 }
@@ -39,6 +41,7 @@ function createRehearsalConfig(basePath: string): void {
   const rehearsalConfigStr = 'module.exports = ' + JSON.stringify(defaultConfig, null, 2);
   const rehearsalConfigPath = resolve(basePath, REHEARSAL_CONFIG_FILENAME);
   outputFileSync(rehearsalConfigPath, rehearsalConfigStr);
+  gitAddIfInRepo(rehearsalConfigPath); // stage '.rehearsal-eslintrc.js'; if in a git repo
 }
 
 async function extendsRehearsalInCurrentConfig(

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -7,7 +7,13 @@ import chalk from 'chalk';
 import execa = require('execa');
 
 import { generateReports, getReportSummary } from '../../../helpers/report';
-import { determineProjectName, openInEditor, getPathToBinary, prettyGitDiff } from '../../../utils';
+import {
+  determineProjectName,
+  openInEditor,
+  getPathToBinary,
+  prettyGitDiff,
+  gitAddIfInRepo,
+} from '../../../utils';
 import type { ListrTask } from 'listr2';
 
 import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
@@ -94,6 +100,7 @@ export async function convertTask(
             }
             const reportOutputPath = resolve(options.basePath, options.outputPath);
             generateReports('migrate', reporter, reportOutputPath, options.format);
+            gitAddIfInRepo(reportOutputPath); // stage report if in a git repo
             task.title = getReportSummary(reporter.report, migratedFiles.length);
           }
         } else {

--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -9,6 +9,8 @@ import {
   sarifFormatter,
   ReportFormatter,
 } from '@rehearsal/reporter';
+
+import { gitAddIfInRepo } from '../utils';
 import type { CliCommand, Formats } from '../types';
 
 export function generateReports(
@@ -46,6 +48,7 @@ export function generateReports(
     }
 
     reporter.print(reportPath, formatter);
+    gitAddIfInRepo(reportPath); // stage report if in git repo
     generatedReports.push(reportPath);
   });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -56,6 +56,13 @@ export async function gitIsRepoDirty(cwd?: string): Promise<boolean> {
   return false; // false if it's not a git repo
 }
 
+// Stage files in a git repo
+export async function gitAddIfInRepo(fileList: string[] | string): Promise<void> {
+  if (await git.checkIsRepo()) {
+    git.add(fileList);
+  }
+}
+
 /**
  * Function to introduce a wait
  *

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -179,8 +179,6 @@ describe('migrate - generate tsconfig', async () => {
       cwd: basePath,
     });
 
-    console.log(basePath);
-
     expect(result.stdout).toContain('Create tsconfig.json');
     expect(readdirSync(basePath)).toContain('tsconfig.json');
   });

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -191,6 +191,9 @@ describe('migrate - generate tsconfig', async () => {
     // Init git, add and commit existed files, to make it a clean state
     await git.init();
     await git.add(resolve(basePath, 'package.json'));
+    // GH CI would require git name and email
+    await git.addConfig('user.name', 'tester');
+    await git.addConfig('user.email', 'tester@tester.com');
     await git.commit('foo');
 
     const result = await runBin('migrate', [], {
@@ -307,6 +310,9 @@ describe('migrate - JS to TS conversion', async () => {
     // Init git, add and commit existed files, to make it a clean state
     await git.init();
     await git.add(readdirSync(basePath));
+    // GH CI would require git name and email
+    await git.addConfig('user.name', 'tester');
+    await git.addConfig('user.email', 'tester@tester.com');
     await git.commit('foo');
 
     await runBin('migrate', [], {
@@ -389,6 +395,9 @@ describe('migrate - generate eslint config', async () => {
     // Init git, add and commit existed files, to make it a clean state
     await git.init();
     await git.add(resolve(basePath, 'package.json'));
+    // GH CI would require git name and email
+    await git.addConfig('user.name', 'tester');
+    await git.addConfig('user.email', 'tester@tester.com');
     await git.commit('foo');
 
     await runBin('migrate', [], {


### PR DESCRIPTION
For #623.

- Stage `tsconfig.json`, `.eslintrc.js`, `.rehearsal-eslintrc.js` and all generated reports in the CLI, so that user won't need to do `git add` manually.
- Add a few more test for lint config task.