### PR TITLE
feat(cli): validate task

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/index.ts
+++ b/packages/cli/src/commands/migrate/tasks/index.ts
@@ -5,3 +5,4 @@ export * from './initialize';
 export * from './config-ts';
 export * from './create-scripts';
 export * from './regen';
+export * from './validate';

--- a/packages/cli/src/commands/migrate/tasks/validate.ts
+++ b/packages/cli/src/commands/migrate/tasks/validate.ts
@@ -1,0 +1,39 @@
+import { resolve } from 'path';
+import { ListrTask } from 'listr2';
+import { Logger } from 'winston';
+import { existsSync } from 'fs-extra';
+
+import { getEsLintConfigPath } from '../../../utils';
+import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
+
+export async function validateTask(
+  options: MigrateCommandOptions,
+  logger: Logger
+): Promise<ListrTask> {
+  return {
+    title: 'Validate project',
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    task: async (): Promise<void> => {
+      const packageJsonPath = resolve(options.basePath, 'package.json');
+      if (!existsSync(packageJsonPath)) {
+        throw new Error(
+          `${packageJsonPath} does not exists. Please run rehearsal migrate inside a project with a valid package.json.`
+        );
+      }
+      if (options.regen) {
+        const lintConfigPath = getEsLintConfigPath(options.basePath);
+        if (!lintConfigPath) {
+          logger.warn(
+            `Eslint config (.eslintrc.{js,yml,json,yaml}) does not exist. You need to run rehearsal migrate first before you can run rehearsal migrate --regen`
+          );
+        }
+        const tsConfigPath = resolve(options.basePath, 'tsconfig.json');
+        if (!existsSync(tsConfigPath)) {
+          logger.warn(
+            `${tsConfigPath} does not exist. You need to run rehearsal migrate first before you can run rehearsal migrate --regen`
+          );
+        }
+      }
+    },
+  };
+}

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`migrate: e2e > Print debug messages with verbose 1`] = `
 "info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Initialize
 [DATA] Running migration on basic
 [SUCCESS] Initialize
@@ -44,6 +46,8 @@ debug:   fileNames: [\\"<tmp-path>/foo.ts\\",\\"<tmp-path>/depends-on-foo.ts\\",
 
 exports[`migrate: e2e > againt specific basePath via -basePath option 1`] = `
 "info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Initialize
 [DATA] Running migration on base
 [SUCCESS] Initialize
@@ -134,6 +138,8 @@ exports[`migrate: e2e > againt specific basePath via -basePath option 5`] = `
 
 exports[`migrate: e2e > default migrate command 1`] = `
 "info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Initialize
 [DATA] Running migration on basic
 [SUCCESS] Initialize
@@ -244,6 +250,8 @@ exports[`migrate: e2e > default migrate command 7`] = `
 
 exports[`migrate: e2e > regen result after the first pass 1`] = `
 "info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
 [STARTED] Regenerating report for TS errors and Eslint errors
 [DATA] processing file: /foo.ts
 [DATA] processing file: /depends-on-foo.ts

--- a/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1
+
+exports[`Task: validate > pass with all config files in --regen 1`] = `
+"[STARTED] Validate project
+[SUCCESS] Validate project"
+`;
+
+exports[`Task: validate > pass with paackage.json 1`] = `
+"[STARTED] Validate project
+[SUCCESS] Validate project"
+`;
+
+exports[`Task: validate > show warning message for missing files in --regen 1`] = `
+"[STARTED] Validate project
+Eslint config (.eslintrc.{js,yml,json,yaml}) does not exist. You need to run rehearsal migrate first before you can run rehearsal migrate --regen
+<tmp-path>/tsconfig.json does not exist. You need to run rehearsal migrate first before you can run rehearsal migrate --regen
+[SUCCESS] Validate project"
+`;

--- a/packages/cli/test/commands/migrate/validate.test.ts
+++ b/packages/cli/test/commands/migrate/validate.test.ts
@@ -1,0 +1,84 @@
+import { resolve } from 'path';
+import { createFileSync, rmSync } from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createLogger, format, transports } from 'winston';
+
+import { validateTask } from '../../../src/commands/migrate/tasks';
+import {
+  prepareTmpDir,
+  listrTaskRunner,
+  createMigrateOptions,
+  cleanOutput,
+} from '../../test-helpers';
+
+const logger = createLogger({
+  transports: [new transports.Console({ format: format.cli() })],
+});
+
+describe('Task: validate', async () => {
+  let basePath = '';
+  let output = '';
+  vi.spyOn(console, 'info').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+  });
+  vi.spyOn(console, 'log').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+  });
+  vi.spyOn(console, 'error').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+  });
+  vi.spyOn(logger, 'warn').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+    return logger;
+  });
+  vi.spyOn(logger, 'error').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+    return logger;
+  });
+
+  beforeEach(() => {
+    output = '';
+    basePath = prepareTmpDir('initialization');
+  });
+
+  afterEach(() => {
+    output = '';
+    vi.clearAllMocks();
+  });
+
+  test('pass with paackage.json', async () => {
+    const options = createMigrateOptions(basePath);
+    const tasks = [await validateTask(options, logger)];
+
+    await listrTaskRunner(tasks);
+    expect(cleanOutput(output, basePath)).toMatchSnapshot();
+  });
+
+  test('error if no package.json', async () => {
+    const options = createMigrateOptions(basePath);
+    const tasks = [await validateTask(options, logger)];
+
+    rmSync(resolve(basePath, 'package.json'));
+
+    await expect(() => listrTaskRunner(tasks)).rejects.toThrowError(`package.json does not exists`);
+  });
+
+  test('show warning message for missing files in --regen', async () => {
+    const options = createMigrateOptions(basePath, { regen: true });
+    const tasks = [await validateTask(options, logger)];
+
+    await listrTaskRunner(tasks);
+    expect(cleanOutput(output, basePath)).toMatchSnapshot();
+  });
+
+  test('pass with all config files in --regen', async () => {
+    const options = createMigrateOptions(basePath, { regen: true });
+    const tasks = [await validateTask(options, logger)];
+
+    createFileSync(resolve(basePath, '.eslintrc.js'));
+    createFileSync(resolve(basePath, 'tsconfig.json'));
+
+    await listrTaskRunner(tasks);
+    expect(cleanOutput(output, basePath)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Add new validate task in rehearsal migrate CLI, since we would definitely need more validation steps in the future for framework migrations:
- Add check for `package.json`
- Move `--regen` warning message into validate task

This fixes #621 