### PR TITLE
feat: add --regen option

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "@microsoft/api-documenter": "^7.13.68",
     "@rehearsal/migrate": "workspace:*",
     "@rehearsal/migration-graph": "workspace:*",
+    "@rehearsal/regen": "workspace:*",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/upgrade": "workspace:*",
     "chalk": "^4.1.2",

--- a/packages/cli/src/commands/migrate/tasks/index.ts
+++ b/packages/cli/src/commands/migrate/tasks/index.ts
@@ -4,3 +4,4 @@ export * from './dependency-install';
 export * from './initialize';
 export * from './config-ts';
 export * from './create-scripts';
+export * from './regen';

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -1,0 +1,45 @@
+import { resolve } from 'path';
+import { Logger } from 'winston';
+import { Reporter } from '@rehearsal/reporter';
+import { regen } from '@rehearsal/regen';
+import execa = require('execa');
+
+import { generateReports, getRegenSummary } from '../../../helpers/report';
+import { determineProjectName, getPathToBinary } from '../../../utils';
+import type { ListrTask } from 'listr2';
+
+import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
+
+export async function regenTask(
+  options: MigrateCommandOptions,
+  logger: Logger
+): Promise<ListrTask> {
+  return {
+    title: 'Regenerating report for TS errors and Eslint errors',
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    task: async (_: MigrateCommandContext, task): Promise<void> => {
+      const projectName = determineProjectName() || '';
+      const { basePath } = options;
+      const tscPath = await getPathToBinary('tsc');
+      const { stdout } = await execa(tscPath, ['--version']);
+      const tsVersion = stdout.split(' ')[1];
+      const reporter = new Reporter(
+        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate' },
+        logger
+      );
+
+      const input = {
+        basePath,
+        logger: logger,
+        reporter,
+        task,
+      };
+
+      const { scannedFiles } = await regen(input);
+
+      const reportOutputPath = resolve(options.basePath, options.outputPath);
+      generateReports('migrate', reporter, reportOutputPath, options.format);
+      task.title = getRegenSummary(reporter.report, scannedFiles.length);
+    },
+  };
+}

--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -107,6 +107,28 @@ export function getReportSummary(report: Report, migratedFileCount: number): str
   ${totalErrorCount} errors caught by rehearsal\n
   ${report.fixedItemCount} have been fixed by rehearsal\n
   ${totalUnfixedCount} errors need to be fixed manually\n
-  \t\t-- ${tsErrorCount} ts errors, marked by @ts-expect-error @rehearsal TODO\n
-  \t\t-- ${lintErrorCount} eslint errors, with details in the report\n`;
+    -- ${tsErrorCount} ts errors, marked by @ts-expect-error @rehearsal TODO\n
+    -- ${lintErrorCount} eslint errors, with details in the report\n`;
+}
+
+export function getRegenSummary(report: Report, scannedFileCount: number): string {
+  const fileMap = new Set<string>();
+  let tsErrorCount = 0;
+  let lintErrorCount = 0;
+
+  report.items.forEach((item) => {
+    fileMap.add(item.analysisTarget);
+    if (item.hintAdded) {
+      tsErrorCount++;
+    } else {
+      lintErrorCount++;
+    }
+  });
+  const totalErrorCount = report.items.length;
+
+  return `Migration Report Generated\n\n
+  ${scannedFileCount} ts files have been scanned\n
+  ${totalErrorCount} errors caught by rehearsal\n
+    -- ${tsErrorCount} ts errors, marked by @ts-expect-error @rehearsal TODO\n
+    -- ${lintErrorCount} eslint errors, with details in the report\n`;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -15,6 +15,7 @@ export type MigrateCommandOptions = {
   userConfig: string | undefined;
   interactive: boolean | undefined;
   dryRun: boolean;
+  regen: boolean | undefined;
 };
 
 export type MigrateCommandContext = {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -7,6 +7,7 @@ import { type SimpleGit, type SimpleGitOptions, simpleGit } from 'simple-git';
 import which from 'which';
 import { InvalidArgumentError } from 'commander';
 import chalk from 'chalk';
+import { glob } from 'glob';
 
 import findup = require('findup-sync');
 import execa = require('execa');
@@ -507,4 +508,10 @@ export function prettyGitDiff(text: string): string {
       return line;
     })
     .join('\n');
+}
+
+export function getLintConfigPath(basePath: string): string {
+  // glob against the following file extension pattern js,yml,json,yaml and return the first match
+  const configPath = glob.sync(join(basePath, '.eslintrc.{js,yml,json,yaml}'))[0];
+  return configPath;
 }

