### PR TITLE
fix: refactor blocking code from all plugins

### DIFF
--- a/packages/plugins/src/plugins/index.ts
+++ b/packages/plugins/src/plugins/index.ts
@@ -1,4 +1,4 @@
 export { DiagnosticCheckPlugin, DiagnosticCheckPluginOptions } from './diagnostic-check.plugin';
 export { DiagnosticFixPlugin, DiagnosticFixPluginOptions } from './diagnostic-fix.plugin';
-export { LintPlugin, LintPluginOption } from './lint.plugin';
+export { LintPlugin, LintPluginOptions } from './lint.plugin';
 export { ReRehearsePlugin, ReRehearsePluginOptions } from './re-rehearse.plugin';

--- a/packages/plugins/test/re-rehearse.plugin.test.ts
+++ b/packages/plugins/test/re-rehearse.plugin.test.ts
@@ -24,7 +24,7 @@ describe('Test ReRehearsalPlugin', function () {
     project.write();
     const fileNames = Object.keys(project.files).map((file) => resolve(project.baseDir, file));
 
-    const service = new RehearsalService({ baseUrl: project.baseDir }, fileNames);
+    const rehearsal = new RehearsalService({ baseUrl: project.baseDir }, fileNames);
     const reporter = new Reporter({
       tsVersion: '',
       projectName: '@rehearsal/test',
@@ -35,8 +35,12 @@ describe('Test ReRehearsalPlugin', function () {
     const plugin = new ReRehearsePlugin();
 
     for (const fileName of fileNames) {
-      const result = await plugin.run(fileName, { service, reporter, commentTag: '@rehearsal' });
-      const resultText = service.getFileText(fileName).trim();
+      const result = await plugin.run(
+        fileName,
+        { basePath: '', rehearsal, reporter },
+        { commentTag: '@rehearsal' }
+      );
+      const resultText = rehearsal.getFileText(fileName).trim();
 
       expect(result).toHaveLength(1);
       expect(resultText).toMatchSnapshot();

--- a/packages/regen/package.json
+++ b/packages/regen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rehearsal/regen",
-  "version": "1.0.5-beta",
+  "version": "1.0.4-beta",
   "description": "Rehearsal JavaScript to TypeScript migration status reporting tool",
   "keywords": [
     "rehearsal",

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,4 +1,4 @@
-export { Plugin, PluginOptions } from './plugin';
+export { Plugin, PluginOptions, PluginsRunnerContext, PluginsRunner } from './plugin';
 export { RehearsalService } from './rehearsal-service';
 export { RehearsalServiceHost } from './rehearsal-service-host';
 

--- a/packages/service/src/plugin.ts
+++ b/packages/service/src/plugin.ts
@@ -1,17 +1,97 @@
-import type { Reporter } from '@rehearsal/reporter';
-import type { Logger } from 'winston';
-
-import type { RehearsalService } from './rehearsal-service';
+import { Reporter } from '@rehearsal/reporter';
+import { Logger } from 'winston';
+import { RehearsalService } from './rehearsal-service';
 
 export interface Plugin<PluginOptions> {
-  run(fileName: string, options: PluginOptions): PluginResult;
+  run(fileName: string, context: PluginsRunnerContext, options: PluginOptions): PluginResult;
 }
 
-export interface PluginOptions {
-  [key: string]: unknown;
-  service: RehearsalService;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PluginOptions {}
+
+export type PluginResult = Promise<string[]>;
+
+export interface PluginsRunnerContext {
+  basePath: string;
+  rehearsal: RehearsalService;
   reporter: Reporter;
   logger?: Logger;
 }
 
-export type PluginResult = Promise<string[]>;
+// TODO: Remove this class with @rehearsal/logger
+export interface PluginLogger {
+  log(message: string): void;
+}
+
+export class PluginsRunner {
+  plugins: { plugin: Plugin<PluginOptions>; options: PluginOptions }[] = [];
+  context: PluginsRunnerContext;
+
+  constructor(context: PluginsRunnerContext) {
+    this.context = context;
+  }
+
+  queue<P extends Plugin<PluginOptions>>(
+    plugin: P,
+    options: P extends Plugin<infer O> ? O : never
+  ): this {
+    this.plugins.push({ plugin, options });
+    return this;
+  }
+
+  async run(fileNames: string[], logger?: PluginLogger): Promise<void> {
+    const fileIteratorProcessor = this.processFilesGenerator(fileNames, logger);
+
+    for await (const _ of fileIteratorProcessor) {
+      const next = async (): Promise<void> => {
+        const { done } = await fileIteratorProcessor.next();
+        if (!done) {
+          setImmediate(next);
+        }
+      };
+
+      await next();
+    }
+  }
+
+  // Async generator to process files
+  // Since this is a long-running process, we need to yield to the event loop
+  // So we don't block the main thread
+  async *processFilesGenerator(fileNames: string[], logger?: PluginLogger): AsyncGenerator<void> {
+    for (const fileName of fileNames) {
+      logger?.log(`processing file: ${fileName.replace(this.context.basePath, '')}`);
+
+      const allChangedFiles: Set<string> = new Set();
+      const pluginIteratorProcessor = this.processPlugins(fileName, allChangedFiles);
+
+      for await (const changedFile of pluginIteratorProcessor) {
+        const next = async (): Promise<void> => {
+          const { done } = await pluginIteratorProcessor.next();
+          // Save file to the filesystem
+          changedFile.forEach((file) => this.context.rehearsal.saveFile(file));
+
+          if (!done) {
+            setImmediate(next);
+          }
+        };
+
+        await next();
+      }
+
+      yield;
+    }
+  }
+
+  async *processPlugins(
+    fileName: string,
+    allChangedFiles: Set<string>
+  ): AsyncGenerator<Set<string>> {
+    for (const plugin of this.plugins) {
+      const changedFiles = await plugin.plugin.run(fileName, this.context, plugin.options);
+
+      allChangedFiles = new Set([...allChangedFiles, ...changedFiles]);
+
+      yield allChangedFiles;
+    }
+  }
+}

--- a/packages/service/src/rehearsal-service.ts
+++ b/packages/service/src/rehearsal-service.ts
@@ -1,4 +1,4 @@
-import { createLanguageService, resolveModuleName, ScriptSnapshot, sys } from 'typescript';
+import { createLanguageService, ScriptSnapshot } from 'typescript';
 
 import { RehearsalServiceHost } from './rehearsal-service-host';
 import type {
@@ -75,18 +75,5 @@ export class RehearsalService {
    */
   getSuggestionDiagnostics(fileName: string): DiagnosticWithLocation[] {
     return this.service.getSuggestionDiagnostics(fileName);
-  }
-
-  /**
-   * Provides a path to a module file by its name
-   */
-  resolveModuleName(moduleName: string, containingFile: string): string | undefined {
-    const result = resolveModuleName(
-      moduleName,
-      containingFile,
-      this.host.getCompilationSettings(),
-      sys
-    );
-    return result?.resolvedModule?.resolvedFileName;
   }
 }

--- a/packages/service/test/rehearsal-service.test.ts
+++ b/packages/service/test/rehearsal-service.test.ts
@@ -81,20 +81,4 @@ describe('Test service', function () {
     expect(diagnostics[0].code).toEqual(2304);
     expect(diagnostics[0].messageText).toEqual(`Cannot find name 'oops'.`);
   });
-
-  test('resolveModuleName, existing module', async () => {
-    const service = new RehearsalService(options, fileNames);
-
-    const path = service.resolveModuleName('typescript', fileName);
-
-    expect(path).toContain('node_modules/typescript');
-  });
-
-  test('resolveModuleName, non-existing module', async () => {
-    const service = new RehearsalService(options, fileNames);
-
-    const path = service.resolveModuleName('this-module-is-not-exists', fileName);
-
-    expect(path).toBeUndefined();
-  });
 });


### PR DESCRIPTION
Use `migrate` code as an example of a non-blocking solution for `PluginsRunner` :)
Now all 3 - `migrate`, `upgrade`, and `regen` utilizes the same code... and seem can be merged together because they are basically the same (except for a number of plugins and their configs. 

Also separated PluginOptions and PluginsRunnerContext