### PR TITLE
Correct peerDependencies typescript version

### DIFF
--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -38,7 +38,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -41,7 +41,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -42,7 +42,7 @@
     "walk-sync": "^3"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -36,7 +36,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -28,7 +28,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -36,7 +36,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -39,7 +39,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "volta": {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -42,7 +42,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
     "vitest": "^0.23.4"
   },
   "peerDependencies": {
-    "typescript": ">4.9"
+    "typescript": "^4.9 || ^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {


### PR DESCRIPTION
Should fix this:

```
everbits-mn2:urn-utils everbits$ yarn explain peer-requirements pfd5be
➤ YN0000: @rehearsal/cli@npm:1.0.2-beta::...1.0.2-beta.tgz provides typescript@patch:typescript@npm::version=4.9.4&hash=7ad353 with version 4.9.4, which doesn't satisfy the following requirements:

➤ YN0000: @rehearsal/codefixes@npm:1.0.2-beta::...1.0.2-beta.tgz [ffb00] → >4.9 ✘
➤ YN0000: @rehearsal/migrate@npm:1.0.2-beta::...1.0.2-beta.tgz [7f7d8]       → >4.9 ✘
➤ YN0000: @rehearsal/plugins@npm:1.0.2-beta::...1.0.2-beta.tgz [5abd3]       → >4.9 ✘
```

https://jubianchi.github.io/semver-check/#/^4.9%20||%20^5.0/4.9.4
https://jubianchi.github.io/semver-check/#/^4.9%20||%20^5.0/5.0.1

Added 5.0 in advance :)