--- a/packages/regen/package.json
+++ b/packages/regen/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@rehearsal/regen",
+  "version": "1.0.4-beta",
+  "description": "Rehearsal JavaScript to TypeScript migration status reporting tool",
+  "keywords": [
+    "rehearsal",
+    "migrate",
+    "migration",
+    "javascript",
+    "typescript",
+    "reporting"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rehearsal-js/rehearsal-js.git"
+  },
+  "license": "BSD-2-Clause",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "npm-run-all lint:*",
+    "lint:eslint": "eslint --fix . --ext .ts",
+    "lint:tsc-src": "tsc --noEmit",
+    "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
+    "test": "vitest --run",
+    "test:watch": "vitest --coverage --watch"
+  },
+  "dependencies": {
+    "@rehearsal/plugins": "workspace:*",
+    "@rehearsal/reporter": "workspace:*",
+    "@rehearsal/service": "workspace:*",
+    "@rehearsal/utils": "workspace:*",
+    "debug": "^4.3.2",
+    "execa": "^5.1.1",
+    "winston": "^3.6.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "@typescript-eslint/parser": "^5.36.2",
+    "eslint-config-prettier": "^8.5.0",
+    "fs-extra": "^11.1.0",
+    "listr2": "^5.0.5",
+    "prettier": "^2.8.3",
+    "vitest": "^0.23.4"
+  },
+  "peerDependencies": {
+    "typescript": ">4.0"
+  },
+  "packageManager": "pnpm@7.12.1",
+  "engines": {
+    "node": ">=14.16.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/regen/src/index.ts
+++ b/packages/regen/src/index.ts
@@ -1,0 +1,1 @@
+export { regen, RegenInput } from './regen';

--- a/packages/regen/src/regen.ts
+++ b/packages/regen/src/regen.ts
@@ -1,0 +1,90 @@
+import { dirname, resolve } from 'path';
+import { RehearsalService } from '@rehearsal/service';
+import {
+  ReRehearsePlugin,
+  LintFixPlugin,
+  DiagnosticCheckPlugin,
+  LintCheckPlugin,
+} from '@rehearsal/plugins';
+import { findConfigFile, parseJsonConfigFileContent, readConfigFile, sys } from 'typescript';
+import type { Reporter } from '@rehearsal/reporter';
+import type { Logger } from 'winston';
+import type { ListrContext } from 'listr2';
+
+export type RegenInput = {
+  basePath: string;
+  configName?: string;
+  reporter: Reporter;
+  logger?: Logger;
+  task?: ListrContext;
+};
+
+export type RegenOutput = {
+  basePath: string;
+  configFile: string;
+  scannedFiles: Array<string>;
+};
+
+export async function regen(input: RegenInput): Promise<RegenOutput> {
+  const basePath = resolve(input.basePath);
+  const configName = input.configName || 'tsconfig.json';
+  const reporter = input.reporter;
+  const logger = input.logger;
+  // output is only for tests
+  const listrTask = input.task || { output: '' };
+
+  const plugins = [
+    ReRehearsePlugin,
+    LintFixPlugin,
+    DiagnosticCheckPlugin,
+    LintFixPlugin,
+    LintCheckPlugin,
+  ];
+
+  logger?.debug('migration regen started');
+  logger?.debug(`Base path: ${basePath}`);
+
+  const configFile = findConfigFile(basePath, sys.fileExists, configName);
+
+  if (!configFile) {
+    const message = `Config file '${configName}' not found in '${basePath}'`;
+    logger?.error(message);
+    throw Error(message);
+  }
+
+  logger?.debug(`config file: ${configFile}`);
+
+  const { config } = readConfigFile(configFile, sys.readFile);
+
+  const { options, fileNames } = parseJsonConfigFileContent(
+    config,
+    sys,
+    dirname(configFile),
+    {},
+    configFile
+  );
+
+  logger?.debug(`fileNames: ${JSON.stringify(fileNames)}`);
+
+  const service = new RehearsalService(options, fileNames);
+
+  for (const fileName of fileNames) {
+    listrTask.output = `processing file: ${fileName.replace(basePath, '')}`;
+
+    let allChangedFiles: Set<string> = new Set();
+
+    for (const pluginClass of plugins) {
+      const plugin = new pluginClass(service, reporter, logger);
+      const changedFiles = await plugin.run(fileName);
+      allChangedFiles = new Set([...allChangedFiles, ...changedFiles]);
+    }
+
+    allChangedFiles.forEach((file) => service.saveFile(file));
+  }
+
+  return {
+    basePath,
+    configFile,
+    scannedFiles: fileNames,
+  };
+}

--- a/packages/regen/test/__snapshots__/index.test.ts.snap
+++ b/packages/regen/test/__snapshots__/index.test.ts.snap
@@ -1,0 +1,85 @@
+// Vitest Snapshot v1
+
+exports[`regen > should generate correct rehearsal comments for a group of files 1`] = `
+"[
+  {
+    \\"analysisTarget\\": \\"tmp/test3.ts\\",
+    \\"type\\": 0,
+    \\"ruleId\\": \\"TS2345\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"Argument of type 'string' is not assignable to parameter of type 'number'.\\",
+    \\"hint\\": \\"Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('5' as string)', or using type guard: 'if ('5' instanceof string) { ... }'.\\",
+    \\"hintAdded\\": true,
+    \\"nodeKind\\": \\"StringLiteral\\",
+    \\"nodeText\\": \\"'5'\\",
+    \\"helpUrl\\": \\"https://stackoverflow.com/questions/42421501/error-ts2345-argument-of-type-t-is-not-assignable-to-parameter-of-type-objec\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 6,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 6,
+      \\"endColumn\\": 8
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test3.ts\\",
+    \\"type\\": 0,
+    \\"ruleId\\": \\"TS2322\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"Type 'number' is not assignable to type 'string'.\\",
+    \\"hint\\": \\"The variable 'baz' has type 'string', but 'number' is assigned. Please convert 'number' to 'string' or change variable's type.\\",
+    \\"hintAdded\\": true,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"baz\\",
+    \\"helpUrl\\": \\"https://stackoverflow.com/questions/72139358/ts2322-type-typeof-statusenum-is-not-assignable-to-type-statusenum\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 10,
+      \\"startColumn\\": 1,
+      \\"endLine\\": 10,
+      \\"endColumn\\": 4
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test3.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"@typescript-eslint/no-unused-vars\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'baz' is assigned a value but never used.\\",
+    \\"hint\\": \\"'baz' is assigned a value but never used.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 10,
+      \\"startColumn\\": 1,
+      \\"endLine\\": 10,
+      \\"endColumn\\": 4
+    }
+  }
+]"
+`;
+
+exports[`regen > should report lint errors 1`] = `
+"[
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"@typescript-eslint/no-explicit-any\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"Unexpected any. Specify a different type.\\",
+    \\"hint\\": \\"Unexpected any. Specify a different type.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"TSAnyKeyword\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 1,
+      \\"startColumn\\": 26,
+      \\"endLine\\": 1,
+      \\"endColumn\\": 29
+    }
+  }
+]"
+`;
+
+exports[`regen > should scan ts files but ignore js files 1`] = `"[]"`;

--- a/packages/regen/test/eslintrc.js
+++ b/packages/regen/test/eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'eslint:recommended',
+    'plugin:prettier/recommended',
+    'prettier',
+  ],
+};

