### PR TITLE
feat: skip config tasks after first run

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -14,6 +14,7 @@ import {
   createScriptsTask,
   regenTask,
   validateTask,
+  reportExisted,
 } from './tasks';
 
 import type { MigrateCommandOptions } from '../../types';
@@ -53,7 +54,11 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
 
   logger.info(`@rehearsal/migrate ${version.trim()}`);
 
-  if (!options.dryRun && !options.regen) {
+  // Show git warning if:
+  // 1. Not --dryRun
+  // 2. Not --regen
+  // 3. First time run (check if any report exists)
+  if (!options.dryRun && !options.regen && !reportExisted(options.basePath, options.outputPath)) {
     const hasUncommittedFiles = await gitIsRepoDirty(options.basePath);
     if (hasUncommittedFiles) {
       logger.warn(

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -30,7 +30,7 @@ export async function lintConfigTask(
 ): Promise<ListrTask> {
   return {
     title: 'Create eslint config',
-    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skipLintConfig,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // If context is provide via external parameter, merge with existed
       if (context) {

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -12,7 +12,7 @@ export async function tsConfigTask(
 ): Promise<ListrTask> {
   return {
     title: 'Create tsconfig.json',
-    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skipTsConfig,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // If context is provide via external parameter, merge with existed
       if (context) {

--- a/packages/cli/src/commands/migrate/tasks/create-scripts.ts
+++ b/packages/cli/src/commands/migrate/tasks/create-scripts.ts
@@ -6,7 +6,7 @@ import type { MigrateCommandContext, MigrateCommandOptions } from '../../../type
 export async function createScriptsTask(options: MigrateCommandOptions): Promise<ListrTask> {
   return {
     title: 'Add package scripts',
-    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skipScriptConfig,
     task: async (): Promise<void> => {
       addPackageJsonScripts(options.basePath, {
         'build:tsc': 'tsc -b',

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -20,7 +20,7 @@ export async function depInstallTask(
 ): Promise<ListrTask> {
   return {
     title: 'Install dependencies',
-    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skipDepInstall,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // If context is provide via external parameter, merge with existed
       if (context) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,6 +21,10 @@ export type MigrateCommandOptions = {
 
 export type MigrateCommandContext = {
   skip: boolean;
+  skipTsConfig: boolean;
+  skipLintConfig: boolean;
+  skipDepInstall: boolean;
+  skipScriptConfig: boolean;
   userConfig: UserConfig | undefined;
   strategy: MigrationStrategy;
   sourceFilesWithAbsolutePath: string[];

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1
 
+exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
+"info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
+[STARTED] Initialize
+[DATA] Running migration on initilization
+[SUCCESS] Initialize
+[STARTED] Convert JS files to TS
+[TITLE] Migration Complete
+[TITLE]   0 JS files converted to TS
+[TITLE]   0 errors caught by rehearsal
+[TITLE]   0 have been fixed by rehearsal
+[TITLE]   0 errors need to be fixed manually
+[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 0 eslint errors, with details in the report
+[SUCCESS] Migration Complete
+[SUCCESS]   0 JS files converted to TS
+[SUCCESS]   0 errors caught by rehearsal
+[SUCCESS]   0 have been fixed by rehearsal
+[SUCCESS]   0 errors need to be fixed manually
+[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 0 eslint errors, with details in the report"
+`;
+
 exports[`migrate: e2e > Print debug messages with verbose 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project

--- a/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/validate.test.ts.snap
@@ -10,6 +10,11 @@ exports[`Task: validate > pass with package.json 1`] = `
 [SUCCESS] Validate project"
 `;
 
+exports[`Task: validate > set skips if report exists 1`] = `
+"[STARTED] Validate project
+[SUCCESS] Validate project"
+`;
+
 exports[`Task: validate > show warning message for missing files in --regen 1`] = `
 "[STARTED] Validate project
 Eslint config (.eslintrc.{js,yml,json,yaml}) does not exist. You need to run rehearsal migrate first before you can run rehearsal migrate --regen

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -88,6 +88,32 @@ describe('migrate - validation', async () => {
       'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'
     );
   });
+
+  test('pass in a dirty git in multi runs', async () => {
+    // simulate clean git project
+    const git = simpleGit({
+      baseDir: basePath,
+    } as Partial<SimpleGitOptions>);
+    await git
+      .init()
+      .add('package.json')
+      .addConfig('user.name', 'tester')
+      .addConfig('user.email', 'tester@tester.com')
+      .commit('test');
+
+    const { stdout: firstRunStdout } = await runBin('migrate', [], {
+      cwd: basePath,
+    });
+    expect(firstRunStdout).not.toContain(
+      'You have uncommitted files in your repo. Please commit or stash them as Rehearsal will reset your uncommitted changes.'
+    );
+    expect(firstRunStdout).toContain('Migration Complete');
+
+    const { stdout: secondRunStdout } = await runBin('migrate', [], {
+      cwd: basePath,
+    });
+    expect(cleanOutput(secondRunStdout, basePath)).toMatchSnapshot();
+  });
 });
 
 describe('migrate: e2e', async () => {

--- a/packages/cli/test/commands/migrate/validate.test.ts
+++ b/packages/cli/test/commands/migrate/validate.test.ts
@@ -94,4 +94,20 @@ describe('Task: validate', async () => {
     await listrTaskRunner(tasks);
     expect(cleanOutput(output, basePath)).toMatchSnapshot();
   });
+
+  test('set skips if report exists', async () => {
+    const options = createMigrateOptions(basePath);
+    const tasks = [await validateTask(options, logger)];
+
+    // create dummy report
+    createFileSync(resolve(basePath, '.rehearsal', 'migrate-report.sarif'));
+
+    const { skipDepInstall, skipTsConfig, skipLintConfig, skipScriptConfig } =
+      await listrTaskRunner(tasks);
+    expect(skipDepInstall).toBeTruthy();
+    expect(skipTsConfig).toBeTruthy();
+    expect(skipLintConfig).toBeTruthy();
+    expect(skipScriptConfig).toBeTruthy();
+    expect(cleanOutput(output, basePath)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This fixes #692.

The PR adds check for report (`migration-report.xx`) existence, to decide if it is the first run or sequential runs. In sequential runs, these tasks would be skipped:
- git dirty check
- dep install
- ts config
- lint config
- inject scripts in `package.json`

For this one, I think checking report is good enough to prove if it is the first run or not, so there is no specific check for each configs in order to skip them. For example, we don't check `devDependencies` in `package.json`, to see if we need to skip the dep install tasks.

I'm open to add more specific checks if anyone thinks it's needed.