### PR TITLE
fix: correct line and column numbers for sonarqube

### DIFF
--- a/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
@@ -12,10 +12,10 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"The declaration 'react' is never read or used. Remove the declaration or use it.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 1,
-          \\"startColumn\\": 1,
-          \\"endLine\\": 1,
-          \\"endColumn\\": 12
+          \\"startLine\\": 0,
+          \\"startColumn\\": 0,
+          \\"endLine\\": 0,
+          \\"endColumn\\": 11
         }
       }
     },
@@ -28,10 +28,10 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"The variable 'a' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 1,
-          \\"startColumn\\": 10,
-          \\"endLine\\": 1,
-          \\"endColumn\\": 20
+          \\"startLine\\": 0,
+          \\"startColumn\\": 9,
+          \\"endLine\\": 0,
+          \\"endColumn\\": 19
         }
       }
     },
@@ -44,10 +44,10 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 1,
-          \\"startColumn\\": 10,
-          \\"endLine\\": 1,
-          \\"endColumn\\": 26
+          \\"startLine\\": 0,
+          \\"startColumn\\": 9,
+          \\"endLine\\": 0,
+          \\"endColumn\\": 25
         }
       }
     },
@@ -60,10 +60,10 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"Unexpected any. Specify a different type.\\",
         \\"filePath\\": \\"/base/path/file2.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 1,
-          \\"startColumn\\": 1,
-          \\"endLine\\": 1,
-          \\"endColumn\\": 12
+          \\"startLine\\": 0,
+          \\"startColumn\\": 0,
+          \\"endLine\\": 0,
+          \\"endColumn\\": 11
         }
       }
     }


### PR DESCRIPTION
Closes #714 

We bump line number and column number for sarif reader by 1. Now we need to deduct by 1 for sonarqube. 