--- a/packages/regen/test/fixtures/output/test1.ts.output
+++ b/packages/regen/test/fixtures/output/test1.ts.output
@@ -1,0 +1,1 @@
+export const DAY_IN_WEEK = 7;

--- a/packages/regen/test/fixtures/output/test3.ts.output
+++ b/packages/regen/test/fixtures/output/test3.ts.output
@@ -1,0 +1,10 @@
+function add(foo: number, bar: number): number {
+  return foo + bar;
+}
+
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('5' as string)', or using type guard: 'if ('5' instanceof string) { ... }'. */
+add('5', 10);
+
+let baz: string = '';
+/* @ts-expect-error @rehearsal TODO TS2322: The variable 'baz' has type 'string', but 'number' is assigned. Please convert 'number' to 'string' or change variable's type. */
+baz = 2;

--- a/packages/regen/test/fixtures/output/test4.ts.output
+++ b/packages/regen/test/fixtures/output/test4.ts.output
@@ -1,0 +1,17 @@
+function printType(num1: any): void {
+  if (typeof num1 === 'number') {
+    console.log('is a number');
+  } else if (typeof num1 === 'string') {
+    console.log('is a string');
+  } else if (Array.isArray(num1)) {
+    console.log('is an array');
+  } else if (num1 === null) {
+    console.log('is null');
+  } else if (typeof num1 === 'object') {
+    console.log('is an object');
+  } else {
+    console.log('we do not know');
+  }
+}
+
+printType(5);

