### PR TITLE
fix: .rehearsal in .gitignore

### DIFF
--- a/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Task: validate > pass with all config files in --regen 1`] = `
 [SUCCESS] Validate project"
 `;
 
-exports[`Task: validate > pass with paackage.json 1`] = `
+exports[`Task: validate > pass with package.json 1`] = `
 "[STARTED] Validate project
 [SUCCESS] Validate project"
 `;


### PR DESCRIPTION
Fixes #662 

Check if `.gitignore` contains `.rehearsal`. If so we show the message to update `.gitignore`, since we need `.rehearsal/*` to be committed.