### PR TITLE
feat(migration-graph): include exclude config

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "yaml": "^2.2.1"
   },
   "devDependencies": {
+    "@rehearsal/test-support": "workspace:*",
     "@types/which": "^2.0.1",
     "typescript": "^4.9.5",
     "typescript-json-schema": "^0.55.0",

--- a/packages/cli/rehearsal-config-schema.json
+++ b/packages/cli/rehearsal-config-schema.json
@@ -1,60 +1,86 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "migrate": {
-            "properties": {
-                "install": {
+    "definitions": {
+        "MigrateCommandConfig": {
+            "allOf": [
+                {
                     "properties": {
-                        "dependencies": {
-                            "items": {
-                                "type": "string"
+                        "install": {
+                            "properties": {
+                                "dependencies": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "devDependencies": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
                             },
-                            "type": "array"
+                            "type": "object"
                         },
-                        "devDependencies": {
-                            "items": {
-                                "type": "string"
+                        "setup": {
+                            "properties": {
+                                "lint": {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "ts": {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
                             },
-                            "type": "array"
+                            "type": "object"
                         }
                     },
                     "type": "object"
                 },
-                "setup": {
+                {
                     "properties": {
-                        "lint": {
-                            "properties": {
-                                "args": {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                "command": {
-                                    "type": "string"
-                                }
+                        "exclude": {
+                            "items": {
+                                "type": "string"
                             },
-                            "type": "object"
+                            "type": "array"
                         },
-                        "ts": {
-                            "properties": {
-                                "args": {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                "command": {
-                                    "type": "string"
-                                }
+                        "include": {
+                            "items": {
+                                "type": "string"
                             },
-                            "type": "object"
+                            "type": "array"
                         }
                     },
                     "type": "object"
                 }
-            },
-            "type": "object"
+            ]
+        }
+    },
+    "properties": {
+        "migrate": {
+            "$ref": "#/definitions/MigrateCommandConfig"
         },
         "upgrade": {
             "properties": {

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -118,6 +118,8 @@ export async function initTask(
       // construct migration strategy and prepare all the files needs to be migrated
       const strategy = getMigrationStrategy(ctx.targetPackagePath, {
         entrypoint: options.entrypoint,
+        exclude: userConfig?.exclude,
+        include: userConfig?.include,
       });
       const files: SourceFile[] = strategy.getMigrationOrder();
       DEBUG_CALLBACK(

--- a/packages/cli/src/configs/rehearsal-config.ts
+++ b/packages/cli/src/configs/rehearsal-config.ts
@@ -18,9 +18,18 @@ export type CustomCommandConfig = {
   setup?: SetupConfig;
 };
 
+export type MigrateCommandConfig = CustomCommandConfig & {
+  include?: string[];
+  exclude?: string[];
+};
+
+export type UpgradeCommandConfig = CustomCommandConfig;
+
+export type CommandConfig = UpgradeCommandConfig | MigrateCommandConfig;
+
 export interface IRehearsalConfig {
-  upgrade?: CustomCommandConfig;
-  migrate?: CustomCommandConfig;
+  upgrade?: UpgradeCommandConfig;
+  migrate?: MigrateCommandConfig;
 }
 
 export type CustomConfig = IRehearsalConfig;

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -62,4 +62,12 @@ export class UserConfig {
       await execa(command, args, { cwd: this.basePath });
     }
   }
+
+  get exclude(): Array<string> | undefined {
+    return this.config?.exclude;
+  }
+
+  get include(): Array<string> | undefined {
+    return this.config?.include;
+  }
 }

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -24,7 +24,7 @@ exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
-exports[`migrate: e2e > Print debug messages with verbose 1`] = `
+exports[`migrate: e2e > Print debug messages with --verbose 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project
 [SUCCESS] Validate project
@@ -70,98 +70,6 @@ debug:   fileNames: [\\"<tmp-path>/foo.ts\\",\\"<tmp-path>/depends-on-foo.ts\\",
 
 exports[`migrate: e2e > againt specific basePath via --basePath option 1`] = `
 "info:    @rehearsal/migrate<test-version>
-[STARTED] Initialize
-[DATA] Running migration on base
-[SUCCESS] Initialize
-[STARTED] Install dependencies
-[SUCCESS] Install dependencies
-[STARTED] Create tsconfig.json
-[SUCCESS] Create tsconfig.json
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default typescript-related config
-[SUCCESS] Create eslint config
-[STARTED] Add package scripts
-[SUCCESS] Add package scripts
-[STARTED] Convert JS files to TS
-[DATA] git mv /index.js to /index.ts
-[DATA] processing file: /index.ts
-[TITLE] Migration Complete
-[TITLE]   1 JS file converted to TS
-[TITLE]   7 errors caught by rehearsal
-[TITLE]   3 have been fixed by rehearsal
-[TITLE]   4 errors need to be fixed manually
-[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 4 eslint errors, with details in the report
-[SUCCESS] Migration Complete
-[SUCCESS]   1 JS file converted to TS
-[SUCCESS]   7 errors caught by rehearsal
-[SUCCESS]   3 have been fixed by rehearsal
-[SUCCESS]   4 errors need to be fixed manually
-[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 4 eslint errors, with details in the report"
-`;
-
-exports[`migrate: e2e > againt specific basePath via --basePath option 2`] = `
-"export function run(baz: any) {
-  return foo(baz);
-}
-
-function foo(_baz: any) {
-  throw new Error(\\"Function not implemented.\\");
-}
-"
-`;
-
-exports[`migrate: e2e > againt specific basePath via --basePath option 3`] = `
-{
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "es2020",
-    "moduleResolution": "node",
-    "newLine": "lf",
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "strict": true,
-    "target": "ES2021",
-  },
-  "include": [
-    "index.ts",
-  ],
-}
-`;
-
-exports[`migrate: e2e > againt specific basePath via --basePath option 4`] = `
-"module.exports = {
-  extends: [\\"./.rehearsal-eslintrc.js\\"],
-};
-"
-`;
-
-exports[`migrate: e2e > againt specific basePath via --basePath option 5`] = `
-"module.exports = {
-  \\"parser\\": \\"@typescript-eslint/parser\\",
-  \\"parserOptions\\": {
-    \\"sourceType\\": \\"module\\"
-  },
-  \\"plugins\\": [
-    \\"@typescript-eslint\\",
-    \\"prettier\\"
-  ],
-  \\"extends\\": [
-    \\"plugin:@typescript-eslint/eslint-recommended\\",
-    \\"plugin:@typescript-eslint/recommended\\",
-    \\"eslint:recommended\\",
-    \\"plugin:prettier/recommended\\",
-    \\"prettier\\"
-  ]
-}"
-`;
-
-exports[`migrate: e2e > againt specific basePath via -basePath option 1`] = `
-"info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project
 [SUCCESS] Validate project
 [STARTED] Initialize
@@ -195,7 +103,7 @@ exports[`migrate: e2e > againt specific basePath via -basePath option 1`] = `
 [SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
-exports[`migrate: e2e > againt specific basePath via -basePath option 2`] = `
+exports[`migrate: e2e > againt specific basePath via --basePath option 2`] = `
 "/* @ts-expect-error @rehearsal TODO TS7006: Parameter 'baz' implicitly has an 'any' type. */
 export function run(baz) {
   /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'foo'. */
@@ -204,7 +112,7 @@ export function run(baz) {
 "
 `;
 
-exports[`migrate: e2e > againt specific basePath via -basePath option 3`] = `
+exports[`migrate: e2e > againt specific basePath via --basePath option 3`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
@@ -225,14 +133,14 @@ exports[`migrate: e2e > againt specific basePath via -basePath option 3`] = `
 }
 `;
 
-exports[`migrate: e2e > againt specific basePath via -basePath option 4`] = `
+exports[`migrate: e2e > againt specific basePath via --basePath option 4`] = `
 "module.exports = {
   extends: [\\"./.rehearsal-eslintrc.js\\"],
 };
 "
 `;
 
-exports[`migrate: e2e > againt specific basePath via -basePath option 5`] = `
+exports[`migrate: e2e > againt specific basePath via --basePath option 5`] = `
 "module.exports = {
   \\"parser\\": \\"@typescript-eslint/parser\\",
   \\"parserOptions\\": {
@@ -467,23 +375,47 @@ exports[`migrate: e2e > regen result after the first pass 1`] = `
 [SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
-exports[`migrate: e2e > rehearsal-config.json > exclude path defined in config 1`] = `
-"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+exports[`migrate: e2e > user defined options passed by --user-config -u > migrate.exclude 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.7-beta
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Initialize -- Dry Run Mode
 [DATA] Running migration on my-package
 [DATA] List of files will be attempted to migrate:
 [DATA]  lib/a.js
 [DATA] index.js
-[SUCCESS] Initialize -- Dry Run Mode"
+[SUCCESS] Initialize -- Dry Run Mode
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[SUCCESS] Create eslint config
+[STARTED] Add package scripts
+[SUCCESS] Add package scripts"
 `;
 
-exports[`migrate: e2e > rehearsal-config.json > include path defined in config 1`] = `
-"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+exports[`migrate: e2e > user defined options passed by --user-config -u > migrate.include 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.7-beta
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Initialize -- Dry Run Mode
 [DATA] Running migration on my-package
 [DATA] List of files will be attempted to migrate:
 [DATA]  lib/a.js
 [DATA] index.js
 [DATA] test/index.js
-[SUCCESS] Initialize -- Dry Run Mode"
+[SUCCESS] Initialize -- Dry Run Mode
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[SUCCESS] Create eslint config
+[STARTED] Add package scripts
+[SUCCESS] Add package scripts"
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -1,6 +1,5 @@
 // Vitest Snapshot v1
 
-<<<<<<< HEAD
 exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project
@@ -23,27 +22,6 @@ exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 [SUCCESS]   0 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
-=======
-exports[`migrate: e2e >  rehearsal-config.json > exclude path defined in config 1`] = `
-"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
-[STARTED] Initialize -- Dry Run Mode
-[DATA] Running migration on my-package
-[DATA] List of files will be attempted to migrate:
-[DATA]  lib/a.js
-[DATA] index.js
-[SUCCESS] Initialize -- Dry Run Mode"
-`;
-
-exports[`migrate: e2e >  rehearsal-config.json > include path defined in config 1`] = `
-"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
-[STARTED] Initialize -- Dry Run Mode
-[DATA] Running migration on my-package
-[DATA] List of files will be attempted to migrate:
-[DATA]  lib/a.js
-[DATA] index.js
-[DATA] test/index.js
-[SUCCESS] Initialize -- Dry Run Mode"
->>>>>>> 9fe5305 (feat(cli): add config for include/exclude of files)
 `;
 
 exports[`migrate: e2e > Print debug messages with verbose 1`] = `

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -1,5 +1,6 @@
 // Vitest Snapshot v1
 
+<<<<<<< HEAD
 exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project
@@ -22,6 +23,27 @@ exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 [SUCCESS]   0 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
+=======
+exports[`migrate: e2e >  rehearsal-config.json > exclude path defined in config 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on my-package
+[DATA] List of files will be attempted to migrate:
+[DATA]  lib/a.js
+[DATA] index.js
+[SUCCESS] Initialize -- Dry Run Mode"
+`;
+
+exports[`migrate: e2e >  rehearsal-config.json > include path defined in config 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on my-package
+[DATA] List of files will be attempted to migrate:
+[DATA]  lib/a.js
+[DATA] index.js
+[DATA] test/index.js
+[SUCCESS] Initialize -- Dry Run Mode"
+>>>>>>> 9fe5305 (feat(cli): add config for include/exclude of files)
 `;
 
 exports[`migrate: e2e > Print debug messages with verbose 1`] = `
@@ -66,6 +88,98 @@ debug:   fileNames: [\\"<tmp-path>/foo.ts\\",\\"<tmp-path>/depends-on-foo.ts\\",
 [SUCCESS]   1 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 1 eslint errors, with details in the report"
+`;
+
+exports[`migrate: e2e > againt specific basePath via --basePath option 1`] = `
+"info:    @rehearsal/migrate<test-version>
+[STARTED] Initialize
+[DATA] Running migration on base
+[SUCCESS] Initialize
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default typescript-related config
+[SUCCESS] Create eslint config
+[STARTED] Add package scripts
+[SUCCESS] Add package scripts
+[STARTED] Convert JS files to TS
+[DATA] git mv /index.js to /index.ts
+[DATA] processing file: /index.ts
+[TITLE] Migration Complete
+[TITLE]   1 JS file converted to TS
+[TITLE]   7 errors caught by rehearsal
+[TITLE]   3 have been fixed by rehearsal
+[TITLE]   4 errors need to be fixed manually
+[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 4 eslint errors, with details in the report
+[SUCCESS] Migration Complete
+[SUCCESS]   1 JS file converted to TS
+[SUCCESS]   7 errors caught by rehearsal
+[SUCCESS]   3 have been fixed by rehearsal
+[SUCCESS]   4 errors need to be fixed manually
+[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 4 eslint errors, with details in the report"
+`;
+
+exports[`migrate: e2e > againt specific basePath via --basePath option 2`] = `
+"export function run(baz: any) {
+  return foo(baz);
+}
+
+function foo(_baz: any) {
+  throw new Error(\\"Function not implemented.\\");
+}
+"
+`;
+
+exports[`migrate: e2e > againt specific basePath via --basePath option 3`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2021",
+  },
+  "include": [
+    "index.ts",
+  ],
+}
+`;
+
+exports[`migrate: e2e > againt specific basePath via --basePath option 4`] = `
+"module.exports = {
+  extends: [\\"./.rehearsal-eslintrc.js\\"],
+};
+"
+`;
+
+exports[`migrate: e2e > againt specific basePath via --basePath option 5`] = `
+"module.exports = {
+  \\"parser\\": \\"@typescript-eslint/parser\\",
+  \\"parserOptions\\": {
+    \\"sourceType\\": \\"module\\"
+  },
+  \\"plugins\\": [
+    \\"@typescript-eslint\\",
+    \\"prettier\\"
+  ],
+  \\"extends\\": [
+    \\"plugin:@typescript-eslint/eslint-recommended\\",
+    \\"plugin:@typescript-eslint/recommended\\",
+    \\"eslint:recommended\\",
+    \\"plugin:prettier/recommended\\",
+    \\"prettier\\"
+  ]
+}"
 `;
 
 exports[`migrate: e2e > againt specific basePath via -basePath option 1`] = `
@@ -373,4 +487,25 @@ exports[`migrate: e2e > regen result after the first pass 1`] = `
 [SUCCESS]   1 errors caught by rehearsal
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 1 eslint errors, with details in the report"
+`;
+
+exports[`migrate: e2e > rehearsal-config.json > exclude path defined in config 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on my-package
+[DATA] List of files will be attempted to migrate:
+[DATA]  lib/a.js
+[DATA] index.js
+[SUCCESS] Initialize -- Dry Run Mode"
+`;
+
+exports[`migrate: e2e > rehearsal-config.json > include path defined in config 1`] = `
+"[32minfo[39m:    @rehearsal/migrate 1.0.4-beta
+[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on my-package
+[DATA] List of files will be attempted to migrate:
+[DATA]  lib/a.js
+[DATA] index.js
+[DATA] test/index.js
+[SUCCESS] Initialize -- Dry Run Mode"
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -318,7 +318,7 @@ exports[`migrate: e2e > init flag 3`] = `
     "@types/node": "^18.13.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
-    "eslint": "^8.33.0",
+    "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.4",

--- a/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
@@ -1,75 +1,13 @@
 // Vitest Snapshot v1
 
-exports[`Task: initialize > disable package selection if completed 1`] = `
-{
-  ".": [],
-  "./module-a": [
-    "./module-a/index.js",
-  ],
-  "./module-b": [],
-}
-`;
-
-exports[`Task: initialize > disable package selection if completed 2`] = `
-{
-  "./module-a/index.js": {
-    "current": "./module-a/index.ts",
-    "errorCount": 0,
-    "origin": "./module-a/index.js",
-    "package": "./module-a",
-  },
-}
-`;
-
-exports[`Task: initialize > get files that will be migrated 1`] = `
-[
-  "foo.js",
-  "depends-on-foo.js",
-  "index.js",
-]
-`;
-
-exports[`Task: initialize > get files that will be migrated 2`] = `
-"[STARTED] Initialize
-[DATA] Running migration on basic
-[SUCCESS] Initialize
-"
-`;
-
-exports[`Task: initialize > print files will be attempted to migrate with --dryRun 1`] = `
-"[STARTED] Initialize -- Dry Run Mode
-[DATA] Running migration on basic
-[DATA] List of files will be attempted to migrate:
-[DATA]  foo.js
-[DATA] depends-on-foo.js
-[DATA] index.js
-[SUCCESS] Initialize -- Dry Run Mode
-"
-`;
-
-exports[`Task: initialize > show package progress in interactive mode 1`] = `
-{
-  ".": [],
-  "./module-a": [
-    "./module-a/index.js",
-  ],
-  "./module-b": [],
-}
-`;
-
-exports[`Task: initialize > show package progress in interactive mode 2`] = `
-{
-  "./module-a/index.js": {
-    "current": "./module-a/index.ts",
-    "errorCount": 2,
-    "origin": "./module-a/index.js",
-    "package": "./module-a",
-  },
-}
-`;
-
 exports[`Task: initialize > store custom config in context 1`] = `
 {
+  "exclude": [
+    "docs",
+  ],
+  "include": [
+    "test",
+  ],
   "install": {
     "dependencies": [
       "foo",

--- a/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
@@ -1,5 +1,73 @@
 // Vitest Snapshot v1
 
+exports[`Task: initialize > disable package selection if completed 1`] = `
+{
+  ".": [],
+  "./module-a": [
+    "./module-a/index.js",
+  ],
+  "./module-b": [],
+}
+`;
+
+exports[`Task: initialize > disable package selection if completed 2`] = `
+{
+  "./module-a/index.js": {
+    "current": "./module-a/index.ts",
+    "errorCount": 0,
+    "origin": "./module-a/index.js",
+    "package": "./module-a",
+  },
+}
+`;
+
+exports[`Task: initialize > get files that will be migrated 1`] = `
+[
+  "foo.js",
+  "depends-on-foo.js",
+  "index.js",
+]
+`;
+
+exports[`Task: initialize > get files that will be migrated 2`] = `
+"[STARTED] Initialize
+[DATA] Running migration on basic
+[SUCCESS] Initialize
+"
+`;
+
+exports[`Task: initialize > print files will be attempted to migrate with --dryRun 1`] = `
+"[STARTED] Initialize -- Dry Run Mode
+[DATA] Running migration on basic
+[DATA] List of files will be attempted to migrate:
+[DATA]  foo.js
+[DATA] depends-on-foo.js
+[DATA] index.js
+[SUCCESS] Initialize -- Dry Run Mode
+"
+`;
+
+exports[`Task: initialize > show package progress in interactive mode 1`] = `
+{
+  ".": [],
+  "./module-a": [
+    "./module-a/index.js",
+  ],
+  "./module-b": [],
+}
+`;
+
+exports[`Task: initialize > show package progress in interactive mode 2`] = `
+{
+  "./module-a/index.js": {
+    "current": "./module-a/index.ts",
+    "errorCount": 2,
+    "origin": "./module-a/index.js",
+    "package": "./module-a",
+  },
+}
+`;
+
 exports[`Task: initialize > store custom config in context 1`] = `
 {
   "exclude": [

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -237,7 +237,7 @@ describe('migrate: e2e', async () => {
     expect(eslint).toMatchSnapshot();
   });
 
-  test('Print debug messages with verbose', async () => {
+  test('Print debug messages with --verbose', async () => {
     const { stdout } = await runBin('migrate', ['--verbose'], {
       cwd: basePath,
     });
@@ -321,13 +321,13 @@ describe('migrate: e2e', async () => {
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
   });
 
-  describe('rehearsal-config.json', async () => {
+  describe('user defined options passed by --user-config -u', async () => {
     function createUserConfig(basePath: string, config: CustomConfig): void {
       const configPath = resolve(basePath, 'rehearsal-config.json');
       writeJSONSync(configPath, config);
     }
 
-    test('exclude path defined in config', async () => {
+    test('migrate.exclude', async () => {
       const files = getFiles('simple');
       // Add a directory that we don't want to ignore
       files['some-dir'] = { 'index.js': '// I should be excluded ' };
@@ -349,7 +349,7 @@ describe('migrate: e2e', async () => {
       expect(result.stdout).toMatchSnapshot();
     });
 
-    test('include path defined in config', async () => {
+    test('migrate.include', async () => {
       const files = getFiles('simple');
 
       // test is a default ignored directory in Package.ts

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -1,12 +1,14 @@
 import { resolve } from 'path';
 import { readFileSync } from 'fs';
-import { readdirSync, readJSONSync } from 'fs-extra';
+import { readdirSync, readJSONSync, writeJSONSync } from 'fs-extra';
 import { setGracefulCleanup } from 'tmp';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { simpleGit, type SimpleGitOptions } from 'simple-git';
+import { create, getFiles } from '@rehearsal/test-support';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install';
 
 import { runBin, prepareTmpDir, cleanOutput } from '../../test-helpers';
+import { CustomConfig } from '../../../src/types';
 
 setGracefulCleanup();
 
@@ -243,7 +245,7 @@ describe('migrate: e2e', async () => {
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
   });
 
-  test('againt specific basePath via -basePath option', async () => {
+  test('againt specific basePath via --basePath option', async () => {
     basePath = prepareTmpDir('custom_basepath');
 
     const customBasePath = resolve(basePath, 'base');
@@ -317,5 +319,58 @@ describe('migrate: e2e', async () => {
       cwd: basePath,
     });
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
+  });
+
+  describe('rehearsal-config.json', async () => {
+    function createUserConfig(basePath: string, config: CustomConfig): void {
+      const configPath = resolve(basePath, 'rehearsal-config.json');
+      writeJSONSync(configPath, config);
+    }
+
+    test('exclude path defined in config', async () => {
+      const files = getFiles('simple');
+      // Add a directory that we don't want to ignore
+      files['some-dir'] = { 'index.js': '// I should be excluded ' };
+      const basePath = create(files);
+
+      createUserConfig(basePath, {
+        migrate: {
+          setup: {
+            ts: { command: 'touch', args: ['custom-ts-config-script'] },
+          },
+          exclude: ['some-dir'],
+        },
+      });
+
+      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json'], {
+        cwd: basePath,
+      });
+
+      expect(result.stdout).toMatchSnapshot();
+    });
+
+    test('include path defined in config', async () => {
+      const files = getFiles('simple');
+
+      // test is a default ignored directory in Package.ts
+      // adding it to the include list should override that value.
+      files['test'] = { 'index.js': '// I should be included ' };
+      const basePath = create(files);
+
+      createUserConfig(basePath, {
+        migrate: {
+          setup: {
+            ts: { command: 'touch', args: ['custom-ts-config-script'] },
+          },
+          include: ['test'],
+        },
+      });
+
+      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json'], {
+        cwd: basePath,
+      });
+
+      expect(result.stdout).toMatchSnapshot();
+    });
   });
 });

--- a/packages/cli/test/commands/migrate/initialize.test.ts
+++ b/packages/cli/test/commands/migrate/initialize.test.ts
@@ -57,9 +57,11 @@ describe('Task: initialize', async () => {
     expect(output).matchSnapshot();
   });
 
-  test('store custom config in context', async () => {
+  test.only('store custom config in context', async () => {
     createUserConfig(basePath, {
       migrate: {
+        include: ['test'],
+        exclude: ['docs'],
         install: {
           dependencies: ['foo'],
           devDependencies: ['bat'],
@@ -75,14 +77,16 @@ describe('Task: initialize', async () => {
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
+    expect.assertions(8);
+
     expect(ctx.userConfig).toBeTruthy();
-    if (ctx.userConfig) {
-      expect(ctx.userConfig.basePath).toBe(basePath);
-      expect(ctx.userConfig.config).toMatchSnapshot();
-      expect(ctx.userConfig.hasDependencies).toBeTruthy();
-      expect(ctx.userConfig.hasLintSetup).toBeTruthy();
-      expect(ctx.userConfig.hasTsSetup).toBeTruthy();
-    }
+    expect(ctx.userConfig?.basePath).toBe(basePath);
+    expect(ctx.userConfig?.config).toMatchSnapshot();
+    expect(ctx.userConfig?.hasDependencies).toBeTruthy();
+    expect(ctx.userConfig?.hasLintSetup).toBeTruthy();
+    expect(ctx.userConfig?.hasTsSetup).toBeTruthy();
+    expect(ctx.userConfig?.include).toStrictEqual(['test']);
+    expect(ctx.userConfig?.exclude).toStrictEqual(['docs']);
   });
 
   test('print files will be attempted to migrate with --dryRun', async () => {

--- a/packages/cli/test/commands/migrate/initialize.test.ts
+++ b/packages/cli/test/commands/migrate/initialize.test.ts
@@ -1,7 +1,6 @@
 import { resolve } from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { writeJSONSync, mkdirSync, writeFileSync } from 'fs-extra';
-
 import { initTask } from '../../../src/commands/migrate/tasks';
 import {
   prepareTmpDir,

--- a/packages/cli/test/commands/migrate/initialize.test.ts
+++ b/packages/cli/test/commands/migrate/initialize.test.ts
@@ -57,7 +57,7 @@ describe('Task: initialize', async () => {
     expect(output).matchSnapshot();
   });
 
-  test.only('store custom config in context', async () => {
+  test('store custom config in context', async () => {
     createUserConfig(basePath, {
       migrate: {
         include: ['test'],
@@ -80,13 +80,13 @@ describe('Task: initialize', async () => {
     expect.assertions(8);
 
     expect(ctx.userConfig).toBeTruthy();
-    expect(ctx.userConfig?.basePath).toBe(basePath);
-    expect(ctx.userConfig?.config).toMatchSnapshot();
-    expect(ctx.userConfig?.hasDependencies).toBeTruthy();
-    expect(ctx.userConfig?.hasLintSetup).toBeTruthy();
-    expect(ctx.userConfig?.hasTsSetup).toBeTruthy();
-    expect(ctx.userConfig?.include).toStrictEqual(['test']);
-    expect(ctx.userConfig?.exclude).toStrictEqual(['docs']);
+    expect(ctx?.userConfig?.basePath).toBe(basePath);
+    expect(ctx?.userConfig?.config).toMatchSnapshot();
+    expect(ctx?.userConfig?.hasDependencies).toBeTruthy();
+    expect(ctx?.userConfig?.hasLintSetup).toBeTruthy();
+    expect(ctx?.userConfig?.hasTsSetup).toBeTruthy();
+    expect(ctx?.userConfig?.include).toStrictEqual(['test']);
+    expect(ctx?.userConfig?.exclude).toStrictEqual(['docs']);
   });
 
   test('print files will be attempted to migrate with --dryRun', async () => {

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -62,7 +62,16 @@ export class PackageGraph {
       ? Array.from(this.package.includePatterns)
       : ['index.js'];
 
-    const exclude = this.package.excludePatterns ? Array.from(this.package.excludePatterns) : [];
+    let exclude = this.package.excludePatterns ? Array.from(this.package.excludePatterns) : [];
+
+    if (this.projectGraph) {
+      // This should be moved to the Package constructor.
+      const relativePackagePath = relative(this.projectGraph.rootDir, this.baseDir);
+      const additionalExcludes: string[] = Array.from(this.projectGraph.exclude)
+        .map((match) => relative(relativePackagePath, match))
+        .filter((relativePath) => !relativePath.startsWith('..'));
+      exclude = exclude.concat(additionalExcludes);
+    }
 
     const cruiseOptions: ICruiseOptions = {
       baseDir,

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -200,12 +200,22 @@ export class Package implements IPackage {
   }
 
   addIncludePattern(...patterns: string[]): this {
-    patterns.forEach((pattern) => this.#includePatterns.add(pattern));
+    patterns.forEach((pattern) => {
+      if (this.#excludePatterns.has(pattern)) {
+        this.#excludePatterns.delete(pattern);
+      }
+      this.#includePatterns.add(pattern);
+    });
     return this;
   }
 
   addExcludePattern(...patterns: string[]): this {
-    patterns.forEach((pattern) => this.#excludePatterns.add(pattern));
+    patterns.forEach((pattern) => {
+      if (this.#includePatterns.has(pattern)) {
+        this.#includePatterns.delete(pattern);
+      }
+      this.#excludePatterns.add(pattern);
+    });
     return this;
   }
 

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -70,13 +70,13 @@ describe('Unit | Entities | Package', function () {
       expect(p.includePatterns).toStrictEqual(new Set(['.']));
     });
 
-    test('options.excludePatterns ', () => {
+    test('set excludePatterns ', () => {
       const p = new Package(pathToPackage);
       p.excludePatterns = new Set(['dist', 'test-packages']);
       expect(p.excludePatterns).toStrictEqual(new Set(['dist', 'test-packages']));
     });
 
-    test('options.includePatterns ', () => {
+    test('set includePatterns ', () => {
       const p = new Package(pathToPackage);
       p.includePatterns = new Set(['src/**/*.js']);
       expect(p.includePatterns).toStrictEqual(new Set(['src/**/*.js']));
@@ -102,6 +102,14 @@ describe('Unit | Entities | Package', function () {
           'test-packages',
         ])
       );
+
+      p.addIncludePattern('index.js');
+      expect(p.includePatterns).toStrictEqual(new Set(['.', 'index.js']));
+      p.addExcludePattern('index.js');
+      expect(
+        p.includePatterns,
+        'should remove index.js from excludes if addExcludePattern called with that value'
+      ).toStrictEqual(new Set(['.']));
     });
 
     test('addIncludePattern', () => {
@@ -112,6 +120,12 @@ describe('Unit | Entities | Package', function () {
 
       p.addIncludePattern('file1', 'file2');
       expect(p.includePatterns).toStrictEqual(new Set(['.', 'foo.js', 'file1', 'file2']));
+
+      p.addIncludePattern('tests');
+      expect(
+        p.excludePatterns,
+        'should remove tests from excludes if addIncludePattern'
+      ).toStrictEqual(new Set(['dist', 'test']));
     });
   });
 

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -121,11 +121,12 @@ describe('Unit | Entities | Package', function () {
       p.addIncludePattern('file1', 'file2');
       expect(p.includePatterns).toStrictEqual(new Set(['.', 'foo.js', 'file1', 'file2']));
 
+      expect(p.excludePatterns.has('tests')).toBe(true);
       p.addIncludePattern('tests');
       expect(
-        p.excludePatterns,
+        p.excludePatterns.has('tests'),
         'should remove tests from excludes if addIncludePattern'
-      ).toStrictEqual(new Set(['dist', 'test']));
+      ).toBe(false);
     });
   });
 

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -115,6 +115,26 @@ describe('project-graph', () => {
     expect(somePackage.hasModuleGraph(), 'should exist when options.eager=true').toBe(true);
   });
 
+  test('options.include', () => {
+    const baseDir = getLibrary('simple');
+
+    const projectGraph = new ProjectGraph(baseDir, { include: ['test'] });
+    const [somePackage] = projectGraph.discover();
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual([
+      'lib/a.js',
+      'index.js',
+      'test/some.test.js',
+    ]);
+  });
+
+  test('options.exclude', () => {
+    const baseDir = getLibrary('simple');
+
+    const projectGraph = new ProjectGraph(baseDir, { exclude: ['lib'] });
+    const [somePackage] = projectGraph.discover();
+    expect(flatten(somePackage.getModuleGraph().topSort())).toStrictEqual(['index.js']);
+  });
+
   describe('workspaces', () => {
     test('should discover all packages in the project', () => {
       const baseDir = getLibrary('library-with-workspaces');

--- a/packages/migration-graph/src/migration-graph.ts
+++ b/packages/migration-graph/src/migration-graph.ts
@@ -23,9 +23,9 @@ export function buildMigrationGraph(
   options?: MigrationGraphOptions
 ): { projectGraph: ProjectGraph; sourceType: SourceType } {
   // Determine what kind of MigrationGraph should be created.
-  // Library
   // Ember App
   // Ember Addon
+  // Library
 
   const packageJson = readPackageJson(rootDir);
 

--- a/packages/migration-graph/src/migration-strategy.ts
+++ b/packages/migration-graph/src/migration-strategy.ts
@@ -94,10 +94,12 @@ export function getMigrationStrategy(
       }
 
       if (!packageNode.content.pkg) {
-        throw new Error('WTF');
+        throw new Error('Unable to create MigrationStrategy, packageNode has no Package');
       }
 
-      const moduleGraph = packageNode.content.pkg?.getModuleGraph();
+      const somePackage = packageNode.content.pkg;
+
+      const moduleGraph = somePackage.getModuleGraph({ project: projectGraph });
 
       // For this package, get a list of modules (files)
       const ordered: Array<ModuleNode> = moduleGraph

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -103,7 +103,7 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
           'some.test.js': '// Should not be included by default',
         },
         tests: {
-          'index.test.js': '// Should not included by default',
+          'index.test.js': '// Should not be included by default',
         },
       };
       break;

--- a/packages/test-support/src/library.ts
+++ b/packages/test-support/src/library.ts
@@ -99,6 +99,12 @@ export function getFiles(variant: LibraryVariants): fixturify.DirJSON {
             console.log('foo');
            `,
         },
+        test: {
+          'some.test.js': '// Should not be included by default',
+        },
+        tests: {
+          'index.test.js': '// Should not included by default',
+        },
       };
       break;
     case 'library-with-ignored-files':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
       '@rehearsal/migration-graph': workspace:*
       '@rehearsal/regen': workspace:*
       '@rehearsal/reporter': workspace:*
+      '@rehearsal/test-support': workspace:*
       '@rehearsal/upgrade': workspace:*
       '@rehearsal/utils': workspace:*
       '@types/which': ^2.0.1
@@ -156,6 +157,7 @@ importers:
       winston: 3.8.2
       yaml: 2.2.1
     devDependencies:
+      '@rehearsal/test-support': link:../test-support
       '@types/which': 2.0.1
       typescript: 4.9.5
       typescript-json-schema: 0.55.0


### PR DESCRIPTION
This will address the features outlined in #602 
This PR will fix: #605 

## Features
- [x] Leverage existing config work:
  - https://linkedin.ghe.com/multiproduct/rehearsal-cli-config
  - https://github.com/rehearsal-js/rehearsal-js/blob/master/packages/cli/src/user-config.ts
- [x] Improve rehearsal-config.json to have a schema
```
{
migrate: {
  // Defaults: ...
  include: ['tests'],
  // Defaults are: 
  exclude: ['docs', 'webpack.config.js']
}
``` 
  - This can be a defined schema similar to [tracerbench tb-schema.json](https://raw.githubusercontent.com/TracerBench/tracerbench/master/packages/cli/tb-schema.json)
  - Using this package https://www.npmjs.com/package/typescript-json-schema
- [x] ~If types are shared we should move this all to `util` package.~


## Use Cases
### Simple Project (single package)
- [X] API single package library / root package projects include/exclude files.

### Workspaces
- ~Include a specific file include/exclude for a given package.~
- ~A way to configure each package or just for the project, which files or directories to ignore.~
- ~Configure by package, all packages, or at the project level.~
- [x] Support directories from root from rehearsal-config.json and resolve paths to the package's module graph when created.

## Testing Strategy
- [x] Test config arguments in `cli/test/migrate/e2e.test.ts`
- [x] Test at migration-graph package layer.
- [x] Add tests to `initialize.test.ts`