--- a/packages/regen/test/fixtures/src/test1.ts
+++ b/packages/regen/test/fixtures/src/test1.ts
@@ -1,0 +1,1 @@
+export const DAY_IN_WEEK = 7

--- a/packages/regen/test/fixtures/src/test2.js
+++ b/packages/regen/test/fixtures/src/test2.js
@@ -1,0 +1,1 @@
+export const DAY_IN_WEEK = 7;

--- a/packages/regen/test/fixtures/src/test3.ts
+++ b/packages/regen/test/fixtures/src/test3.ts
@@ -1,0 +1,9 @@
+function add(foo: number, bar: number): number {
+  return foo + bar;
+}
+
+/* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('5' as string)', or using type guard: 'if ('5' instanceof string) { ... }'. */
+add('5', 10);
+
+let baz: string = '';
+baz = 2;

--- a/packages/regen/test/fixtures/src/test4.ts
+++ b/packages/regen/test/fixtures/src/test4.ts
@@ -1,0 +1,17 @@
+function printType(num1: any): void {
+  if (typeof num1 === 'number') {
+    console.log('is a number');
+  } else if (typeof num1 === 'string') {
+    console.log('is a string');
+  } else if (Array.isArray(num1)) {
+    console.log('is an array');
+  } else if (num1 === null) {
+    console.log('is null');
+  } else if (typeof num1 === 'object') {
+    console.log('is an object');
+  } else {
+    console.log('we do not know');
+  }
+}
+
+printType(5);

