### PR TITLE
fix: when packages aren't found we need to swallow the error

### DIFF
--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -128,16 +128,12 @@ export class DiagnosticFixPlugin implements Plugin<DiagnosticFixPluginOptions> {
     command: CodeActionCommand[],
     options: DiagnosticFixPluginOptions
   ): Promise<boolean> {
-    const result = await options.service.getLanguageService().applyCodeActionCommand(command);
-    const ls = options.service.getLanguageService();
-
-    if (result) {
+    try {
+      await options.service.getLanguageService().applyCodeActionCommand(command);
       return true;
+    } catch (e) {
+      return false;
     }
-
-    ls.dispose();
-
-    return false;
   }
 
   /**


### PR DESCRIPTION
Apparently my assumption of the TypeScript language server swallowing download errors was incorrect. This try/catches attempts to download types.
