### PR TITLE
chore: lazy load modules who need typescript in cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
     "listr2": "^5.0.7",
     "simple-git": "^3.16.0",
     "tmp": "^0.2.1",
-    "typescript": "^4.9.5",
     "which": "^3.0.0",
     "winston": "^3.8.2",
     "yaml": "^2.2.1"
@@ -56,7 +55,8 @@
   "devDependencies": {
     "@types/which": "^2.0.1",
     "typescript-json-schema": "^0.55.0",
-    "vitest": "^0.28.4"
+    "vitest": "^0.28.4",
+    "typescript": "^4.9.5"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -1,8 +1,6 @@
 import { resolve } from 'path';
 import { Logger } from 'winston';
 import { debug } from 'debug';
-import { Reporter } from '@rehearsal/reporter';
-import { migrate } from '@rehearsal/migrate';
 import chalk from 'chalk';
 import execa = require('execa');
 
@@ -13,7 +11,7 @@ import {
   prettyGitDiff,
   gitAddIfInRepo,
 } from '@rehearsal/utils';
-import { generateReports, getReportSummary } from '../../../helpers/report';
+
 import type { ListrTask } from 'listr2';
 
 import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
@@ -29,6 +27,11 @@ export async function convertTask(
     title: 'Convert JS files to TS',
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
+      // Because we have to eagerly import all the tasks we need tolazily load these
+      // modules because they refer to typescript which may or may not be installed
+      const migrate = await import('@rehearsal/migrate').then((m) => m.migrate);
+      const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
+      const { generateReports, getReportSummary } = await import('../../../helpers/report');
       // If context is provide via external parameter, merge with existed
       if (context) {
         ctx = { ...ctx, ...context };

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -1,11 +1,8 @@
 import { resolve } from 'path';
 import { Logger } from 'winston';
-import { Reporter } from '@rehearsal/reporter';
-import { regen } from '@rehearsal/regen';
 import execa = require('execa');
 
 import { determineProjectName, getPathToBinary } from '@rehearsal/utils';
-import { generateReports, getRegenSummary } from '../../../helpers/report';
 import type { ListrTask } from 'listr2';
 
 import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types';
@@ -18,6 +15,12 @@ export async function regenTask(
     title: 'Regenerating report for TS errors and Eslint errors',
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
     task: async (_: MigrateCommandContext, task): Promise<void> => {
+      // Because we have to eagerly import all the tasks we need tolazily load these
+      // modules because they refer to typescript which may or may not be installed
+      const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
+      const { generateReports, getRegenSummary } = await import('../../../helpers/report');
+      const regen = await import('@rehearsal/regen').then((m) => m.regen);
+
       const projectName = determineProjectName() || '';
       const { basePath } = options;
       const tscPath = await getPathToBinary('tsc');

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -13,7 +13,7 @@ const FIXTURE_APP_PATH = resolve(__dirname, '../fixtures/app');
 // eg 4.2.4 since we want to be sure to get compile errors
 const TEST_TSC_VERSION = '4.5.5';
 // we bundle the latest version of typescript with the cli
-const ORIGIN_TSC_VERSION = packageJson.dependencies.typescript;
+const ORIGIN_TSC_VERSION = packageJson.devDependencies.typescript;
 let WORKING_BRANCH = '';
 
 const beforeEachPrep = async (): Promise<void> => {

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -48,7 +48,7 @@ export const FIXTURE_APP_PATH = resolve(__dirname, '../fixtures/app');
 // we want an older version of typescript to test against
 // eg 4.2.4 since we want to be sure to get compile errors
 export const TEST_TSC_VERSION = '4.5.5';
-export const ORIGIN_TSC_VERSION = packageJson.dependencies.typescript;
+export const ORIGIN_TSC_VERSION = packageJson.devDependencies.typescript;
 
 // we bundle typescript in deps
 export const beforeEachPrep = async (): Promise<void> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,13 +152,13 @@ importers:
       listr2: 5.0.7_enquirer@2.3.6
       simple-git: 3.16.0
       tmp: 0.2.1
-      typescript: 4.9.5
       which: 3.0.0
       winston: 3.8.2
       yaml: 2.2.1
     devDependencies:
       '@types/which': 2.0.1
       typescript-json-schema: 0.55.0
+      typescript: 4.9.5
       vitest: 0.28.4
 
   packages/codefixes:
@@ -5432,6 +5432,7 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /ufo/1.0.1:
     resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}


### PR DESCRIPTION
This moves imports that eagerly import typescript e.g. `import * as ts from "typescript";` to be lazily loaded as they are needed. As a result of this we should be able to remove the dependency on typescript and simply make it a devDependency.
