### PR TITLE
feat: reporting for sequential runs

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -38,12 +38,12 @@ export async function convertTask(
       }
 
       const projectName = determineProjectName() || '';
-      const { basePath } = options;
+      const { basePath, entrypoint } = options;
       const tscPath = await getPathToBinary('tsc', { cwd: options.basePath });
       const { stdout } = await execa(tscPath, ['--version']);
       const tsVersion = stdout.split(' ')[1];
       const reporter = new Reporter(
-        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate' },
+        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate', entrypoint },
         logger
       );
 
@@ -58,6 +58,7 @@ export async function convertTask(
 
             const input = {
               basePath: ctx.targetPackagePath,
+              entrypoint: options.entrypoint,
               sourceFiles: [f],
               logger: logger,
               reporter,
@@ -126,6 +127,7 @@ export async function convertTask(
         } else {
           const input = {
             basePath: ctx.targetPackagePath,
+            entrypoint: options.entrypoint,
             sourceFiles: ctx.sourceFilesWithAbsolutePath,
             logger: logger,
             reporter,

--- a/packages/cli/src/commands/migrate/tasks/index.ts
+++ b/packages/cli/src/commands/migrate/tasks/index.ts
@@ -6,3 +6,4 @@ export * from './config-ts';
 export * from './create-scripts';
 export * from './regen';
 export * from './validate';
+export * from './sequential';

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -14,7 +14,7 @@ export async function regenTask(
   return {
     title: 'Regenerating report for TS errors and Eslint errors',
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
-    task: async (_: MigrateCommandContext, task): Promise<void> => {
+    task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // Because we have to eagerly import all the tasks we need tolazily load these
       // modules because they refer to typescript which may or may not be installed
       const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
@@ -22,17 +22,21 @@ export async function regenTask(
       const regen = await import('@rehearsal/regen').then((m) => m.regen);
 
       const projectName = determineProjectName() || '';
-      const { basePath } = options;
+      // const { basePath, entrypoint } = options;
+      const basePath = ctx.targetPackagePath;
+      const { entrypoint } = options;
       const tscPath = await getPathToBinary('tsc');
       const { stdout } = await execa(tscPath, ['--version']);
       const tsVersion = stdout.split(' ')[1];
       const reporter = new Reporter(
-        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate' },
+        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate', entrypoint },
         logger
       );
 
       const input = {
         basePath,
+        entrypoint,
+        sourceFiles: ctx.sourceFilesWithAbsolutePath,
         logger: logger,
         reporter,
         task,

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -14,7 +14,7 @@ export async function regenTask(
   return {
     title: 'Regenerating report for TS errors and Eslint errors',
     enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
-    task: async (ctx: MigrateCommandContext, task): Promise<void> => {
+    task: async (_: MigrateCommandContext, task): Promise<void> => {
       // Because we have to eagerly import all the tasks we need tolazily load these
       // modules because they refer to typescript which may or may not be installed
       const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
@@ -22,9 +22,7 @@ export async function regenTask(
       const regen = await import('@rehearsal/regen').then((m) => m.regen);
 
       const projectName = determineProjectName() || '';
-      // const { basePath, entrypoint } = options;
-      const basePath = ctx.targetPackagePath;
-      const { entrypoint } = options;
+      const { basePath, entrypoint } = options;
       const tscPath = await getPathToBinary('tsc');
       const { stdout } = await execa(tscPath, ['--version']);
       const tsVersion = stdout.split(' ')[1];
@@ -36,7 +34,7 @@ export async function regenTask(
       const input = {
         basePath,
         entrypoint,
-        sourceFiles: ctx.sourceFilesWithAbsolutePath,
+        sourceFiles: [],
         logger: logger,
         reporter,
         task,

--- a/packages/cli/src/commands/migrate/tasks/sequential.ts
+++ b/packages/cli/src/commands/migrate/tasks/sequential.ts
@@ -1,0 +1,76 @@
+import { resolve } from 'path';
+import { Logger } from 'winston';
+import { debug } from 'debug';
+import execa = require('execa');
+import { determineProjectName, getPathToBinary, gitAddIfInRepo } from '@rehearsal/utils';
+import { getSourceFiles } from '../../../helpers/sequential';
+import type { ListrTask } from 'listr2';
+
+import type { MigrateCommandContext, MigrateCommandOptions, PreviousRuns } from '../../../types';
+
+const DEBUG_CALLBACK = debug('rehearsal:migrate:sequential');
+
+export async function sequentialTask(
+  options: MigrateCommandOptions,
+  logger: Logger,
+  previousRuns: PreviousRuns
+): Promise<ListrTask> {
+  return {
+    title:
+      'Regenerating past migrate report(s), generating current migrate report and merging all reports',
+    enabled: (ctx: MigrateCommandContext): boolean => !ctx.skip,
+    task: async (_: MigrateCommandContext, task): Promise<void> => {
+      const regen = await import('@rehearsal/regen').then((m) => m.regen);
+      const migrate = await import('@rehearsal/migrate').then((m) => m.migrate);
+      const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
+      const { generateReports, getReportSummary, getRegenSummary } = await import('../../../helpers/report');
+
+      const projectName = determineProjectName() || '';
+      const { basePath } = options;
+      const tscPath = await getPathToBinary('tsc', { cwd: options.basePath });
+      const { stdout } = await execa(tscPath, ['--version']);
+      const tsVersion = stdout.split(' ')[1];
+      const reporter = new Reporter(
+        {
+          tsVersion,
+          projectName,
+          basePath,
+          commandName: '@rehearsal/migrate',
+          previousFixedCount: previousRuns.previousFixedCount,
+        },
+        logger
+      );
+
+      for (const runPath of previousRuns.paths) {
+        const files = getSourceFiles(runPath.basePath, runPath.entrypoint);
+        const { scannedFiles } = await regen({
+          basePath: runPath.basePath,
+          entrypoint: runPath.entrypoint,
+          sourceFiles: files,
+          logger,
+          reporter,
+          task,
+        });
+
+        task.title = getRegenSummary(reporter.lastRun!, scannedFiles.length, true);
+      }
+
+      const currentRunFiles = getSourceFiles(options.basePath, options.entrypoint);
+
+      const { migratedFiles } = await migrate({
+        basePath,
+        entrypoint: options.entrypoint,
+        sourceFiles: currentRunFiles,
+        logger: logger,
+        reporter,
+        task,
+      });
+
+      DEBUG_CALLBACK('migratedFiles', migratedFiles);
+      const reportOutputPath = resolve(options.basePath, options.outputPath);
+      generateReports('migrate', reporter, reportOutputPath, options.format);
+      gitAddIfInRepo(reportOutputPath, basePath); // stage report if in git repo
+      task.title = getReportSummary(reporter.report, migratedFiles.length);
+    },
+  };
+}

--- a/packages/cli/src/commands/migrate/tasks/sequential.ts
+++ b/packages/cli/src/commands/migrate/tasks/sequential.ts
@@ -23,7 +23,9 @@ export async function sequentialTask(
       const regen = await import('@rehearsal/regen').then((m) => m.regen);
       const migrate = await import('@rehearsal/migrate').then((m) => m.migrate);
       const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
-      const { generateReports, getReportSummary, getRegenSummary } = await import('../../../helpers/report');
+      const { generateReports, getReportSummary, getRegenSummary } = await import(
+        '../../../helpers/report'
+      );
 
       const projectName = determineProjectName() || '';
       const { basePath } = options;

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -121,7 +121,7 @@ upgradeCommand
                   if (compare(ctx.latestAvailableBuild, ctx.currentTSVersion, '>')) {
                     ctx.tsVersion = ctx.latestAvailableBuild;
                     parent.title = `Rehearsing with typescript@${ctx.tsVersion}`;
-                    reporter.addSummary('tsVersion', ctx.tsVersion);
+                    reporter.addToRunSummary('tsVersion', ctx.tsVersion);
                   } else {
                     parent.title = `This application is already on the latest version of TypeScript@${ctx.currentTSVersion}. Exiting.`;
                     // this is a master skip that will skip the remainder of the tasks
@@ -144,7 +144,7 @@ upgradeCommand
                     await gitCheckoutNewLocalBranch(`${ctx.tsVersion}`);
                   }
                   await addDep([`typescript@${ctx.tsVersion}`], true);
-                  reporter.report.summary[0].tsVersion = ctx.tsVersion;
+                  reporter.addToRunSummary('tsVersion', ctx.tsVersion);
                 },
               },
               {

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -81,7 +81,7 @@ upgradeCommand
     const projectName = determineProjectName() || '';
 
     const reporter = new Reporter(
-      { tsVersion: '', projectName, basePath, commandName: '@rehearsal/upgrade' },
+      { tsVersion: '', projectName, basePath, commandName: '@rehearsal/upgrade', entrypoint: '' },
       logger
     );
 
@@ -144,7 +144,7 @@ upgradeCommand
                     await gitCheckoutNewLocalBranch(`${ctx.tsVersion}`);
                   }
                   await addDep([`typescript@${ctx.tsVersion}`], true);
-                  reporter.report.summary.tsVersion = ctx.tsVersion;
+                  reporter.report.summary[0].tsVersion = ctx.tsVersion;
                 },
               },
               {
@@ -217,7 +217,7 @@ upgradeCommand
           task: async (ctx, task) => {
             const configName = 'tsconfig.json';
 
-            await upgrade({ basePath, configName, reporter, logger });
+            await upgrade({ basePath, entrypoint: '', configName, reporter, logger });
 
             // TODO: Check if code actually been fixed
             task.title = 'Codefixes applied successfully';

--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -112,14 +112,14 @@ export function getRegenSummary<T extends ReportLike>(
   let message;
   if (!isSequential) {
     message = `Migration Report Generated\n\n
-    ${scannedFileCount} ts files have been scanned\n
-    ${totalErrorCount} errors caught by rehearsal\n
-      -- ${tsErrorCount} ts errors, marked by @ts-expect-error @rehearsal TODO\n
-      -- ${lintErrorCount} eslint errors, with details in the report\n`;
+  ${scannedFileCount} ts files have been scanned\n
+  ${totalErrorCount} errors caught by rehearsal\n
+    -- ${tsErrorCount} ts errors, marked by @ts-expect-error @rehearsal TODO\n
+    -- ${lintErrorCount} eslint errors, with details in the report\n`;
   } else {
     message = `Rescanning previously migrated files based on existing report:\n
-    ${scannedFileCount} ts files have been scanned\n
-    ${totalErrorCount} errors caught by rehearsal, and will be merged into the migration report\n
+  ${scannedFileCount} ts files have been scanned\n
+  ${totalErrorCount} errors caught by rehearsal, and will be merged into the migration report\n
     `;
   }
 

--- a/packages/cli/src/helpers/sequential.ts
+++ b/packages/cli/src/helpers/sequential.ts
@@ -1,0 +1,11 @@
+import { getMigrationStrategy, SourceFile } from '@rehearsal/migration-graph';
+// import { type RunPath } from '../types';
+
+export function getSourceFiles(basePath: string, entrypoint: string): string[] {
+  const strategy = getMigrationStrategy(basePath, {
+    entrypoint,
+  });
+  const sourceFiles: SourceFile[] = strategy.getMigrationOrder();
+  const files = sourceFiles.map((f) => f.path);
+  return files;
+}

--- a/packages/cli/src/helpers/sequential.ts
+++ b/packages/cli/src/helpers/sequential.ts
@@ -1,5 +1,4 @@
 import { getMigrationStrategy, SourceFile } from '@rehearsal/migration-graph';
-// import { type RunPath } from '../types';
 
 export function getSourceFiles(basePath: string, entrypoint: string): string[] {
   const strategy = getMigrationStrategy(basePath, {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -65,3 +65,13 @@ export type TSConfig = {
     strict: boolean;
   };
 };
+
+export type RunPath = {
+  basePath: string;
+  entrypoint: string;
+};
+
+export type PreviousRuns = {
+  paths: RunPath[];
+  previousFixedCount: number;
+};

--- a/packages/cli/test/commands/migrate/__snapshots__/convert.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/convert.test.ts.snap
@@ -62,18 +62,18 @@ exports[`Task: convert > accept and discard changes with git 1`] = `
 [DATA]   Discard
 [TITLE] Migration Complete
 [TITLE]   3 JS files converted to TS
-[TITLE]   3 errors caught by rehearsal
+[TITLE]   2 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   2 errors need to be fixed manually
+[TITLE]   1 errors need to be fixed manually
 [TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 2 eslint errors, with details in the report
+[TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Migration Complete
 [SUCCESS]   3 JS files converted to TS
-[SUCCESS]   3 errors caught by rehearsal
+[SUCCESS]   2 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   2 errors need to be fixed manually
+[SUCCESS]   1 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 2 eslint errors, with details in the report"
+[SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
 exports[`Task: convert > accept changes without git 1`] = `
@@ -134,18 +134,18 @@ exports[`Task: convert > accept changes without git 1`] = `
 [DATA]   Accept
 [TITLE] Migration Complete
 [TITLE]   3 JS files converted to TS
-[TITLE]   3 errors caught by rehearsal
+[TITLE]   2 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   2 errors need to be fixed manually
+[TITLE]   1 errors need to be fixed manually
 [TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 2 eslint errors, with details in the report
+[TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Migration Complete
 [SUCCESS]   3 JS files converted to TS
-[SUCCESS]   3 errors caught by rehearsal
+[SUCCESS]   2 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   2 errors need to be fixed manually
+[SUCCESS]   1 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 2 eslint errors, with details in the report"
+[SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
 exports[`Task: convert > againt specific basePath via -basePath option 1`] = `
@@ -431,16 +431,16 @@ exports[`Task: convert > view changes in $EDITOR 1`] = `
 [DATA]   Edit
 [TITLE] Migration Complete
 [TITLE]   3 JS files converted to TS
-[TITLE]   3 errors caught by rehearsal
+[TITLE]   2 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   2 errors need to be fixed manually
+[TITLE]   1 errors need to be fixed manually
 [TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 2 eslint errors, with details in the report
+[TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Migration Complete
 [SUCCESS]   3 JS files converted to TS
-[SUCCESS]   3 errors caught by rehearsal
+[SUCCESS]   2 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   2 errors need to be fixed manually
+[SUCCESS]   1 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 2 eslint errors, with details in the report"
+[SUCCESS]     -- 1 eslint errors, with details in the report"
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -24,6 +24,30 @@ exports[`migrate - validation > pass in a dirty git in multi runs 1`] = `
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
+exports[`migrate - validation > pass in a dirty git in multi runs, regenerate past run reports before current run 1`] = `
+"info:    @rehearsal/migrate<test-version>
+[STARTED] Validate project
+[SUCCESS] Validate project
+[STARTED] Initialize
+[DATA] Running migration on initilization
+[SUCCESS] Initialize
+[STARTED] Convert JS files to TS
+[TITLE] Migration Complete
+[TITLE]   0 JS files converted to TS
+[TITLE]   0 errors caught by rehearsal
+[TITLE]   0 have been fixed by rehearsal
+[TITLE]   0 errors need to be fixed manually
+[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 0 eslint errors, with details in the report
+[SUCCESS] Migration Complete
+[SUCCESS]   0 JS files converted to TS
+[SUCCESS]   0 errors caught by rehearsal
+[SUCCESS]   0 have been fixed by rehearsal
+[SUCCESS]   0 errors need to be fixed manually
+[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 0 eslint errors, with details in the report"
+`;
+
 exports[`migrate: e2e > Print debug messages with --verbose 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project

--- a/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
@@ -1,0 +1,115 @@
+// Vitest Snapshot v1
+
+exports[`Task: sequential > sequential run regen on the existing report, and run migrate on current base path and entrypoint 1`] = `
+"[STARTED] Initialize
+[DATA] Running migration on sequential
+[SUCCESS] Initialize
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[SUCCESS] Create eslint config
+[STARTED] Regenerating past migrate report(s), generating current migrate report and merging all reports
+[DATA] processing file: /foo.ts
+[DATA] processing file: /index.ts
+[DATA] processing file: /depends-on-foo.ts
+[TITLE] Rescanning previously migrated files based on existing report:
+[TITLE] 
+[TITLE]     3 ts files have been scanned
+[TITLE] 
+[TITLE]     4 errors caught by rehearsal, and will be merged into the migration report
+[TITLE] 
+[TITLE]     
+[DATA] processing file: /foo.ts
+[DATA] processing file: /index.ts
+[TITLE] Migration Complete
+[TITLE] 
+[TITLE] 
+[TITLE]   2 JS files converted to TS
+[TITLE] 
+[TITLE]   4 errors caught by rehearsal
+[TITLE] 
+[TITLE]   2 have been fixed by rehearsal
+[TITLE] 
+[TITLE]   2 errors need to be fixed manually
+[TITLE] 
+[TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE] 
+[TITLE]     -- 1 eslint errors, with details in the report
+[TITLE] 
+[SUCCESS] Migration Complete
+[SUCCESS] 
+[SUCCESS] 
+[SUCCESS]   2 JS files converted to TS
+[SUCCESS] 
+[SUCCESS]   4 errors caught by rehearsal
+[SUCCESS] 
+[SUCCESS]   2 have been fixed by rehearsal
+[SUCCESS] 
+[SUCCESS]   2 errors need to be fixed manually
+[SUCCESS] 
+[SUCCESS]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS] 
+[SUCCESS]     -- 1 eslint errors, with details in the report
+[SUCCESS] 
+"
+`;
+
+exports[`Task: sequential > should work 1`] = `
+"[STARTED] Initialize
+[DATA] Running migration on sequential
+[SUCCESS] Initialize
+[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create tsconfig.json
+[SUCCESS] Create tsconfig.json
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[SUCCESS] Create eslint config
+[STARTED] Regenerating past migrate report(s), generating current migrate report and merging all reports
+[DATA] processing file: /foo.ts
+[DATA] processing file: /index.ts
+[DATA] processing file: /depends-on-foo.ts
+[TITLE] Rescanning previously migrated files based on existing report:
+[TITLE] 
+[TITLE]     3 ts files have been scanned
+[TITLE] 
+[TITLE]     4 errors caught by rehearsal, and will be merged into the migration report
+[TITLE] 
+[TITLE]     
+[DATA] processing file: /foo.ts
+[DATA] processing file: /index.ts
+[TITLE] Migration Complete
+[TITLE] 
+[TITLE] 
+[TITLE]   2 JS files converted to TS
+[TITLE] 
+[TITLE]   4 errors caught by rehearsal
+[TITLE] 
+[TITLE]   2 have been fixed by rehearsal
+[TITLE] 
+[TITLE]   2 errors need to be fixed manually
+[TITLE] 
+[TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE] 
+[TITLE]     -- 1 eslint errors, with details in the report
+[TITLE] 
+[SUCCESS] Migration Complete
+[SUCCESS] 
+[SUCCESS] 
+[SUCCESS]   2 JS files converted to TS
+[SUCCESS] 
+[SUCCESS]   4 errors caught by rehearsal
+[SUCCESS] 
+[SUCCESS]   2 have been fixed by rehearsal
+[SUCCESS] 
+[SUCCESS]   2 errors need to be fixed manually
+[SUCCESS] 
+[SUCCESS]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS] 
+[SUCCESS]     -- 1 eslint errors, with details in the report
+[SUCCESS] 
+"
+`;

--- a/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
@@ -17,66 +17,9 @@ exports[`Task: sequential > sequential run regen on the existing report, and run
 [DATA] processing file: /depends-on-foo.ts
 [TITLE] Rescanning previously migrated files based on existing report:
 [TITLE] 
-[TITLE]     3 ts files have been scanned
+[TITLE]   3 ts files have been scanned
 [TITLE] 
-[TITLE]     4 errors caught by rehearsal, and will be merged into the migration report
-[TITLE] 
-[TITLE]     
-[DATA] processing file: /foo.ts
-[DATA] processing file: /index.ts
-[TITLE] Migration Complete
-[TITLE] 
-[TITLE] 
-[TITLE]   2 JS files converted to TS
-[TITLE] 
-[TITLE]   4 errors caught by rehearsal
-[TITLE] 
-[TITLE]   2 have been fixed by rehearsal
-[TITLE] 
-[TITLE]   2 errors need to be fixed manually
-[TITLE] 
-[TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE] 
-[TITLE]     -- 1 eslint errors, with details in the report
-[TITLE] 
-[SUCCESS] Migration Complete
-[SUCCESS] 
-[SUCCESS] 
-[SUCCESS]   2 JS files converted to TS
-[SUCCESS] 
-[SUCCESS]   4 errors caught by rehearsal
-[SUCCESS] 
-[SUCCESS]   2 have been fixed by rehearsal
-[SUCCESS] 
-[SUCCESS]   2 errors need to be fixed manually
-[SUCCESS] 
-[SUCCESS]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS] 
-[SUCCESS]     -- 1 eslint errors, with details in the report
-[SUCCESS] 
-"
-`;
-
-exports[`Task: sequential > should work 1`] = `
-"[STARTED] Initialize
-[DATA] Running migration on sequential
-[SUCCESS] Initialize
-[STARTED] Install dependencies
-[SUCCESS] Install dependencies
-[STARTED] Create tsconfig.json
-[SUCCESS] Create tsconfig.json
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
-[SUCCESS] Create eslint config
-[STARTED] Regenerating past migrate report(s), generating current migrate report and merging all reports
-[DATA] processing file: /foo.ts
-[DATA] processing file: /index.ts
-[DATA] processing file: /depends-on-foo.ts
-[TITLE] Rescanning previously migrated files based on existing report:
-[TITLE] 
-[TITLE]     3 ts files have been scanned
-[TITLE] 
-[TITLE]     4 errors caught by rehearsal, and will be merged into the migration report
+[TITLE]   4 errors caught by rehearsal, and will be merged into the migration report
 [TITLE] 
 [TITLE]     
 [DATA] processing file: /foo.ts

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -191,6 +191,7 @@ describe('migrate: e2e', async () => {
     expect(gitStatus.staged).toStrictEqual([
       '.eslintrc.js',
       '.rehearsal-eslintrc.js',
+      '.rehearsal/migrate-report.json',
       '.rehearsal/migrate-report.sarif',
       'tsconfig.json',
     ]);

--- a/packages/cli/test/commands/migrate/sequential.test.ts
+++ b/packages/cli/test/commands/migrate/sequential.test.ts
@@ -1,0 +1,86 @@
+import { resolve } from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { readdirSync, readJSONSync } from 'fs-extra';
+import { createLogger, format, transports } from 'winston';
+import {
+  initTask,
+  depInstallTask,
+  tsConfigTask,
+  lintConfigTask,
+  sequentialTask,
+} from '../../../src/commands/migrate/tasks';
+
+import {
+  prepareTmpDir,
+  listrTaskRunner,
+  createOutputStream,
+  createMigrateOptions,
+} from '../../test-helpers';
+
+const logger = createLogger({
+  transports: [new transports.Console({ format: format.cli() })],
+});
+
+describe('Task: sequential', async () => {
+  let basePath = '';
+  let output = '';
+
+  let outputStream = createOutputStream();
+
+  vi.spyOn(console, 'info').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+    outputStream.push(`${chunk}\n`);
+  });
+  vi.spyOn(console, 'log').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+    outputStream.push(`${chunk}\n`);
+  });
+  vi.spyOn(console, 'error').mockImplementation((chunk) => {
+    output += `${chunk}\n`;
+    outputStream.push(`${chunk}\n`);
+  });
+
+  beforeEach(() => {
+    output = '';
+    basePath = prepareTmpDir('sequential');
+    outputStream = createOutputStream();
+  });
+
+  afterEach(() => {
+    output = '';
+    vi.clearAllMocks();
+    outputStream.destroy();
+  });
+
+  test('sequential run regen on the existing report, and run migrate on current base path and entrypoint', async () => {
+    const options = createMigrateOptions(basePath, { entrypoint: 'index.ts' });
+    const previousRuns = {
+      previousFixedCount: 1,
+      paths: [{ basePath, entrypoint: 'depends-on-foo.ts' }],
+    };
+    const tasks = [
+      await initTask(options),
+      await depInstallTask(options),
+      await tsConfigTask(options),
+      await lintConfigTask(options),
+      await sequentialTask(options, logger, previousRuns),
+    ];
+
+    await listrTaskRunner(tasks);
+    expect(output).toMatchSnapshot();
+
+    const fileList = readdirSync(basePath);
+    expect(fileList).toContain('depends-on-foo.ts');
+    expect(fileList).toContain('foo.ts');
+    expect(fileList).toContain('index.ts');
+
+    const report = readJSONSync(resolve(basePath, '.rehearsal', 'migrate-report.json'));
+    const { summary, fixedItemCount, items } = report;
+    expect(summary.length).toBe(2);
+    expect(summary[0].basePath).toEqual(summary[1].basePath);
+    expect(summary[0].entrypoint).toBe('depends-on-foo.ts');
+    expect(summary[1].entrypoint).toBe('index.ts');
+    expect(fixedItemCount).toBe(2);
+    expect(items.length).toBe(2);
+  });
+});

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -63,8 +63,8 @@ describe.each(['rc', 'latest', 'beta', 'latestBeta'])(
       const report: Report = readJSONSync(reportFile);
       expect(report).to.exist;
       expect(report).toHaveProperty('summary');
-      expect(report.summary.projectName).toBe('@rehearsal/cli');
-      expect(report.summary.tsVersion).toBe(latestPublishedTSVersion);
+      expect(report.summary[0].projectName).toBe('@rehearsal/cli');
+      expect(report.summary[0].tsVersion).toBe(latestPublishedTSVersion);
     });
   }
 );

--- a/packages/cli/test/fixtures/app_for_migrate/src/sequential/depends-on-foo.ts
+++ b/packages/cli/test/fixtures/app_for_migrate/src/sequential/depends-on-foo.ts
@@ -1,0 +1,5 @@
+import { foo } from './foo';
+
+console.log(foo('hello'));
+
+const str = 'yes';

--- a/packages/cli/test/fixtures/app_for_migrate/src/sequential/foo.ts
+++ b/packages/cli/test/fixtures/app_for_migrate/src/sequential/foo.ts
@@ -1,0 +1,3 @@
+export function foo(name = 'World') {
+  return `Hello ${name}`;
+}

--- a/packages/cli/test/fixtures/app_for_migrate/src/sequential/index.ts
+++ b/packages/cli/test/fixtures/app_for_migrate/src/sequential/index.ts
@@ -1,0 +1,5 @@
+import { foo } from './foo';
+
+export function run(baz) {
+  return foo(baz);
+}

--- a/packages/cli/test/fixtures/app_for_migrate/src/sequential/package.json
+++ b/packages/cli/test/fixtures/app_for_migrate/src/sequential/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sequential",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "path": "*"    
+  },
+  "packageManager": "pnpm@7.12.1"
+}

--- a/packages/migrate/test/index.test.ts
+++ b/packages/migrate/test/index.test.ts
@@ -69,15 +69,16 @@ describe('migrate', () => {
       sourceFiles,
       logger,
       reporter,
+      entrypoint: '',
     };
 
     const output = await migrate(input);
     migratedFiles = output.migratedFiles;
     const jsonReport = resolve(basePath, '.rehearsal-report.json');
-    reporter.save(jsonReport);
+    reporter.saveReport(jsonReport);
     const report = JSON.parse(readFileSync(jsonReport).toString());
 
-    expect(report.summary.basePath).toMatch(/migrate/);
+    expect(report.summary[0].basePath).toMatch(/migrate/);
     expect(migratedFiles).includes(`${actualDir}/index.ts`);
     expect(existsSync(`${actualDir}/index.js`)).toBeFalsy();
     rmSync(jsonReport);
@@ -89,6 +90,7 @@ describe('migrate', () => {
       sourceFiles,
       logger,
       reporter,
+      entrypoint: '',
     };
 
     const output = await migrate(input);
@@ -103,10 +105,10 @@ describe('migrate', () => {
     const expected = readFileSync(`${expectedDir}/index.ts.output`, 'utf-8');
     expect(actual).toBe(expected);
     const jsonReport = resolve(basePath, '.rehearsal-report.json');
-    reporter.save(jsonReport);
+    reporter.saveReport(jsonReport);
     const report = JSON.parse(readFileSync(jsonReport).toString());
 
-    expect(report.summary.basePath).toMatch(/migrate/);
+    expect(report.summary[0].basePath).toMatch(/migrate/);
     rmSync(jsonReport);
   });
 
@@ -133,6 +135,7 @@ describe('migrate', () => {
       sourceFiles,
       logger,
       reporter,
+      entrypoint: '',
     };
 
     const output = await migrate(input);
@@ -148,10 +151,10 @@ describe('migrate', () => {
 
     expect(actual).toBe(expected);
     const jsonReport = resolve(basePath, '.rehearsal-report.json');
-    reporter.save(jsonReport);
+    reporter.saveReport(jsonReport);
     const report = JSON.parse(readFileSync(jsonReport).toString());
 
-    expect(report.summary.basePath).toMatch(/migrate/);
+    expect(report.summary[0].basePath).toMatch(/migrate/);
     rmSync(jsonReport);
 
     const pkgJSON = JSON.parse(readFileSync(pkgJSONPath!, 'utf-8'));

--- a/packages/plugins/src/plugins/diagnostic-check.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-check.plugin.ts
@@ -56,7 +56,7 @@ export class DiagnosticCheckPlugin implements Plugin<DiagnosticCheckPluginOption
 
       const helpUrl = hints.getHelpUrl(diagnostic);
       const location = getLocation(diagnostic.file, diagnostic.start, diagnostic.length);
-      context.reporter.addTSItem(
+      context.reporter.addTSItemToRun(
         diagnostic,
         diagnostic.node,
         location,

--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -97,7 +97,7 @@ export class DiagnosticFixPlugin implements Plugin<DiagnosticFixPluginOptions> {
         DEBUG_CALLBACK(`- TS${diagnostic.code} at ${diagnostic.start}:\t codefix applied`);
       }
 
-      context.reporter.incrementFixedItemCount();
+      context.reporter.incrementRunFixedItemCount();
 
       // Get updated list of diagnostics
       diagnostics = this.getDiagnostics(context.rehearsal, fileName);

--- a/packages/plugins/src/plugins/lint.plugin.ts
+++ b/packages/plugins/src/plugins/lint.plugin.ts
@@ -33,7 +33,7 @@ export class LintPlugin implements Plugin<LintPluginOptions> {
       if (options.reportErrors) {
         const { messages: errors } = report;
         for (const error of errors) {
-          context.reporter.addLintItem(fileName, error);
+          context.reporter.addLintItemToRun(fileName, error);
         }
       }
 

--- a/packages/regen/src/regen.ts
+++ b/packages/regen/src/regen.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'path';
+import { dirname, resolve, extname } from 'path';
 import { PluginsRunner, RehearsalService } from '@rehearsal/service';
 import { DiagnosticCheckPlugin, LintPlugin, ReRehearsePlugin } from '@rehearsal/plugins';
 import { findConfigFile, parseJsonConfigFileContent, readConfigFile, sys } from 'typescript';
@@ -29,6 +29,9 @@ export async function regen(input: RegenInput): Promise<RegenOutput> {
   const reporter = input.reporter;
   const logger = input.logger;
 
+  //regen will only work on ts files
+  const filteredSourceFiles = sourceFiles.filter((file) => extname(file) === '.ts');
+
   const listrTask = input.task || { output: '' };
 
   logger?.debug('migration regen started');
@@ -54,7 +57,7 @@ export async function regen(input: RegenInput): Promise<RegenOutput> {
     configFile
   );
 
-  const fileNames = [...new Set([...someFiles, ...sourceFiles])];
+  const fileNames = [...new Set([...someFiles, ...filteredSourceFiles])];
 
   logger?.debug(`fileNames: ${JSON.stringify(fileNames)}`);
 

--- a/packages/regen/test/index.test.ts
+++ b/packages/regen/test/index.test.ts
@@ -28,7 +28,9 @@ describe('regen', () => {
 
     regenInput = {
       basePath: resolve(basePath, 'tmp'),
+      sourceFiles: [],
       reporter,
+      entrypoint: '',
     };
   });
 
@@ -42,7 +44,7 @@ describe('regen', () => {
     const { scannedFiles } = await regen(regenInput);
     expect(scannedFiles.length).toBe(1);
 
-    reporter.save(jsonReportPath);
+    reporter.saveReport(jsonReportPath);
     expect(existsSync(jsonReportPath)).toBeTruthy();
   });
 
@@ -53,7 +55,7 @@ describe('regen', () => {
     expect(scannedFiles.length).toBe(1);
     expect(scannedFiles[0].includes('test1.ts')).toBeTruthy();
 
-    reporter.save(jsonReportPath);
+    reporter.saveReport(jsonReportPath);
     const report = JSON.parse(readFileSync(jsonReportPath).toString());
     const { items } = report;
     expect(JSON.stringify(items, null, 2)).toMatchSnapshot();
@@ -67,7 +69,7 @@ describe('regen', () => {
     const { scannedFiles } = await regen(regenInput);
     expect(scannedFiles.length).toBe(2);
 
-    reporter.save(jsonReportPath);
+    reporter.saveReport(jsonReportPath);
 
     const report = JSON.parse(readFileSync(jsonReportPath).toString());
     const { items } = report;
@@ -82,7 +84,7 @@ describe('regen', () => {
 
     const { scannedFiles } = await regen(regenInput);
     expect(scannedFiles.length).toBe(1);
-    reporter.save(jsonReportPath);
+    reporter.saveReport(jsonReportPath);
 
     const report = JSON.parse(readFileSync(jsonReportPath).toString());
     const { items } = report;

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -6,17 +6,22 @@ export function mdFormatter(report: Report): string {
   let text = ``;
 
   text += `### Summary:\n`;
-  text += `Typescript Version: ${report.summary.tsVersion}\n`;
-  text += `Files Tested: ${fileNames.length}\n`;
-  text += `\n`;
+
+  for (const block of report.summary) {
+    text += `Project Name: ${block.projectName}\n`;
+    text += `Typescript Version: ${block.tsVersion}\n`;
+    text += `Base path: ${block.basePath}\n`;
+    text += `timestamp: ${block.timestamp}\n`;
+    text += `\n`;
+  }
+
   text += `### Results:\n`;
 
   for (const fileName of fileNames) {
     const items = report.items.filter((item) => item.analysisTarget === fileName);
-    const relativeFileName = fileName.replace(report.summary.basePath, '');
 
     text += `\n`;
-    text += `#### File: ${relativeFileName}, issues: ${items.length}:\n`;
+    text += `#### File: ${fileName}, issues: ${items.length}:\n`;
 
     for (const item of items) {
       text += `\n`;

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -165,7 +165,7 @@ function createRun(report: Report): Run {
   return {
     tool: {
       driver: {
-        name: `${report.summary.commandName}`,
+        name: `${report.summary[0].commandName}`,
         informationUri: 'https://github.com/rehearsal-js/rehearsal-js',
         rules: [],
       },
@@ -174,7 +174,9 @@ function createRun(report: Report): Run {
     results: [],
     automationDetails: {
       description: {
-        text: `This is the run of ${report.summary.commandName} on your product against TypeScript ${report.summary.tsVersion} at ${report.summary.timestamp}`,
+        //For sequential runs, the time difference between each run is minimal, and ts version should be the same.
+        //So printing out the first timestamp and first ts version.
+        text: `This is the result of ${report.summary[0].commandName} on your product against TypeScript ${report.summary[0].tsVersion} at ${report.summary[0].timestamp}`,
       },
     },
   };

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -70,8 +70,8 @@ export class Reporter {
   /**
    * Appends an element to the summary
    */
-  addSummary(key: string, value: unknown): void {
-    this.report.summary[0][key] = value;
+  addToRunSummary(key: string, value: unknown): void {
+    this.currentRun.runSummary[key] = value;
   }
 
   /**

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -6,6 +6,7 @@ import {
   type ReportItem,
   type Location,
   type LintErrorLike,
+  type Run,
   ReportItemType,
 } from './types';
 import { normalizeFilePath } from './normalize-paths';
@@ -17,6 +18,8 @@ type ReporterMeta = {
   basePath: string;
   commandName: string;
   tsVersion: string;
+  entrypoint?: string;
+  previousFixedCount?: number;
 };
 
 /**
@@ -27,36 +30,37 @@ export class Reporter {
 
   public report: Report;
   private logger?: Logger;
+  public currentRun: Run;
+  public lastRun: Run | undefined;
+  private uniqueFiles: string[];
 
   constructor(meta: ReporterMeta, logger?: Logger) {
-    const { projectName, basePath, commandName, tsVersion } = meta;
+    const { projectName, basePath, commandName, tsVersion, previousFixedCount } = meta;
 
     this.basePath = basePath;
     this.logger = logger?.child({ service: 'rehearsal-reporter' });
-
     this.report = {
-      summary: {
-        projectName: projectName,
-        tsVersion: tsVersion,
-        timestamp: new Date().toLocaleString('en-US', {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-          hourCycle: 'h24',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        }),
-        basePath: basePath,
-        commandName: commandName,
-      },
+      summary: [],
+      fixedItemCount: previousFixedCount || 0,
       items: [],
+    };
+    this.uniqueFiles = [];
+    this.currentRun = {
+      runSummary: {
+        projectName,
+        tsVersion,
+        timestamp: '',
+        basePath: '',
+        entrypoint: '',
+        commandName,
+      },
       fixedItemCount: 0,
+      items: [],
     };
   }
 
-  getFileNames(): string[] {
-    return [...new Set(this.report.items.map((item) => item.analysisTarget))];
+  public getFileNames(): string[] {
+    return this.uniqueFiles;
   }
 
   getItemsByAnalysisTarget(fileName: string): ReportItem[] {
@@ -67,13 +71,13 @@ export class Reporter {
    * Appends an element to the summary
    */
   addSummary(key: string, value: unknown): void {
-    this.report.summary[key] = value;
+    this.report.summary[0][key] = value;
   }
 
   /**
    * Appends am information about provided diagnostic and related node to the report
    */
-  addTSItem(
+  addTSItemToRun(
     diagnostic: DiagnosticWithLocation,
     node?: Node,
     triggeringLocation?: Location,
@@ -81,7 +85,7 @@ export class Reporter {
     helpUrl = '',
     hintAdded = true
   ): void {
-    this.report.items.push({
+    this.currentRun.items.push({
       analysisTarget: normalizeFilePath(this.basePath, diagnostic.file.fileName),
       type: ReportItemType.ts,
       ruleId: `TS${diagnostic.code}`,
@@ -96,8 +100,8 @@ export class Reporter {
     });
   }
 
-  addLintItem(fileName: string, lintError: LintErrorLike): void {
-    this.report.items.push({
+  addLintItemToRun(fileName: string, lintError: LintErrorLike): void {
+    this.currentRun.items.push({
       analysisTarget: normalizeFilePath(this.basePath, fileName),
       type: ReportItemType.lint,
       ruleId: lintError.ruleId || '',
@@ -117,14 +121,60 @@ export class Reporter {
     });
   }
 
-  incrementFixedItemCount(): void {
-    this.report.fixedItemCount++;
+  incrementRunFixedItemCount(): void {
+    this.currentRun.fixedItemCount++;
+  }
+
+  saveCurrentRunToReport(runBasePath: string, runEntrypoint: string, timestamp?: string): void {
+    timestamp =
+      timestamp ??
+      new Date().toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hourCycle: 'h24',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+    this.currentRun.runSummary.timestamp = timestamp;
+    this.currentRun.runSummary.basePath = runBasePath;
+    this.currentRun.runSummary.entrypoint = runEntrypoint || '';
+    this.report.summary = [...this.report.summary, { ...this.currentRun.runSummary }];
+
+    this.report.fixedItemCount += this.currentRun.fixedItemCount;
+
+    const { uniqueFiles, items } = this.mergeItems();
+    this.report.items = items;
+    this.uniqueFiles = uniqueFiles;
+
+    this.lastRun = { ...this.currentRun };
+
+    this.resetCurrentRun();
+  }
+
+  private mergeItems(): { uniqueFiles: string[]; items: ReportItem[] } {
+    const fileSet = new Set<string>();
+    for (const item of this.currentRun.items) {
+      if (!fileSet.has(item.analysisTarget)) {
+        fileSet.add(item.analysisTarget);
+      }
+    }
+    const items = [...this.currentRun.items];
+    for (const item of this.report.items) {
+      if (!fileSet.has(item.analysisTarget)) {
+        fileSet.add(item.analysisTarget);
+        items.push(item);
+      }
+    }
+    const uniqueFiles = Array.from(fileSet);
+    return { uniqueFiles, items };
   }
 
   /**
    * Prints the current report using provided formatter (ex. json, pull-request etc.)
    */
-  print(file: string, formatter: ReportFormatter): string {
+  printReport(file: string, formatter: ReportFormatter): string {
     const report = formatter(this.report);
 
     if (file) {
@@ -138,32 +188,41 @@ export class Reporter {
    * Saves the current report information to the file in simple JSON format
    * to be able to load it later with 'load' function
    */
-  save(file: string): void {
-    this.print(file, (report: Report): string => JSON.stringify(report, null, 2));
+  saveReport(file: string): void {
+    this.printReport(file, (report: Report): string => JSON.stringify(report, null, 2));
     this.logger?.info(`Report saved to: ${file}.`);
   }
 
   /**
    * Loads the report exported by function 'save' from the file
    */
-  load(file: string): Reporter {
+  loadRun(file: string): Reporter {
     if (!existsSync(file)) {
       this.logger?.error(`Report file not found: ${file}.`);
     }
 
     this.logger?.info(`Report file found: ${file}.`);
-    const content = readFileSync(file, 'utf-8');
-    const report: Report = JSON.parse(content);
 
-    if (!Reporter.isReport(report)) {
+    const content = readFileSync(file, 'utf-8');
+    const run: Run = JSON.parse(content);
+    this.currentRun = run;
+
+    if (!Reporter.isReport(this.report)) {
       this.logger?.error(`Report not loaded: wrong file format`);
       return this;
     }
 
-    this.report = report as Report;
     this.logger?.info(`Report loaded from file.`);
 
     return this;
+  }
+
+  private resetCurrentRun(): void {
+    this.currentRun.runSummary.timestamp = '';
+    this.currentRun.runSummary.basePath = '';
+    this.currentRun.runSummary.entrypoint = '';
+    this.currentRun.fixedItemCount = 0;
+    this.currentRun.items = [];
   }
 
   private static isReport(report: Report): report is Report {

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -1,6 +1,7 @@
 export type ReportSummary = Record<string, unknown> & {
   projectName: string;
   basePath: string;
+  entrypoint: string;
   tsVersion: string;
   timestamp: string;
   commandName: string;
@@ -49,9 +50,15 @@ export interface LintErrorLike {
 }
 
 export type Report = {
-  summary: ReportSummary;
-  items: ReportItem[];
+  summary: ReportSummary[];
   fixedItemCount: number;
+  items: ReportItem[];
 };
 
 export type ReportFormatter = (report: Report) => string;
+
+export interface Run {
+  runSummary: ReportSummary;
+  fixedItemCount: number;
+  items: ReportItem[];
+}

--- a/packages/reporter/test/__snapshots__/reporter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/reporter.test.ts.snap
@@ -2,13 +2,16 @@
 
 exports[`Test reporter > addItem 1`] = `
 "{
-  \\"summary\\": {
-    \\"projectName\\": \\"@rehearsal/test\\",
-    \\"tsVersion\\": \\"4.7.4\\",
-    \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\",
-    \\"commandName\\": \\"@rehearsal/reporter\\"
-  },
+  \\"summary\\": [
+    {
+      \\"projectName\\": \\"@rehearsal/test\\",
+      \\"tsVersion\\": \\"4.7.4\\",
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
+      \\"basePath\\": \\"/base/path\\",
+      \\"entrypoint\\": \\"\\",
+      \\"commandName\\": \\"@rehearsal/reporter\\"
+    }
+  ],
   \\"fixedItemCount\\": 4,
   \\"items\\": [
     {
@@ -219,25 +222,31 @@ exports[`Test reporter > load 1`] = `
       "type": 1,
     },
   ],
-  "summary": {
-    "basePath": "/base/path",
-    "commandName": "@rehearsal/reporter",
-    "projectName": "@rehearsal/test",
-    "timestamp": "9/16/2022, 13:24:57",
-    "tsVersion": "4.7.4",
-  },
+  "summary": [
+    {
+      "basePath": "/base/path",
+      "commandName": "@rehearsal/reporter",
+      "entrypoint": "",
+      "projectName": "@rehearsal/test",
+      "timestamp": "9/16/2022, 13:24:57",
+      "tsVersion": "4.7.4",
+    },
+  ],
 }
 `;
 
 exports[`Test reporter > print, json 1`] = `
 "{
-  \\"summary\\": {
-    \\"projectName\\": \\"@rehearsal/test\\",
-    \\"tsVersion\\": \\"4.7.4\\",
-    \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\",
-    \\"commandName\\": \\"@rehearsal/reporter\\"
-  },
+  \\"summary\\": [
+    {
+      \\"projectName\\": \\"@rehearsal/test\\",
+      \\"tsVersion\\": \\"4.7.4\\",
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
+      \\"basePath\\": \\"/base/path\\",
+      \\"entrypoint\\": \\"\\",
+      \\"commandName\\": \\"@rehearsal/reporter\\"
+    }
+  ],
   \\"fixedItemCount\\": 4,
   \\"items\\": [
     {
@@ -310,12 +319,14 @@ exports[`Test reporter > print, json 1`] = `
 
 exports[`Test reporter > print, pull-request-md 1`] = `
 "### Summary:
+Project Name: @rehearsal/test
 Typescript Version: 4.7.4
-Files Tested: 2
+Base path: /base/path
+timestamp: 9/16/2022, 13:24:57
 
 ### Results:
 
-#### File: /file1.ts, issues: 3:
+#### File: /base/path/file1.ts, issues: 3:
 
 **Error TS6133**: 'NEED TO BE FIXED MANUALLY'
 The declaration 'react' is never read or used. Remove the declaration or use it.
@@ -329,7 +340,7 @@ Code: \`a\`
 Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.
 Code: \`{}\`
 
-#### File: /file2.ts, issues: 1:
+#### File: /base/path/file2.ts, issues: 1:
 
 **Error @typescript-eslint/no-explicit-any**: 'NEED TO BE FIXED MANUALLY'
 Unexpected any. Specify a different type.
@@ -339,13 +350,16 @@ Code: \`\`
 
 exports[`Test reporter > save 1`] = `
 "{
-  \\"summary\\": {
-    \\"projectName\\": \\"@rehearsal/test\\",
-    \\"tsVersion\\": \\"4.7.4\\",
-    \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-    \\"basePath\\": \\"/base/path\\",
-    \\"commandName\\": \\"@rehearsal/reporter\\"
-  },
+  \\"summary\\": [
+    {
+      \\"projectName\\": \\"@rehearsal/test\\",
+      \\"tsVersion\\": \\"4.7.4\\",
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
+      \\"basePath\\": \\"/base/path\\",
+      \\"entrypoint\\": \\"\\",
+      \\"commandName\\": \\"@rehearsal/reporter\\"
+    }
+  ],
   \\"fixedItemCount\\": 4,
   \\"items\\": [
     {

--- a/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
@@ -186,7 +186,7 @@ exports[`Test sarif-formatter > should set the correct version, $schema, and ini
       \\"results\\": [],
       \\"automationDetails\\": {
         \\"description\\": {
-          \\"text\\": \\"This is the run of @rehearsal/reporter on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
+          \\"text\\": \\"This is the result of @rehearsal/reporter on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
         }
       }
     }

--- a/packages/reporter/test/fixtures/reporter/rehearsal-run.json
+++ b/packages/reporter/test/fixtures/reporter/rehearsal-run.json
@@ -1,12 +1,12 @@
 {
-  "summary": [{
+  "runSummary": {
     "projectName": "@rehearsal/test",
     "tsVersion": "4.7.4",
     "timestamp": "9/16/2022, 13:24:57",
     "basePath": "/base/path",
     "entrypoint": "",
     "commandName": "@rehearsal/reporter"
-  }],
+  },
   "fixedItemCount": 4,
   "items": [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
@@ -6,7 +6,8 @@ const addArtifactData: Report = {
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:55",
     basePath: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter"
+    commandName: "@rehearsal/reporter",
+    entrypoint: '',
   }],
   fixedItemCount: 5,
   items: [

--- a/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-artifact.ts
@@ -1,13 +1,13 @@
 import type { Report } from '../../../src';
 
 const addArtifactData: Report = {
-  summary: {
+  summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:55",
     basePath: "/reporter/test/sarif-formatter",
     commandName: "@rehearsal/reporter"
-  },
+  }],
   fixedItemCount: 5,
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
@@ -6,7 +6,8 @@ const addResultData: Report = {
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:57",
     basePath: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter"
+    commandName: "@rehearsal/reporter",
+    entrypoint: "",
   }],
   fixedItemCount: 3,
   items: [

--- a/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-result.ts
@@ -1,13 +1,13 @@
 import { type Report } from '../../../src';
 
 const addResultData: Report = {
-  summary: {
+  summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:57",
     basePath: "/reporter/test/sarif-formatter",
     commandName: "@rehearsal/reporter"
-  },
+  }],
   fixedItemCount: 3,
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
@@ -6,7 +6,8 @@ const addRuleData: Report = {
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:52",
     basePath: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter"
+    commandName: "@rehearsal/reporter",
+    entrypoint: "",
   }],
   fixedItemCount: 5,
   items: [

--- a/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/add-rule.ts
@@ -1,13 +1,13 @@
 import { type Report } from '../../../src';
 
 const addRuleData: Report = {
-  summary: {
+  summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 13:24:52",
     basePath: "/reporter/test/sarif-formatter",
     commandName: "@rehearsal/reporter"
-  },
+  }],
   fixedItemCount: 5,
   items: [
     {

--- a/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
@@ -6,7 +6,8 @@ const initialData: Report = {
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 20:16:50",
     basePath: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter"
+    commandName: "@rehearsal/reporter",
+    entrypoint: "",
   }],
   items: [],
   fixedItemCount: 0

--- a/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/initial-data.ts
@@ -1,13 +1,13 @@
 import { type Report } from '../../../src';
 
 const initialData: Report = {
-  summary: {
+  summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
     timestamp: "9/16/2022, 20:16:50",
     basePath: "/reporter/test/sarif-formatter",
     commandName: "@rehearsal/reporter"
-  },
+  }],
   items: [],
   fixedItemCount: 0
 };

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, rmSync } from 'fs';
-import { readJSONSync } from 'fs-extra';
 import { resolve } from 'path';
+import { readJSONSync } from 'fs-extra';
 import { DiagnosticWithLocation, SourceFile, Node } from 'typescript';
 import { afterEach, assert, beforeEach, describe, expect, test } from 'vitest';
 import { mock } from 'vitest-mock-extended';

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, rmSync } from 'fs';
+import { readJSONSync } from 'fs-extra';
 import { resolve } from 'path';
 import { DiagnosticWithLocation, SourceFile, Node } from 'typescript';
 import { afterEach, assert, beforeEach, describe, expect, test } from 'vitest';
@@ -8,6 +9,11 @@ import { type Report, jsonFormatter, mdFormatter, Reporter } from '../src';
 
 describe('Test reporter', function () {
   const basePath = resolve(__dirname, 'fixtures/reporter');
+  const testDataPath = resolve(basePath, 'rehearsal-run.json');
+  const testData = readJSONSync(testDataPath);
+  const timestamp = testData.runSummary.timestamp;
+  const runBasePath = testData.runSummary.basePath;
+  const runEntrypoint = testData.runSummary.entrypoint;
 
   let reporter: Reporter | undefined;
 
@@ -16,8 +22,9 @@ describe('Test reporter', function () {
       tsVersion: '',
       projectName: 'test',
       basePath,
+      entrypoint: '',
       commandName: '@rehearsal/reporter',
-    }).load(resolve(basePath, 'rehearsal-report.json'));
+    }).loadRun(testDataPath);
   });
 
   afterEach(() => {
@@ -25,18 +32,21 @@ describe('Test reporter', function () {
   });
 
   test('load', async () => {
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const report = (reporter as any).report as Report;
 
-    expect(report.summary.basePath).toMatch(/base/);
-    expect(report.summary.timestamp).toMatch(/\d+/);
+    expect(report.summary.length).toBe(1);
+    expect(report.summary[0].basePath).toMatch(/base/);
+    expect(report.summary[0].timestamp).toMatch(/\d+/);
     expect(report).toMatchSnapshot();
   });
 
   test('save', async () => {
     const testSaveFile = resolve(basePath, 'test-save.json');
-
-    reporter!.save(testSaveFile);
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
+    reporter!.saveReport(testSaveFile);
     expect(existsSync(testSaveFile)).toBeTruthy;
     expect(readFileSync(testSaveFile, 'utf-8')).toMatchSnapshot();
 
@@ -45,8 +55,8 @@ describe('Test reporter', function () {
 
   test('print, json', async () => {
     const testPrintJsonFile = resolve(basePath, 'test-print-json.json');
-
-    reporter!.print(testPrintJsonFile, jsonFormatter);
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
+    reporter!.printReport(testPrintJsonFile, jsonFormatter);
     expect(existsSync(testPrintJsonFile)).toBeTruthy;
     expect(readFileSync(testPrintJsonFile, 'utf-8')).toMatchSnapshot();
 
@@ -56,7 +66,8 @@ describe('Test reporter', function () {
   test('print, pull-request-md', async () => {
     const testPrintMdFile = resolve(basePath, 'test-print-md.md');
 
-    reporter!.print(testPrintMdFile, mdFormatter);
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
+    reporter!.printReport(testPrintMdFile, mdFormatter);
     expect(existsSync(testPrintMdFile)).toBeTruthy;
     expect(readFileSync(testPrintMdFile, 'utf-8')).toMatchSnapshot();
 
@@ -86,11 +97,12 @@ describe('Test reporter', function () {
     const location = { startLine: 3, startColumn: 7, endLine: 3, endColumn: 12 };
     const hint = 'This is the hint.';
 
-    reporter!.addTSItem(mockDiagnostic, mockNode, location, hint);
+    reporter!.addTSItemToRun(mockDiagnostic, mockNode, location, hint);
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
 
     const testAddItemFile = resolve(basePath, 'test-add-item.json');
 
-    reporter!.save(testAddItemFile);
+    reporter!.saveReport(testAddItemFile);
     expect(existsSync(testAddItemFile)).toBeTruthy;
     expect(readFileSync(testAddItemFile, 'utf-8')).toMatchSnapshot();
 
@@ -98,10 +110,12 @@ describe('Test reporter', function () {
   });
 
   test('getFileNames', async () => {
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
     assert.deepEqual(reporter!.getFileNames(), ['/base/path/file1.ts', '/base/path/file2.ts']);
   });
 
   test('getItemsByFile', async () => {
+    reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
     const items = reporter!.getItemsByAnalysisTarget('/base/path/file1.ts');
     expect(items).toMatchSnapshot();
   });

--- a/packages/upgrade/src/upgrade.ts
+++ b/packages/upgrade/src/upgrade.ts
@@ -13,6 +13,7 @@ import type { Logger } from 'winston';
 
 export type UpgradeInput = {
   basePath: string;
+  entrypoint: string;
   configName?: string;
   reporter: Reporter;
   logger?: Logger;
@@ -91,6 +92,7 @@ export async function upgrade(input: UpgradeInput): Promise<UpgradeOutput> {
     });
 
   await runner.run(fileNames);
+  reporter.saveCurrentRunToReport(basePath, input.entrypoint);
 
   return {
     basePath,

--- a/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
@@ -1069,12 +1069,15 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "type": 1,
     },
   ],
-  "summary": {
-    "basePath": "",
-    "commandName": "@rehearsal/upgrade",
-    "projectName": "@rehearsal/test",
-    "timestamp": "9/22/2022, 13:48:38",
-    "tsVersion": "",
-  },
+  "summary": [
+    {
+      "basePath": "",
+      "commandName": "@rehearsal/upgrade",
+      "entrypoint": "",
+      "projectName": "@rehearsal/test",
+      "timestamp": "9/22/2022, 13:48:38",
+      "tsVersion": "",
+    },
+  ],
 }
 `;

--- a/packages/upgrade/test/transforms.test.ts
+++ b/packages/upgrade/test/transforms.test.ts
@@ -58,7 +58,7 @@ async function runAutofixOnTestApp(basePath: string): Promise<void> {
     basePath: '',
     commandName: '@rehearsal/migrate',
   });
-  await upgrade({ basePath, reporter });
+  await upgrade({ basePath, reporter, entrypoint: '' });
 }
 
 /**

--- a/packages/upgrade/test/upgrade.test.ts
+++ b/packages/upgrade/test/upgrade.test.ts
@@ -22,7 +22,7 @@ describe('Test upgrade', async function () {
 
   createTsFilesFromInputs(files);
 
-  const result = await upgrade({ basePath, logger, reporter });
+  const result = await upgrade({ basePath, logger, reporter, entrypoint: '' });
 
   test('should fix errors or provide hints for errors in the original files', () => {
     expect(result).toBeDefined();
@@ -40,8 +40,8 @@ describe('Test upgrade', async function () {
   test('should output the correct data from upgrade', () => {
     const { report } = reporter;
 
-    report.summary.timestamp = '9/22/2022, 13:48:38';
-    report.summary.basePath = '';
+    report.summary[0].timestamp = '9/22/2022, 13:48:38';
+    report.summary[0].basePath = '';
 
     expect(report).toMatchSnapshot();
   });


### PR DESCRIPTION
Closes #693 

New behavior:

When we detect there are past runs in the existing report of the base path directory, we automatically run `--regen` for past runs, which are determined by basePath + entrypoint, before we run migrate itself with current entrypoint. The regenerated reports for past runs are merged into the current report. 

Changes to @rehearsal/reporter:

1. `Reporter.report` now is the aggregate of data from all runs.
2. `Reporter.currentRun` is the data from the current run. 
3. API of Reporter has been changed, such as, from `save()` to `saveCurrentRunToReport()`, `saveReport()`, etc.
4. Report summary has been changed to array to record runs of migration.
5. basePath + entrypoint saved in summary of the report for each run.
6. fixedItemCount is a cumulative sum of all errors autofixed by rehearsal in all runs.
7. json report will be automatically produced in all cases, since it has the complete raw data.
8. As a bonus, the code changes help fix an existing bug in interactive migrate. As we interactively migrate every file, we print a report for each file migrated. Since we passed in one Reporter instance for the entire migrate command, the last report generated for the last file interactively migrated has the cumulative errors (un-deduplicated). Now with the new reporter, the repeat errors are filtered, since we merge current run with existing data. That's the reason why some of the test results are changed. 

Changes to @rehearsal/migrate
1. Added Rerehearsal plugin at the start of @rehearsal/migrate to remove possible rehearsal comments added by preceding runs of `--regen`.

![Screenshot 2023-02-13 at 8 13 55 AM](https://user-images.githubusercontent.com/26440597/218523070-467a00a2-4657-420a-8701-d2d355e4557f.png)
![Screenshot 2023-02-13 at 8 26 21 AM](https://user-images.githubusercontent.com/26440597/218523131-b7914405-7f3f-4381-884e-d4c56f611846.png)