--- a/packages/regen/test/index.test.ts
+++ b/packages/regen/test/index.test.ts
@@ -1,0 +1,124 @@
+import { resolve } from 'path';
+import { copyFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'fs';
+import { Reporter } from '@rehearsal/reporter';
+import { describe, test, beforeEach, afterEach, expect } from 'vitest';
+import { outputFileSync } from 'fs-extra';
+import { regen, RegenInput } from '../src';
+
+const basePath = resolve(__dirname);
+const expectedDir = resolve(basePath, 'fixtures', 'output');
+const srcDir = resolve(basePath, 'fixtures', 'src');
+const generatedDir = resolve(basePath, 'tmp');
+const jsonReportPath = resolve(generatedDir, '.rehearsal-report.json');
+
+let reporter: Reporter;
+let regenInput: RegenInput;
+
+describe('regen', () => {
+  beforeEach(() => {
+    cleanDir(generatedDir);
+    mkdirSync(generatedDir);
+
+    reporter = new Reporter({
+      tsVersion: '',
+      projectName: '@rehearsal/test',
+      basePath,
+      commandName: '@rehearsal/migrate',
+    });
+
+    regenInput = {
+      basePath: resolve(basePath, 'tmp'),
+      reporter,
+    };
+  });
+
+  afterEach(() => {
+    cleanDir(generatedDir);
+  });
+
+  test('should scan files and generate report', async () => {
+    prepareInputFiles(['test1.ts']);
+
+    const { scannedFiles } = await regen(regenInput);
+    expect(scannedFiles.length).toBe(1);
+
+    reporter.save(jsonReportPath);
+    expect(existsSync(jsonReportPath)).toBeTruthy();
+  });
+
+  test('should scan ts files but ignore js files', async () => {
+    prepareInputFiles(['test1.ts', 'test2.js']);
+
+    const { scannedFiles } = await regen(regenInput);
+    expect(scannedFiles.length).toBe(1);
+    expect(scannedFiles[0].includes('test1.ts')).toBeTruthy();
+
+    reporter.save(jsonReportPath);
+    const report = JSON.parse(readFileSync(jsonReportPath).toString());
+    const { items } = report;
+    expect(JSON.stringify(items, null, 2)).toMatchSnapshot();
+
+    expect(fileOutputMatched('test1.ts')).toBeTruthy();
+  });
+
+  test('should generate correct rehearsal comments for a group of files', async () => {
+    prepareInputFiles(['test1.ts', 'test3.ts']);
+
+    const { scannedFiles } = await regen(regenInput);
+    expect(scannedFiles.length).toBe(2);
+
+    reporter.save(jsonReportPath);
+
+    const report = JSON.parse(readFileSync(jsonReportPath).toString());
+    const { items } = report;
+    expect(JSON.stringify(items, null, 2)).toMatchSnapshot();
+
+    expect(fileOutputMatched('test3.ts')).toBeTruthy();
+    expect(fileOutputMatched('test1.ts')).toBeTruthy();
+  });
+
+  test('should report lint errors', async () => {
+    prepareInputFiles(['test4.ts']);
+
+    const { scannedFiles } = await regen(regenInput);
+    expect(scannedFiles.length).toBe(1);
+    reporter.save(jsonReportPath);
+
+    const report = JSON.parse(readFileSync(jsonReportPath).toString());
+    const { items } = report;
+    expect(JSON.stringify(items, null, 2)).toMatchSnapshot();
+
+    expect(fileOutputMatched('test4.ts')).toBeTruthy();
+  });
+});
+
+function fileOutputMatched(filename: string): boolean {
+  const generatedFile = resolve(generatedDir, filename);
+  const generatedContent = readFileSync(generatedFile, 'utf-8');
+  const expectedContent = readFileSync(`${expectedDir}/${filename}.output`, 'utf-8');
+  return generatedContent === expectedContent;
+}
+
+function prepareInputFiles(srcFiles: string[]): string[] {
+  createTSConfig(generatedDir);
+  return srcFiles.map((file) => {
+    const originalPath = resolve(srcDir, file);
+    const generatedPath = resolve(generatedDir, file);
+    copyFileSync(originalPath, generatedPath);
+    return generatedPath;
+  });
+}
+
+function createTSConfig(dir: string): void {
+  const configStr = `{
+    "extends": "../tsconfig",
+    "include": ["."]
+  }
+  `;
+  const configPath = resolve(dir, 'tsconfig.json');
+  outputFileSync(configPath, configStr);
+}
+
+function cleanDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/regen/test/tsconfig.json
+++ b/packages/regen/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "rootDir": "../",
+    "outDir": "../dist/test/"
+  },
+  "exclude": ["fixtures"],
+  "include": [".", "../src"]
+}

