### PR TITLE
fix(migration-graph): remove *.json from module graph

### DIFF
--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -76,7 +76,7 @@ export class PackageGraph {
     const cruiseOptions: ICruiseOptions = {
       baseDir,
       exclude: {
-        path: ['node_modules', '\\.css$', ...exclude],
+        path: ['node_modules', '\\.css$', '\\.json$', ...exclude],
       },
     };
 


### PR DESCRIPTION
Fixes #733 

**Root Cause**
- DependencyCruiser included json files.

**Fix**
- Add `.json` file extension to excluded files in `PackageGraph`.


### Testing Done
- Wrote a test for reproduction
- Regressed against [`supported`](https://github.com/supportedjs/supported)

```
➜  supported git:(main) ✗ node ../../rehearsal-js/packages/cli/bin/rehearsal.js migrate --dryRun
info:    @rehearsal/migrate 1.0.7-beta
✔ Validate project
✔ Initialize -- Dry Run Mode
✔ Install dependencies
✔ Update tsconfig.json
✔ Update .eslintrc.js
✔ Add package scripts

› List of files will be attempted to migrate:
  .prettierrc.js
  lib/util.js
  lib/time/index.js
  lib/output/messages.js
  lib/output/cli-output.js
  lib/output/csv-output.js
  lib/policy-rules.js
  lib/lts/index.js
  lib/project/index.js
  lib/project/multiple-projects.js
  lib/help.js
  lib/cli.js
  lib/npm/config.js
  lib/project/setup-project.js
  index.js
```

ToDo
- [X]  #735