### PR TITLE
fix: logging of migration order

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -121,7 +121,10 @@ export async function initTask(
         filterByPackageName: [],
       });
       const files: SourceFile[] = strategy.getMigrationOrder();
-      DEBUG_CALLBACK('migrationOrder', files);
+      DEBUG_CALLBACK(
+        'migrationOrder',
+        files.map((file) => file.relativePath)
+      );
 
       ctx.strategy = strategy;
       ctx.sourceFilesWithAbsolutePath = files.map((f) => f.path);


### PR DESCRIPTION
Before we would log out the `SourceFile` objects but we should list the paths.

Before:
<img width="480" alt="Screenshot 2023-02-04 at 10 57 22 AM" src="https://user-images.githubusercontent.com/183799/216777163-b798dcdb-6075-45e5-a8d6-7d7e91fe7bb6.png">

After:
<img width="431" alt="Screenshot 2023-02-04 at 10 56 34 AM" src="https://user-images.githubusercontent.com/183799/216777171-8caf8776-266f-465e-a127-3be7707c3044.png">