--- a/packages/regen/tsconfig.json
+++ b/packages/regen/tsconfig.json
@@ -3,22 +3,21 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src", "package.json"],
+  "include": [
+    "src"
+  ],
   "references": [
     {
-      "path": "../migrate"
-    },
-    {
-      "path": "../migration-graph"
+      "path": "../plugins",
     },
     {
       "path": "../reporter"
     },
     {
-      "path": "../upgrade"
+      "path": "../service"
     },
     {
-      "path": "../regen"
+      "path": "../utils"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,7 @@ importers:
       '@microsoft/api-documenter': ^7.13.68
       '@rehearsal/migrate': workspace:*
       '@rehearsal/migration-graph': workspace:*
+      '@rehearsal/regen': workspace:*
       '@rehearsal/reporter': workspace:*
       '@rehearsal/upgrade': workspace:*
       '@types/which': ^2.0.1
@@ -135,6 +136,7 @@ importers:
       '@microsoft/api-documenter': 7.19.14
       '@rehearsal/migrate': link:../migrate
       '@rehearsal/migration-graph': link:../migration-graph
+      '@rehearsal/regen': link:../regen
       '@rehearsal/reporter': link:../reporter
       '@rehearsal/upgrade': link:../upgrade
       chalk: 4.1.2
@@ -319,6 +321,39 @@ importers:
     devDependencies:
       '@types/eslint': 8.4.6
       fixturify-project: 5.1.0
+      vitest: 0.23.4
+
+  packages/regen:
+    specifiers:
+      '@rehearsal/plugins': workspace:*
+      '@rehearsal/reporter': workspace:*
+      '@rehearsal/service': workspace:*
+      '@rehearsal/utils': workspace:*
+      '@typescript-eslint/eslint-plugin': ^5.36.2
+      '@typescript-eslint/parser': ^5.36.2
+      debug: ^4.3.2
+      eslint-config-prettier: ^8.5.0
+      execa: ^5.1.1
+      fs-extra: ^11.1.0
+      listr2: ^5.0.5
+      prettier: ^2.8.3
+      vitest: ^0.23.4
+      winston: ^3.6.0
+    dependencies:
+      '@rehearsal/plugins': link:../plugins
+      '@rehearsal/reporter': link:../reporter
+      '@rehearsal/service': link:../service
+      '@rehearsal/utils': link:../utils
+      debug: 4.3.4
+      execa: 5.1.1
+      winston: 3.8.2
+    devDependencies:
+      '@typescript-eslint/eslint-plugin': 5.38.0_okw6xx5qjyfhpzrnewspg4ahrm
+      '@typescript-eslint/parser': 5.38.0
+      eslint-config-prettier: 8.5.0
+      fs-extra: 11.1.0
+      listr2: 5.0.5
+      prettier: 2.8.3
       vitest: 0.23.4
 
   packages/reporter:
@@ -1242,6 +1277,30 @@ packages:
     resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
     dev: true
 
+  /@typescript-eslint/eslint-plugin/5.38.0_okw6xx5qjyfhpzrnewspg4ahrm:
+    resolution: {integrity: sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.38.0
+      '@typescript-eslint/scope-manager': 5.38.0
+      '@typescript-eslint/type-utils': 5.38.0
+      '@typescript-eslint/utils': 5.38.0
+      debug: 4.3.4
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.8
+      tsutils: 3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin/5.38.0_tyfe7wnwk37chcerdjy2hh2xsm:
     resolution: {integrity: sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1264,6 +1323,24 @@ packages:
       semver: 7.3.8
       tsutils: 3.21.0_typescript@4.9.4
       typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser/5.38.0:
+    resolution: {integrity: sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.38.0
+      '@typescript-eslint/types': 5.38.0
+      '@typescript-eslint/typescript-estree': 5.38.0
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1296,6 +1373,24 @@ packages:
       '@typescript-eslint/visitor-keys': 5.38.0
     dev: true
 
+  /@typescript-eslint/type-utils/5.38.0:
+    resolution: {integrity: sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.38.0
+      '@typescript-eslint/utils': 5.38.0
+      debug: 4.3.4
+      tsutils: 3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/type-utils/5.38.0_sq327paf6wzcma7omk5wjhfcfa:
     resolution: {integrity: sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1321,6 +1416,26 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.38.0:
+    resolution: {integrity: sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.38.0
+      '@typescript-eslint/visitor-keys': 5.38.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.38.0_typescript@4.9.4:
     resolution: {integrity: sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1340,6 +1455,23 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.38.0:
+    resolution: {integrity: sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.38.0
+      '@typescript-eslint/types': 5.38.0
+      '@typescript-eslint/typescript-estree': 5.38.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /@typescript-eslint/utils/5.38.0_sq327paf6wzcma7omk5wjhfcfa:
@@ -2460,6 +2592,13 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  /eslint-config-prettier/8.5.0:
+    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dev: true
+
   /eslint-config-prettier/8.5.0_eslint@8.22.0:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
@@ -2581,6 +2720,15 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
+  /eslint-utils/3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint-visitor-keys: 2.1.0
+    dev: true
 
   /eslint-utils/3.0.0_eslint@8.22.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
@@ -2957,6 +3105,15 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
+
+  /fs-extra/11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
 
   /fs-extra/7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -4230,6 +4387,12 @@ packages:
     hasBin: true
     dev: true
 
+  /prettier/2.8.3:
+    resolution: {integrity: sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
   /process-nextick-args/2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: true
@@ -4959,6 +5122,15 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
+  /tsutils/3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+    dev: true
 
   /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
     },
     {
       "path": "./packages/utils"
+    },
+    {
+      "path": "./packages/regen"
     }
   ]
 }


### PR DESCRIPTION
Closes #438 

1. regenerate migration report, with or without uncommitted code changes
2. check if ts config and eslint config exist before generating report
3. scan ts files to check for errors
4. what regen does: 
  - remove existing rehearsal comments
  - check ts errors and insert comments
  - reformatting
  - check lint errors
  - sending ts errors and lint errors to reporter

<img width="523" alt="Screenshot 2023-01-24 at 8 58 55 PM" src="https://user-images.githubusercontent.com/26440597/214484988-861e6696-2e48-44a6-b6c9-db32552e5d6a.png">
