### PR TITLE
feat: init flag for migrate

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -33,6 +33,7 @@ process.on('SIGINT', () => {
 migrateCommand
   .name('migrate')
   .description('migrate a javascript project to typescript')
+  .option('--init', 'only initializes the project', false)
   .option(
     '-p, --basePath <project base path>',
     'base directory of your project',
@@ -93,7 +94,9 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
   ];
 
   try {
-    if (options.interactive) {
+    if (options.init) {
+      await new Listr(tasks, defaultListrOption).run();
+    } else if (options.interactive) {
       // For issue #549, have to use simple renderer for the interactive edit flow
       // previous ctx is needed for the isolated convertTask
       const ctx = await new Listr(tasks, defaultListrOption).run();

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -32,7 +32,7 @@ export async function tsConfigTask(
           tsConfig.compilerOptions.strict = true;
           writeJSONSync(configPath, tsConfig, { spaces: 2 });
         } else {
-          writeTSConfig(options.basePath, ctx.sourceFilesWithRelativePath);
+          writeTSConfig(options.basePath, options.init ? [] : ctx.sourceFilesWithRelativePath);
         }
       }
       await gitAddIfInRepo(configPath, options.basePath); // stage tsconfig.json if in a git repo

--- a/packages/cli/src/commands/migrate/tasks/create-scripts.ts
+++ b/packages/cli/src/commands/migrate/tasks/create-scripts.ts
@@ -9,7 +9,6 @@ export async function createScriptsTask(options: MigrateCommandOptions): Promise
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skipScriptConfig,
     task: async (): Promise<void> => {
       addPackageJsonScripts(options.basePath, {
-        'build:tsc': 'tsc -b',
         'lint:tsc': 'tsc --noEmit',
       });
     },

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -8,6 +8,7 @@ export type Formats = 'sarif' | 'json' | 'sonarqube' | 'md';
 export * from './configs/rehearsal-config';
 
 export type MigrateCommandOptions = {
+  init: boolean;
   basePath: string;
   entrypoint: string;
   format: Formats[];

--- a/packages/cli/test/commands/migrate/__snapshots__/create-scripts.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/create-scripts.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`Task: create-scripts > add build:tsc and lint:tsc in package.json 1`] = `
+exports[`Task: create-scripts > add lint:tsc in package.json 1`] = `
 "[STARTED] Add package scripts
 [SUCCESS] Add package scripts
 "

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -272,6 +272,89 @@ exports[`migrate: e2e > default migrate command 7`] = `
 }"
 `;
 
+exports[`migrate: e2e > init flag 1`] = `
+"info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
+[STARTED] Initialize
+[DATA] Running migration on basic
+[SUCCESS] Initialize
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[SUCCESS] Create eslint config
+[STARTED] Add package scripts
+[SUCCESS] Add package scripts"
+`;
+
+exports[`migrate: e2e > init flag 2`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2021",
+  },
+  "include": [],
+}
+`;
+
+exports[`migrate: e2e > init flag 3`] = `
+{
+  "dependencies": {
+    "path": "*",
+  },
+  "devDependencies": {
+    "@types/node": "^18.13.0",
+    "@typescript-eslint/eslint-plugin": "^5.51.0",
+    "@typescript-eslint/parser": "^5.51.0",
+    "eslint": "^8.33.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "prettier": "^2.8.4",
+    "typescript": "^4.9.5",
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "name": "basic",
+  "packageManager": "pnpm@7.12.1",
+  "scripts": {
+    "lint:tsc": "tsc --noEmit",
+  },
+  "version": "1.0.0",
+}
+`;
+
+exports[`migrate: e2e > init flag 4`] = `
+"module.exports = {
+  \\"parser\\": \\"@typescript-eslint/parser\\",
+  \\"parserOptions\\": {
+    \\"sourceType\\": \\"module\\"
+  },
+  \\"plugins\\": [
+    \\"@typescript-eslint\\",
+    \\"prettier\\"
+  ],
+  \\"extends\\": [
+    \\"plugin:@typescript-eslint/eslint-recommended\\",
+    \\"plugin:@typescript-eslint/recommended\\",
+    \\"eslint:recommended\\",
+    \\"plugin:prettier/recommended\\",
+    \\"prettier\\"
+  ]
+}"
+`;
+
 exports[`migrate: e2e > regen result after the first pass 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project

--- a/packages/cli/test/commands/migrate/create-scripts.test.ts
+++ b/packages/cli/test/commands/migrate/create-scripts.test.ts
@@ -24,13 +24,12 @@ describe('Task: create-scripts', async () => {
     vi.clearAllMocks();
   });
 
-  test('add build:tsc and lint:tsc in package.json', async () => {
+  test('add lint:tsc in package.json', async () => {
     const options = createMigrateOptions(basePath);
     const tasks = [await createScriptsTask(options)];
     await listrTaskRunner(tasks);
 
     const packageJson = readJSONSync(resolve(basePath, 'package.json'));
-    expect(packageJson.scripts['build:tsc']).toBe('tsc -b');
     expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
 
     expect(output).matchSnapshot();

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -85,6 +85,7 @@ export function createMigrateOptions(
 ): MigrateCommandOptions {
   return {
     basePath,
+    init: false,
     entrypoint: '',
     format: ['sarif' as Formats],
     outputPath: '.rehearsal',


### PR DESCRIPTION
Fixes #726

This adds a `--init` flag to `migrate` that allows us to quickly configure projects without actually migrating them fully.
