### PR TITLE
fix: bundle typescript and bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "sort-package-json": "^1.57.0",
     "tmp": "^0.2.1",
     "ts-node": "^10.4.0",
-    "typescript": "4.7.4",
+    "typescript": "^4.9.4",
     "vite": "^3.1.3",
     "vitest": "^0.23.4",
     "walk-sync": "^3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,16 +47,13 @@
     "semver": "^7.3.5",
     "simple-git": "^3.10.0",
     "tmp": "^0.2.1",
+    "typescript": "^4.9.4",
     "which": "^2.0.2",
     "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/which": "^2.0.1",
-    "typescript": "4.5.5",
     "vitest": "^0.23.4"
-  },
-  "peerDependencies": {
-    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -325,6 +325,7 @@ describe('migrate - JS to TS conversion', async () => {
     const gitStatus = await git.status();
     expect(gitStatus.staged).toStrictEqual([
       '.rehearsal-eslintrc.js',
+      '.eslintrc.js',
       '.rehearsal/migrate-report.sarif',
       'tsconfig.json',
     ]);

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -34,7 +34,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe.skip('migrate - check repo status', async () => {
+describe('migrate - check repo status', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -108,7 +108,7 @@ describe.skip('migrate - check repo status', async () => {
   });
 });
 
-describe.skip('migrate - initialization', async () => {
+describe('migrate - initialization', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -127,7 +127,7 @@ describe.skip('migrate - initialization', async () => {
   // figure out a way to test the ctx result in other scenario during initialization
 });
 
-describe.skip('migrate - install dependencies', async () => {
+describe('migrate - install dependencies', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -167,7 +167,7 @@ describe.skip('migrate - install dependencies', async () => {
   });
 });
 
-describe.skip('migrate - generate tsconfig', async () => {
+describe('migrate - generate tsconfig', async () => {
   let basePath = '';
 
   beforeEach(() => {

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -34,7 +34,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe('migrate - check repo status', async () => {
+describe.skip('migrate - check repo status', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -108,7 +108,7 @@ describe('migrate - check repo status', async () => {
   });
 });
 
-describe('migrate - initialization', async () => {
+describe.skip('migrate - initialization', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -127,7 +127,7 @@ describe('migrate - initialization', async () => {
   // figure out a way to test the ctx result in other scenario during initialization
 });
 
-describe('migrate - install dependencies', async () => {
+describe.skip('migrate - install dependencies', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -167,7 +167,7 @@ describe('migrate - install dependencies', async () => {
   });
 });
 
-describe('migrate - generate tsconfig', async () => {
+describe.skip('migrate - generate tsconfig', async () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -324,8 +324,8 @@ describe('migrate - JS to TS conversion', async () => {
 
     const gitStatus = await git.status();
     expect(gitStatus.staged).toStrictEqual([
-      '.rehearsal-eslintrc.js',
       '.eslintrc.js',
+      '.rehearsal-eslintrc.js',
       '.rehearsal/migrate-report.sarif',
       'tsconfig.json',
     ]);

--- a/packages/cli/test/commands/migrate.test.ts
+++ b/packages/cli/test/commands/migrate.test.ts
@@ -324,7 +324,6 @@ describe('migrate - JS to TS conversion', async () => {
 
     const gitStatus = await git.status();
     expect(gitStatus.staged).toStrictEqual([
-      '.eslintrc.js',
       '.rehearsal-eslintrc.js',
       '.rehearsal/migrate-report.sarif',
       'tsconfig.json',

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -19,7 +19,7 @@ const beforeEachPrep = async (): Promise<void> => {
   const { current } = await git.branchLocal();
   WORKING_BRANCH = current;
   // install the test version of tsc
-  await execa(PNPM_PATH, ['add', '-D', `typescript@${TEST_TSC_VERSION}`]);
+  await execa(PNPM_PATH, ['add', `typescript@${TEST_TSC_VERSION}`]);
   await execa(PNPM_PATH, ['install']);
   // clean any report files
   rmSync(join(FIXTURE_APP_PATH, '.rehearsal'), { recursive: true, force: true });
@@ -32,7 +32,7 @@ const afterEachCleanup = async (): Promise<void> => {
 
 // Revert to development version of TSC
 afterAll(async (): Promise<void> => {
-  await execa(PNPM_PATH, ['add', '-D', `typescript@${ORIGIN_TSC_VERSION}`]);
+  await execa(PNPM_PATH, ['add', `typescript@${ORIGIN_TSC_VERSION}`]);
   await execa(PNPM_PATH, ['install']);
 });
 
@@ -115,7 +115,7 @@ describe('upgrade:command tsc version check', async () => {
 
   test(`it is on typescript version already tested`, async () => {
     // this will test the version already installed
-    await execa(PNPM_PATH, ['add', '-D', `typescript@${TEST_TSC_VERSION}`]);
+    await execa(PNPM_PATH, ['add', `typescript@${TEST_TSC_VERSION}`]);
     await execa(PNPM_PATH, ['install']);
 
     const result = await runBin(

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -12,7 +12,8 @@ const FIXTURE_APP_PATH = resolve(__dirname, '../fixtures/app');
 // we want an older version of typescript to test against
 // eg 4.2.4 since we want to be sure to get compile errors
 const TEST_TSC_VERSION = '4.5.5';
-const ORIGIN_TSC_VERSION = packageJson.devDependencies.typescript;
+// we bundle the latest version of typescript with the cli
+const ORIGIN_TSC_VERSION = packageJson.dependencies.typescript;
 let WORKING_BRANCH = '';
 
 const beforeEachPrep = async (): Promise<void> => {

--- a/packages/cli/test/helpers/utils.test.ts
+++ b/packages/cli/test/helpers/utils.test.ts
@@ -85,11 +85,15 @@ describe('utils', () => {
   });
 
   test('getLatestTSVersion()', async () => {
-    const latestVersionTagged = compare(await getLatestTSVersion('beta'), '1.0.0', '>');
-    const latestVersion = compare(await getLatestTSVersion('latestBeta'), '1.0.0', '>');
+    const betaVersionTagged = compare(await getLatestTSVersion('beta'), '4.0.0', '>');
+    const latestBetaVersion = compare(await getLatestTSVersion('latestBeta'), '4.0.0', '>');
+    const latestVersion = compare(await getLatestTSVersion('latest'), '4.0.0', '>');
+    const rcVersion = compare(await getLatestTSVersion('rc'), '4.0.0', '>');
 
-    expect(latestVersionTagged).toBeTruthy();
+    expect(betaVersionTagged).toBeTruthy();
     expect(latestVersion).toBeTruthy();
+    expect(latestBetaVersion).toBeTruthy();
+    expect(rcVersion).toBeTruthy();
   });
 
   test('getLockfilePath()', () => {

--- a/packages/cli/test/test-helpers.ts
+++ b/packages/cli/test/test-helpers.ts
@@ -45,13 +45,14 @@ export const FIXTURE_APP_PATH = resolve(__dirname, '../fixtures/app');
 // we want an older version of typescript to test against
 // eg 4.2.4 since we want to be sure to get compile errors
 export const TEST_TSC_VERSION = '4.5.5';
-export const ORIGIN_TSC_VERSION = packageJson.devDependencies.typescript;
+export const ORIGIN_TSC_VERSION = packageJson.dependencies.typescript;
 
+// we bundle typescript in deps
 export const beforeEachPrep = async (): Promise<void> => {
   const { current } = await git.branchLocal();
   WORKING_BRANCH = current;
   // install the test version of tsc
-  await execa(PNPM_PATH, ['add', '-D', '-w', `typescript@${TEST_TSC_VERSION}`]);
+  await execa(PNPM_PATH, ['add', '-w', `typescript@${TEST_TSC_VERSION}`]);
   await execa(PNPM_PATH, ['install']);
   // clean any report files
   rmSync(join(FIXTURE_APP_PATH, '.rehearsal'), { recursive: true, force: true });

--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -38,7 +38,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/codefixes/src/2571/fixtures/2571.ts.output
+++ b/packages/codefixes/src/2571/fixtures/2571.ts.output
@@ -5,18 +5,27 @@ const test = ['dummy'];
 try {
   console.log('success');
 } catch (e) {
-  console.log((e as Error).message);
-  console.log((e as any).notErrorMember);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  console.log(e.message);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  console.log(e.notErrorMember);
 
-  if ((e as Error).name === 'Test') {
-    console.log((e as Error).name);
-    console.log((e as Error).name);
-    console.log((e as Error).name);
-    console.log((e as Error).name);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  if (e.name === 'Test') {
+    /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+    console.log(e.name);
+    /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+    console.log(e.name);
+    /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+    console.log(e.name);
+    /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+    console.log(e.name);
   }
 
-  if (test[1] === undefined && (e as Error).name === 'Test') {
-    console.log((e as Error).name);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  if (test[1] === undefined && e.name === 'Test') {
+    /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+    console.log(e.name);
   }
 }
 
@@ -29,5 +38,5 @@ function getObject<T>(): T {
 
 const dummy = getObject();
 
-/* @ts-expect-error @rehearsal TODO TS2571: Object is of type 'unknown'. Specify a type of dummy, use type assertion: `(dummy as DesiredType)` or type guard: `if (dummy instanceof DesiredType) { ... }` */
+/* @ts-expect-error @rehearsal TODO TS18046: 'dummy' is of type 'unknown'. */
 dummy.key;

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -41,7 +41,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -42,7 +42,7 @@
     "walk-sync": "^3"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migration-graph-ember/src/utils/ember.ts
+++ b/packages/migration-graph-ember/src/utils/ember.ts
@@ -36,14 +36,12 @@ export function isEngine(packageJson: PackageJson): boolean {
 }
 
 export function getPackageMainFileName(pathToPackage: string): string {
-  const packageMain = readPackageJson(pathToPackage) as {
+  const result = readPackageJson(pathToPackage) as {
     main?: string;
-    emberAddon?: {
-      main: string;
-    };
+    'ember-addon'?: { main: string };
   };
 
-  return packageMain.emberAddon?.main ?? packageMain.main ?? 'index.js';
+  return result['ember-addon']?.main ?? result.main ?? 'index.js';
 }
 
 /**

--- a/packages/migration-graph-ember/src/utils/ember.ts
+++ b/packages/migration-graph-ember/src/utils/ember.ts
@@ -36,8 +36,14 @@ export function isEngine(packageJson: PackageJson): boolean {
 }
 
 export function getPackageMainFileName(pathToPackage: string): string {
-  const { main, 'ember-addon': emberAddon = {} } = readPackageJson(pathToPackage);
-  return emberAddon?.main ?? main ?? 'index.js';
+  const packageMain = readPackageJson(pathToPackage) as {
+    main?: string;
+    emberAddon?: {
+      main: string;
+    };
+  };
+
+  return packageMain.emberAddon?.main ?? packageMain.main ?? 'index.js';
 }
 
 /**

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -36,7 +36,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/migration-graph-shared/src/index.ts
+++ b/packages/migration-graph-shared/src/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import { readJsonSync } from 'fs-extra';
 
-export function readPackageJson(pathToPackage: string): Record<string, any> {
+export function readPackageJson(pathToPackage: string): Record<string, unknown> {
   return readJsonSync(resolve(pathToPackage, 'package.json'));
 }
 

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -28,7 +28,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.7"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -36,12 +36,9 @@
     "@types/sarif": "^2.1.4",
     "fs-extra": "^10.1.0",
     "lodash.get": "^4.4.2",
-    "typescript": "4.7.4",
+    "typescript": "^4.9.4",
     "vitest": "^0.23.4",
     "vitest-mock-extended": "^0.1.15"
-  },
-  "peerDependencies": {
-    "typescript": ">4.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -36,7 +36,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -39,7 +39,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Test upgrade > should output the correct data from upgrade 1`] = `
 {
-  "fixedItemCount": 44,
+  "fixedItemCount": 42,
   "items": [
     {
       "analysisTarget": "react-processed.tsx",
@@ -567,20 +567,38 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
     {
       "analysisTarget": "ts-processed.ts",
       "category": "Error",
-      "helpUrl": "",
-      "hint": "Unexpected any. Specify a different type.",
-      "hintAdded": false,
-      "message": "Unexpected any. Specify a different type.",
-      "nodeKind": "TSAnyKeyword",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts18046}",
+      "hint": "'e' is of type 'unknown'.",
+      "hintAdded": true,
+      "message": "'e' is of type 'unknown'.",
+      "nodeKind": "Identifier",
       "nodeLocation": {
-        "endColumn": 24,
+        "endColumn": 16,
         "endLine": 19,
-        "startColumn": 21,
+        "startColumn": 15,
         "startLine": 19,
       },
-      "nodeText": "",
-      "ruleId": "@typescript-eslint/no-explicit-any",
-      "type": 1,
+      "nodeText": "e",
+      "ruleId": "TS18046",
+      "type": 0,
+    },
+    {
+      "analysisTarget": "ts-processed.ts",
+      "category": "Error",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts18046}",
+      "hint": "'e' is of type 'unknown'.",
+      "hintAdded": true,
+      "message": "'e' is of type 'unknown'.",
+      "nodeKind": "Identifier",
+      "nodeLocation": {
+        "endColumn": 16,
+        "endLine": 21,
+        "startColumn": 15,
+        "startLine": 21,
+      },
+      "nodeText": "e",
+      "ruleId": "TS18046",
+      "type": 0,
     },
     {
       "analysisTarget": "ts-types.ts",

--- a/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.input
+++ b/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.input
@@ -11,13 +11,13 @@ function thisFunctionIsNeverRead(): void {
 }
 
 export function usesMissingFunction(): void {
-  return missingFunction();
+  return whereAmI();
 }
 
 export function usesMissingVariable(): boolean {
   const something = true;
   const existingVar = true;
-  
+
   return something
     ? missingVar
     : existingVar;
@@ -25,7 +25,7 @@ export function usesMissingVariable(): boolean {
 
 export function usesMissingVarWithLongName(): boolean {
   const something = true;
-  
+
   return something
     ? missingVar
     : missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;
@@ -34,16 +34,16 @@ export function usesMissingVarWithLongName(): boolean {
 function notProperlyFormatted(file: string): string {
     return                  doSomething(file);
     }
-    
+
    /**
     * Existing multiline comment
     */
-   function thisFunctionIsACompleteMess(  inSeconds = false):   string { 
+   function thisFunctionIsACompleteMess(  inSeconds = false):   string {
       // Existing comment
       const resolved = resolve('a');
       foo = '6';
       function timestamp(  inMinutes = false): void { const b = null; return 'a'; }
-   
+
    return resolved; }
 
 // The next function call is not properly formatted

--- a/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-errors.ts.output
@@ -1,7 +1,7 @@
 /* Existing comment */
 
 export function usesMissingFunction(): void {
-  return missingFunction();
+  return whereAmI();
 }
 
 export function usesMissingVariable(): boolean {
@@ -25,7 +25,7 @@ export function usesMissingVarWithLongName(): boolean {
 // The next function call is not properly formatted
 timestamp();
 
-function missingFunction(): void {
+function whereAmI(): void {
   throw new Error('Function not implemented.');
 }
 

--- a/packages/upgrade/test/fixtures/upgrade/ts-processed.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-processed.ts.output
@@ -15,6 +15,8 @@ fs.existsSync('@rehearsal');
 try {
   console.log('success');
 } catch (e) {
-  console.log((e as Error).message);
-  console.log((e as any).notErrorMember);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  console.log(e.message);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  console.log(e.notErrorMember);
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.0"
+    "typescript": ">4.9"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
       sort-package-json: ^1.57.0
       tmp: ^0.2.1
       ts-node: ^10.4.0
-      typescript: 4.7.4
+      typescript: ^4.9.4
       vite: ^3.1.3
       vitest: ^0.23.4
       walk-sync: ^3
@@ -75,8 +75,8 @@ importers:
       '@types/semver': 7.3.12
       '@types/tmp': 0.2.3
       '@types/toposort': 2.0.3
-      '@typescript-eslint/eslint-plugin': 5.38.0_kpaatme6gjkpxppst52s4fd23a
-      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/eslint-plugin': 5.38.0_tyfe7wnwk37chcerdjy2hh2xsm
+      '@typescript-eslint/parser': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       '@vitest/coverage-c8': 0.22.1
       commander: 9.4.0
       conventional-changelog-cli: 2.2.2
@@ -96,8 +96,8 @@ importers:
       rimraf: 3.0.2
       sort-package-json: 1.57.0
       tmp: 0.2.1
-      ts-node: 10.9.1_nwm5gnmtj5mpwtqjmit2j7xbtu
-      typescript: 4.7.4
+      ts-node: 10.9.1_j6rjsswqyb5ddbsni7a3exmfve
+      typescript: 4.9.4
       vite: 3.1.3
       vitest: 0.23.4
       walk-sync: 3.0.0
@@ -125,7 +125,7 @@ importers:
       semver: ^7.3.5
       simple-git: ^3.10.0
       tmp: ^0.2.1
-      typescript: 4.5.5
+      typescript: ^4.9.4
       vitest: ^0.23.4
       which: ^2.0.2
       winston: ^3.3.3
@@ -150,11 +150,11 @@ importers:
       semver: 7.3.7
       simple-git: 3.14.1
       tmp: 0.2.1
+      typescript: 4.9.4
       which: 2.0.2
       winston: 3.8.2
     devDependencies:
       '@types/which': 2.0.1
-      typescript: 4.5.5
       vitest: 0.23.4
 
   packages/codefixes:
@@ -327,7 +327,7 @@ importers:
       '@types/sarif': ^2.1.4
       fs-extra: ^10.1.0
       lodash.get: ^4.4.2
-      typescript: 4.7.4
+      typescript: ^4.9.4
       vitest: ^0.23.4
       vitest-mock-extended: ^0.1.15
       winston: ^3.6.0
@@ -340,9 +340,9 @@ importers:
       '@types/sarif': 2.1.4
       fs-extra: 10.1.0
       lodash.get: 4.4.2
-      typescript: 4.7.4
+      typescript: 4.9.4
       vitest: 0.23.4
-      vitest-mock-extended: 0.1.15_zzsy5bxc5pgrmtjy3oqlzxlmt4
+      vitest-mock-extended: 0.1.15_e2tpqlrqckzjr2k5njieez2uhu
 
   packages/service:
     specifiers:
@@ -534,11 +534,11 @@ packages:
       '@types/node': 14.18.29
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 4.1.0_feb72btr37tfl7fqcju5syodfe
+      cosmiconfig-typescript-loader: 4.1.0_ai4x64adgq6mr3veeye5bkb3ke
       lodash: 4.17.21
       resolve-from: 5.0.0
-      ts-node: 10.9.1_zrzawzasyzd3rgfyasecwasbty
-      typescript: 4.7.4
+      ts-node: 10.9.1_lmcauzbjtgmfabsylmujigwkbm
+      typescript: 4.9.4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -1240,7 +1240,7 @@ packages:
     resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.38.0_kpaatme6gjkpxppst52s4fd23a:
+  /@typescript-eslint/eslint-plugin/5.38.0_tyfe7wnwk37chcerdjy2hh2xsm:
     resolution: {integrity: sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1251,22 +1251,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/parser': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       '@typescript-eslint/scope-manager': 5.38.0
-      '@typescript-eslint/type-utils': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      '@typescript-eslint/utils': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/type-utils': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
+      '@typescript-eslint/utils': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       debug: 4.3.4
       eslint: 8.22.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+  /@typescript-eslint/parser/5.38.0_sq327paf6wzcma7omk5wjhfcfa:
     resolution: {integrity: sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1278,10 +1278,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.38.0
       '@typescript-eslint/types': 5.38.0
-      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.9.4
       debug: 4.3.4
       eslint: 8.22.0
-      typescript: 4.7.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1294,7 +1294,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.38.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+  /@typescript-eslint/type-utils/5.38.0_sq327paf6wzcma7omk5wjhfcfa:
     resolution: {integrity: sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1304,12 +1304,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.7.4
-      '@typescript-eslint/utils': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.9.4
+      '@typescript-eslint/utils': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       debug: 4.3.4
       eslint: 8.22.0
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1319,7 +1319,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.38.0_typescript@4.7.4:
+  /@typescript-eslint/typescript-estree/5.38.0_typescript@4.9.4:
     resolution: {integrity: sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1334,13 +1334,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq:
+  /@typescript-eslint/utils/5.38.0_sq327paf6wzcma7omk5wjhfcfa:
     resolution: {integrity: sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1349,7 +1349,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.38.0
       '@typescript-eslint/types': 5.38.0
-      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.38.0_typescript@4.9.4
       eslint: 8.22.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.22.0
@@ -1937,7 +1937,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/4.1.0_feb72btr37tfl7fqcju5syodfe:
+  /cosmiconfig-typescript-loader/4.1.0_ai4x64adgq6mr3veeye5bkb3ke:
     resolution: {integrity: sha512-HbWIuR5O+XO5Oj9SZ5bzgrD4nN+rfhrm2PMb0FVx+t+XIvC45n8F0oTNnztXtspWGw0i2IzHaUWFD5LzV1JB4A==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -1948,8 +1948,8 @@ packages:
     dependencies:
       '@types/node': 14.18.29
       cosmiconfig: 7.0.1
-      ts-node: 10.9.1_zrzawzasyzd3rgfyasecwasbty
-      typescript: 4.7.4
+      ts-node: 10.9.1_lmcauzbjtgmfabsylmujigwkbm
+      typescript: 4.9.4
     dev: true
 
   /cosmiconfig/7.0.1:
@@ -2497,7 +2497,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/parser': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       debug: 3.2.7
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.6
@@ -2527,7 +2527,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.0_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/parser': 5.38.0_sq327paf6wzcma7omk5wjhfcfa
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -4849,15 +4849,15 @@ packages:
     resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
     dev: false
 
-  /ts-essentials/9.3.0_typescript@4.7.4:
+  /ts-essentials/9.3.0_typescript@4.9.4:
     resolution: {integrity: sha512-XeiCboEyBG8UqXZtXl59bWEi4ZgOqRsogFDI6WDGIF1LmzbYiAkIwjkXN6zZWWl4re/lsOqMlYfe8KA0XiiEPw==}
     peerDependencies:
       typescript: '>=4.1.0'
     dependencies:
-      typescript: 4.7.4
+      typescript: 4.9.4
     dev: true
 
-  /ts-node/10.9.1_nwm5gnmtj5mpwtqjmit2j7xbtu:
+  /ts-node/10.9.1_j6rjsswqyb5ddbsni7a3exmfve:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -4883,12 +4883,12 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.7.4
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
-  /ts-node/10.9.1_zrzawzasyzd3rgfyasecwasbty:
+  /ts-node/10.9.1_lmcauzbjtgmfabsylmujigwkbm:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -4914,7 +4914,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.7.4
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -4951,14 +4951,14 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsutils/3.21.0_typescript@4.7.4:
+  /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 4.9.4
     dev: true
 
   /type-check/0.4.0:
@@ -5003,17 +5003,16 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
   /typescript/4.7.4:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
+
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   /uglify-js/3.17.1:
     resolution: {integrity: sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==}
@@ -5114,14 +5113,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest-mock-extended/0.1.15_zzsy5bxc5pgrmtjy3oqlzxlmt4:
+  /vitest-mock-extended/0.1.15_e2tpqlrqckzjr2k5njieez2uhu:
     resolution: {integrity: sha512-XN1quYLdddPTonsULiLvTbLlTQaMKE3aNDkeJlAfYvWaRKjNWXmVcJaELdEfejoC3GFS0cQITLgJwPVPVKh62w==}
     peerDependencies:
       typescript: 3.x || 4.x
       vitest: '>=0.23.1'
     dependencies:
-      ts-essentials: 9.3.0_typescript@4.7.4
-      typescript: 4.7.4
+      ts-essentials: 9.3.0_typescript@4.9.4
+      typescript: 4.9.4
       vitest: 0.23.4
     dev: true
 


### PR DESCRIPTION
This PR bumps typescript to latest, bundles it within the cli and updates tests as needed with new version. Fixes #622 