### PR TITLE
fix: package manager version conflict with volta

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -191,6 +191,28 @@ export function isPnpmManager(): boolean {
   return !!pnpmPath;
 }
 
+// Check if a binary exists and if it's executable
+export function isBinExisted(binName: string): boolean {
+  try {
+    which.sync(binName);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Get the binary path for a package manager
+export function getManagerBinPath(
+  manager: 'yarn' | 'npm' | 'pnpm',
+  hasVolta: boolean = isBinExisted('volta')
+): string {
+  if (hasVolta && manager !== 'pnpm') {
+    return execa.sync('volta', ['which', manager]).stdout;
+  } else {
+    return which.sync(manager);
+  }
+}
+
 export function getLockfilePath(): string | null {
   const yarnPath = findup('yarn.lock', {
     cwd: process.cwd(),
@@ -239,7 +261,7 @@ export function getModuleManagerInstaller(
   depList: string[],
   isDev: boolean
 ): { bin: string; args: string[] } {
-  const bin = which.sync(manager);
+  const bin = getManagerBinPath(manager);
 
   switch (manager) {
     case 'yarn':
@@ -299,7 +321,7 @@ export async function getPathToBinary(
   const moduleManager = getModuleManager();
   // /Users/foo/.volta/bin/yarn
   // /usr/local/bin/pnpm
-  const moduleManagerBin = which.sync(moduleManager);
+  const moduleManagerBin = getManagerBinPath(moduleManager);
 
   let stdoutMsg;
 

--- a/packages/cli/test/helpers/utils.test.ts
+++ b/packages/cli/test/helpers/utils.test.ts
@@ -11,6 +11,8 @@ import {
   getPathToBinary,
   isPnpmManager,
   isYarnManager,
+  isBinExisted,
+  getManagerBinPath,
   normalizeVersionString,
   sleep,
   timestamp,
@@ -69,6 +71,24 @@ describe('utils', () => {
     const isPnpm = isPnpmManager();
 
     expect(isPnpm).equal(true);
+  });
+
+  test('isBinExisted()', () => {
+    expect(isBinExisted('ls')).equal(true);
+    expect(isBinExisted('this-should-not-exist')).equal(false);
+  });
+
+  test('getManagerBinPath()', () => {
+    // TODO: Add test scenarios if volta exists
+    // Haven't came up with a quick and good way to do it
+    const npmBinPath = execa.sync('which', ['npm']).stdout;
+    expect(getManagerBinPath('npm', false)).toBe(npmBinPath);
+
+    const yarnBinPath = execa.sync('which', ['yarn']).stdout;
+    expect(getManagerBinPath('yarn', false)).toBe(yarnBinPath);
+
+    const pnpmBinPath = execa.sync('which', ['pnpm']).stdout;
+    expect(getManagerBinPath('pnpm', false)).toBe(pnpmBinPath);
   });
 
   test('getModuleManager()', () => {


### PR DESCRIPTION
For #644.

If a project is using `npm` or `yarn` with `volta`, use `volta which npm/yarn` to get the path of the manager bin path, instead of `which npm/yarn`.