### PR TITLE
fix: use relative path in state file

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -71,6 +71,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
   const defaultListrOption = {
     concurrent: false,
     exitOnError: true,
+    renderer: 'simple',
   };
 
   const tasks = [
@@ -87,7 +88,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
       // previous ctx is needed for the isolated convertTask
       const ctx = await new Listr(tasks, defaultListrOption).run();
       await new Listr([await convertTask(options, logger, ctx)], {
-        renderer: 'simple',
+        // renderer: 'simple',
         ...defaultListrOption,
       }).run();
     } else if (options.regen) {

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -71,7 +71,6 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
   const defaultListrOption = {
     concurrent: false,
     exitOnError: true,
-    renderer: 'simple',
   };
 
   const tasks = [
@@ -88,7 +87,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
       // previous ctx is needed for the isolated convertTask
       const ctx = await new Listr(tasks, defaultListrOption).run();
       await new Listr([await convertTask(options, logger, ctx)], {
-        // renderer: 'simple',
+        renderer: 'simple',
         ...defaultListrOption,
       }).run();
     } else if (options.regen) {

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -71,7 +71,6 @@ export async function convertTask(
               // no-ops
             }
 
-            // TODO: better diff with colors instead of using the output straight from git diff
             const message = `${chalk.yellow(
               `Please view the migration changes for ${f} and select an option to continue:`
             )}\n${prettyGitDiff(diffOutput)}`;
@@ -117,6 +116,10 @@ export async function convertTask(
             gitAddIfInRepo(reportOutputPath, basePath); // stage report if in git repo
             task.title = getReportSummary(reporter.report, migratedFiles.length);
           }
+          if (ctx.state) {
+            ctx.state.addFilesToPackage(ctx.targetPackagePath, ctx.sourceFilesWithAbsolutePath);
+            await ctx.state.addStateFileToGit();
+          }
         } else {
           const input = {
             basePath: ctx.targetPackagePath,
@@ -129,10 +132,6 @@ export async function convertTask(
           const { migratedFiles } = await migrate(input);
 
           DEBUG_CALLBACK('migratedFiles', migratedFiles);
-          if (ctx.state) {
-            ctx.state.addFilesToPackage(ctx.targetPackagePath, migratedFiles);
-            await ctx.state.addStateFileToGit();
-          }
           const reportOutputPath = resolve(options.basePath, options.outputPath);
           generateReports('migrate', reporter, reportOutputPath, options.format);
           gitAddIfInRepo(reportOutputPath, basePath); // stage report if in git repo

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -46,7 +46,8 @@ export async function initTask(
         // Init state and store
         const state = new State(
           projectName,
-          packages.map((p) => p.path)
+          options.basePath,
+          packages.map((p) => p.path) // use relative path
         );
         ctx.state = state;
 

--- a/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
@@ -1,5 +1,26 @@
 // Vitest Snapshot v1
 
+exports[`Task: initialize > disable package selection if completed 1`] = `
+{
+  ".": [],
+  "./module-a": [
+    "./module-a/index.js",
+  ],
+  "./module-b": [],
+}
+`;
+
+exports[`Task: initialize > disable package selection if completed 2`] = `
+{
+  "./module-a/index.js": {
+    "current": "./module-a/index.ts",
+    "errorCount": 0,
+    "origin": "./module-a/index.js",
+    "package": "./module-a",
+  },
+}
+`;
+
 exports[`Task: initialize > get files that will be migrated 1`] = `
 [
   "foo.js",
@@ -24,6 +45,27 @@ exports[`Task: initialize > print files will be attempted to migrate with --dryR
 [DATA] index.js
 [SUCCESS] Initialize -- Dry Run Mode
 "
+`;
+
+exports[`Task: initialize > show package progress in interactive mode 1`] = `
+{
+  ".": [],
+  "./module-a": [
+    "./module-a/index.js",
+  ],
+  "./module-b": [],
+}
+`;
+
+exports[`Task: initialize > show package progress in interactive mode 2`] = `
+{
+  "./module-a/index.js": {
+    "current": "./module-a/index.ts",
+    "errorCount": 2,
+    "origin": "./module-a/index.js",
+    "package": "./module-a",
+  },
+}
 `;
 
 exports[`Task: initialize > store custom config in context 1`] = `

--- a/packages/cli/test/helpers/__snapshots__/state.test.ts.snap
+++ b/packages/cli/test/helpers/__snapshots__/state.test.ts.snap
@@ -1,9 +1,132 @@
 // Vitest Snapshot v1
 
+exports[`state > addFilesToPackages 1`] = `
+{
+  "files": {
+    "./foo": {
+      "current": "./foo",
+      "errorCount": 0,
+      "origin": "./foo",
+      "package": "./bar",
+    },
+  },
+  "name": "bar",
+  "packageMap": {
+    "./bar": [
+      "./foo",
+    ],
+  },
+}
+`;
+
 exports[`state > constructor should init state to disk 1`] = `
 {
   "files": {},
   "name": "foo",
   "packageMap": {},
+}
+`;
+
+exports[`state > constructor should load existed state 1`] = `
+{
+  "files": {
+    "./foo": {
+      "current": "foo",
+      "errorCount": 0,
+      "origin": "foo",
+      "package": "./bar",
+    },
+  },
+  "name": "bar",
+  "packageMap": {
+    "bar": [
+      "./foo",
+    ],
+  },
+}
+`;
+
+exports[`state > does not contain absolute paths in state file 1`] = `
+{
+  "files": {},
+  "name": "bar",
+  "packageMap": {
+    "./sample-package": [],
+  },
+}
+`;
+
+exports[`state > does not contain absolute paths in state file 2`] = `
+{
+  "files": {
+    "./bar": {
+      "current": null,
+      "errorCount": 0,
+      "origin": "./bar",
+      "package": "./sample-package",
+    },
+    "./foo": {
+      "current": null,
+      "errorCount": 0,
+      "origin": "./foo",
+      "package": "./sample-package",
+    },
+  },
+  "name": "bar",
+  "packageMap": {
+    "./sample-package": [
+      "./foo",
+      "./bar",
+    ],
+  },
+}
+`;
+
+exports[`state > getPackageMigrateProgress 1`] = `
+{
+  "files": {
+    "./bar.ts": {
+      "current": null,
+      "errorCount": 0,
+      "origin": "./bar.ts",
+      "package": "sample-package",
+    },
+    "./foo.ts": {
+      "current": "./foo.ts",
+      "errorCount": 0,
+      "origin": "./foo.ts",
+      "package": "sample-package",
+    },
+  },
+  "name": "bar",
+  "packageMap": {
+    "bar": [
+      "./foo.ts",
+      "./bar.ts",
+    ],
+    "sample-package": [
+      "./foo.ts",
+      "./bar.ts",
+    ],
+  },
+}
+`;
+
+exports[`state > getVerifiedStore 1`] = `
+{
+  "files": {
+    "./foo": {
+      "current": null,
+      "errorCount": 2,
+      "origin": "foo",
+      "package": "./bar",
+    },
+  },
+  "name": "bar",
+  "packageMap": {
+    "./bar": [
+      "./foo",
+    ],
+  },
 }
 `;


### PR DESCRIPTION
For #637.

- Make sure all the file/package paths are relative in `migrate-state.json`
- Small cleanups
- New test in `initialize` to check the package selection menu and the state file