### PR TITLE
fix: release script

### DIFF
--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -6,8 +6,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist",
-    "fixtures"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/release.js
+++ b/release.js
@@ -122,9 +122,9 @@ function publish() {
   execSync(gitPushTags);
 
   // publish
-  // const pnpmPublish = `pnpm -r publish`;
-  // console.log(pnpmPublish);
-  // execSync(pnpmPublish);
+  const pnpmPublish = `pnpm -r publish`;
+  console.log(pnpmPublish);
+  execSync(pnpmPublish);
 
   // done
   console.log(`Released ${newVersion} has been published`);


### PR DESCRIPTION
The `pnpm -r publish` is stuck because of node_modules in fixtures... 
We don't need those folders to do the release e anyway.

Fixes: #708