### PR TITLE
chore: release script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,5 +58,5 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': ['off'],
     '@typescript-eslint/no-inferrable-types': ['off'],
   },
-  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*'],
+  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*', 'release.js'],
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "pnpm recursive run test",
     "changelog": "pnpm conventional-changelog -i CHANGELOG.md -s",
     "clean": "find . -name 'node_modules' -o -name 'dist' -o -name 'coverage' -type d -prune -exec rm -rf '{}' +",
-    "reset": "pnpm clean && pnpm install"
+    "reset": "pnpm clean && pnpm install",
+    "release": "node release.js"
   },
   "commitlint": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.8",
     "sort-package-json": "^1.57.0",
     "tmp": "^0.2.1",
     "ts-node": "^10.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@microsoft/api-documenter": "^7.13.68",

--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -27,7 +27,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/utils": "workspace:*"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -26,7 +26,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/plugins": "workspace:*",

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/migration-graph-shared": "workspace:*",

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "version": "pnpm version"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -12,7 +12,8 @@
     "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/migration-graph-ember": "workspace:*",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -26,7 +26,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/codefixes": "workspace:*",

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -24,7 +24,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "winston": "^3.6.0"

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -26,7 +26,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/reporter": "workspace:*",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -18,7 +18,8 @@
     "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@types/lodash.merge": "^4.6.7",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -26,7 +26,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "dependencies": {
     "@rehearsal/codefixes": "workspace:*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,7 +28,8 @@
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",
-    "test:watch": "vitest --coverage --watch"
+    "test:watch": "vitest --coverage --watch",
+    "version": "pnpm version"
   },
   "devDependencies": {
     "vitest": "^0.23.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
       pre-commit: ^1.2.2
       prettier: ^2.7.1
       rimraf: ^3.0.2
+      semver: ^7.3.8
       sort-package-json: ^1.57.0
       tmp: ^0.2.1
       ts-node: ^10.4.0
@@ -94,6 +95,7 @@ importers:
       pre-commit: 1.2.2
       prettier: 2.7.1
       rimraf: 3.0.2
+      semver: 7.3.8
       sort-package-json: 1.57.0
       tmp: 0.2.1
       ts-node: 10.9.1_j6rjsswqyb5ddbsni7a3exmfve
@@ -801,7 +803,7 @@ packages:
       colors: 1.2.5
       lodash: 4.17.21
       resolve: 1.17.0
-      semver: 7.3.7
+      semver: 7.3.8
       source-map: 0.6.1
       typescript: 4.7.4
     dev: true
@@ -847,7 +849,7 @@ packages:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.17.0
-      semver: 7.3.7
+      semver: 7.3.8
       z-schema: 5.0.4
 
   /@rushstack/rig-package/0.3.15:
@@ -1259,7 +1261,7 @@ packages:
       eslint: 8.22.0
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.9.4
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -1333,7 +1335,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.9.4
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -3927,7 +3929,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.10.0
-      semver: 7.3.7
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -4483,7 +4485,7 @@ packages:
     resolution: {integrity: sha512-azXRSvTHW8a0IE6+cTS+otCcHwu/Y4jcKTL7GVR4ZRJN9gdoSx/chw77IYlmoxvOr3q4RrsGMmo8GiJxijhnHw==}
     engines: {node: ^12||^14||>=16}
     dependencies:
-      semver: 7.3.7
+      semver: 7.3.8
 
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -4497,6 +4499,13 @@ packages:
 
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:

--- a/release.js
+++ b/release.js
@@ -1,0 +1,116 @@
+// exec with `node release.js [major|minor|patch|prerelease|version] [alpha|beta|etc]`
+
+const { execSync } = require('node:child_process');
+const { argv } = require('node:process');
+const semver = require('semver');
+const { version } = require('./packages/cli/package.json');
+
+const [_bin, _file, ...args] = argv;
+const [release, prerelease] = args;
+
+const invalidVersionMessage =
+  'specify a version OR version increment "major", "minor", "patch" OR "prerelease" with prerelease identifier eg. "alpha", "beta"';
+
+if (args.length < 1 || args.length >= 3) {
+  throw new Error(invalidVersionMessage);
+}
+
+const newVersion = getNewReleaseVersion();
+
+function getNewReleaseVersion() {
+  if (
+    release === 'major' ||
+    release === 'minor' ||
+    release === 'patch' ||
+    release === 'prerelease'
+  ) {
+    return semver.inc(version, release, prerelease);
+  } else if (semver.valid(release)) {
+    return release;
+  }
+}
+
+// confirm the version is good
+console.log(`The current version is ${version}`);
+console.log(`The new version will be ${newVersion}`);
+
+// wait for user to confirm
+const rl = require('node:readline').createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.question('Is this correct? YES will publish. NO will abort. (y/n) ', (answer) => {
+  if (answer.toLocaleLowerCase() === 'y' || answer.toLocaleLowerCase() === 'yes') {
+    console.log('Releasing...');
+    publish();
+  } else {
+    console.log('Aborting release');
+  }
+  rl.close();
+});
+
+function publish() {
+  // git reset
+  // const gitReset = `git reset --hard`;
+  // console.log(gitReset);
+  // execSync(gitReset);
+
+  // // git clean
+  // const gitClean = `git clean -fdx`;
+  // console.log(gitClean);
+  // execSync(gitClean);
+
+  // replace the version in package json on all packages with version
+  const bumpVersion = `pnpm -r version ${newVersion} --exact --no-git-tag-version`;
+  console.log(bumpVersion);
+  execSync(bumpVersion);
+
+  // pnpm install recursive
+  // const pnpmInstall = `pnpm -r install`;
+  // console.log(pnpmInstall);
+  // execSync(pnpmInstall);
+
+  // pnpm build recursive
+  // const pnpmBuild = `pnpm -r build`;
+  // console.log(pnpmBuild);
+  // execSync(pnpmBuild);
+
+  // pnpm test
+  // const pnpmTest = `pnpm test`;
+  // console.log(pnpmTest);
+  // execSync(pnpmTest);
+
+  // generate a changelog
+  // const pnpmChangelog = `pnpm changelog`;
+  // console.log(pnpmChangelog);
+  // execSync(pnpmChangelog);
+
+  // commit everything
+  // const gitCommit = `git commit -am "release: ${newVersion}"`;
+  // console.log(gitCommit);
+  // execSync(gitCommit);
+
+  // push it
+  // const gitPush = `git push`;
+  // console.log(gitPush);
+  // execSync(gitPush);
+
+  // git tag
+  // const gitTag = `git tag ${version}`;
+  // console.log(gitTag);
+  // execSync(gitTag);
+
+  // push tags
+  // const gitPushTags = `git push origin --tags`;
+  // console.log(gitPushTags);
+  // execSync(gitPushTags);
+
+  // publish
+  // const pnpmPublish = `pnpm -r publish`;
+  // console.log(pnpmPublish);
+  // execSync(pnpmPublish);
+
+  // done
+  console.log(`Released ${newVersion}`);
+}

--- a/release.js
+++ b/release.js
@@ -42,7 +42,7 @@ const rl = require('node:readline').createInterface({
 
 rl.question('Is this correct? YES will publish. NO will abort. (y/n) ', (answer) => {
   if (answer.toLocaleLowerCase() === 'y' || answer.toLocaleLowerCase() === 'yes') {
-    console.log('Releasing...');
+    console.log('Releasing...\n\n');
     publish();
   } else {
     console.log('Aborting release');
@@ -52,14 +52,14 @@ rl.question('Is this correct? YES will publish. NO will abort. (y/n) ', (answer)
 
 function publish() {
   // git reset
-  // const gitReset = `git reset --hard`;
-  // console.log(gitReset);
-  // execSync(gitReset);
+  const gitReset = `git reset --hard`;
+  console.log(gitReset);
+  execSync(gitReset);
 
-  // // git clean
-  // const gitClean = `git clean -fdx`;
-  // console.log(gitClean);
-  // execSync(gitClean);
+  // git clean
+  const gitClean = `git clean -fdx`;
+  console.log(gitClean);
+  execSync(gitClean);
 
   // replace the version in package json on all packages with version
   const bumpVersion = `pnpm -r version ${newVersion} --exact --no-git-tag-version`;
@@ -67,50 +67,50 @@ function publish() {
   execSync(bumpVersion);
 
   // pnpm install recursive
-  // const pnpmInstall = `pnpm -r install`;
-  // console.log(pnpmInstall);
-  // execSync(pnpmInstall);
+  const pnpmInstall = `pnpm -r install`;
+  console.log(pnpmInstall);
+  execSync(pnpmInstall);
 
   // pnpm build recursive
-  // const pnpmBuild = `pnpm -r build`;
-  // console.log(pnpmBuild);
-  // execSync(pnpmBuild);
+  const pnpmBuild = `pnpm -r build`;
+  console.log(pnpmBuild);
+  execSync(pnpmBuild);
 
   // pnpm test
-  // const pnpmTest = `pnpm test`;
-  // console.log(pnpmTest);
-  // execSync(pnpmTest);
+  const pnpmTest = `pnpm test`;
+  console.log(pnpmTest);
+  execSync(pnpmTest);
 
   // generate a changelog
-  // const pnpmChangelog = `pnpm changelog`;
-  // console.log(pnpmChangelog);
-  // execSync(pnpmChangelog);
+  const pnpmChangelog = `pnpm changelog`;
+  console.log(pnpmChangelog);
+  execSync(pnpmChangelog);
 
   // commit everything
-  // const gitCommit = `git commit -am "release: ${newVersion}"`;
-  // console.log(gitCommit);
-  // execSync(gitCommit);
+  const gitCommit = `git commit -am "release: ${newVersion}"`;
+  console.log(gitCommit);
+  execSync(gitCommit);
 
   // push it
-  // const gitPush = `git push`;
-  // console.log(gitPush);
-  // execSync(gitPush);
+  const gitPush = `git push`;
+  console.log(gitPush);
+  execSync(gitPush);
 
   // git tag
-  // const gitTag = `git tag ${version}`;
-  // console.log(gitTag);
-  // execSync(gitTag);
+  const gitTag = `git tag ${version}`;
+  console.log(gitTag);
+  execSync(gitTag);
 
   // push tags
-  // const gitPushTags = `git push origin --tags`;
-  // console.log(gitPushTags);
-  // execSync(gitPushTags);
+  const gitPushTags = `git push origin --tags`;
+  console.log(gitPushTags);
+  execSync(gitPushTags);
 
   // publish
-  // const pnpmPublish = `pnpm -r publish`;
-  // console.log(pnpmPublish);
-  // execSync(pnpmPublish);
+  const pnpmPublish = `pnpm -r publish`;
+  console.log(pnpmPublish);
+  execSync(pnpmPublish);
 
   // done
-  console.log(`Released ${newVersion}`);
+  console.log(`Released ${newVersion} has been published`);
 }


### PR DESCRIPTION
This PR fixes #620 and provides an easier method of publishing. NPM permissions are required for publishing and recursive monorepo publishing is supported.

The script is executed at the root monorepo directory via:

```
pnpm release [major|minor|patch|prerelease|version] [alpha|beta|etc]
```

OR 

```
node release.js [major|minor|patch|prerelease|version] [alpha|beta|etc]
```