### PR TITLE
feat: hooks in user config

### DIFF
--- a/packages/cli/rehearsal-config-schema.json
+++ b/packages/cli/rehearsal-config-schema.json
@@ -22,9 +22,9 @@
                             },
                             "type": "object"
                         },
-                        "setup": {
-                            "properties": {
-                                "lint": {
+                        "postInstall": {
+                            "anyOf": [
+                                {
                                     "properties": {
                                         "args": {
                                             "items": {
@@ -38,19 +38,166 @@
                                     },
                                     "type": "object"
                                 },
-                                "ts": {
-                                    "properties": {
-                                        "args": {
-                                            "items": {
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "args": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
                                                 "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "setup": {
+                            "properties": {
+                                "lint": {
+                                    "anyOf": [
+                                        {
+                                            "properties": {
+                                                "args": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "command": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "items": {
+                                                "properties": {
+                                                    "args": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "command": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
                                             },
                                             "type": "array"
-                                        },
-                                        "command": {
-                                            "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    ]
+                                },
+                                "postLintSetup": {
+                                    "anyOf": [
+                                        {
+                                            "properties": {
+                                                "args": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "command": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "items": {
+                                                "properties": {
+                                                    "args": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "command": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    ]
+                                },
+                                "postTsSetup": {
+                                    "anyOf": [
+                                        {
+                                            "properties": {
+                                                "args": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "command": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "items": {
+                                                "properties": {
+                                                    "args": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "command": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    ]
+                                },
+                                "ts": {
+                                    "anyOf": [
+                                        {
+                                            "properties": {
+                                                "args": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "command": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "items": {
+                                                "properties": {
+                                                    "args": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "command": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    ]
                                 }
                             },
                             "type": "object"
@@ -101,9 +248,9 @@
                     },
                     "type": "object"
                 },
-                "setup": {
-                    "properties": {
-                        "lint": {
+                "postInstall": {
+                    "anyOf": [
+                        {
                             "properties": {
                                 "args": {
                                     "items": {
@@ -117,19 +264,166 @@
                             },
                             "type": "object"
                         },
-                        "ts": {
-                            "properties": {
-                                "args": {
-                                    "items": {
+                        {
+                            "items": {
+                                "properties": {
+                                    "args": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "command": {
                                         "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "setup": {
+                    "properties": {
+                        "lint": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "args": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
                                     },
                                     "type": "array"
-                                },
-                                "command": {
-                                    "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            ]
+                        },
+                        "postLintSetup": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "args": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "postTsSetup": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "args": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "ts": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "args": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "args": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
                         }
                     },
                     "type": "object"

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -40,6 +40,11 @@ export async function lintConfigTask(
       if (ctx.userConfig?.hasLintSetup) {
         task.output = `Create .eslintrc.js from config`;
         await ctx.userConfig.lintSetup();
+
+        if (ctx.userConfig.hasPostLintSetup) {
+          task.output = `Run postLintSetup from config`;
+          await ctx.userConfig.postLintSetup();
+        }
       } else {
         // only run the default process with no custom config provided
         const relativeConfigPath = getEsLintConfigPath(options.basePath);

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -23,6 +23,11 @@ export async function tsConfigTask(
       if (ctx.userConfig?.hasTsSetup) {
         task.output = `Create tsconfig from config`;
         await ctx.userConfig.tsSetup();
+
+        if (ctx.userConfig.hasPostTsSetupHook) {
+          task.output = `Run postTsSetup from config`;
+          await ctx.userConfig.postTsSetup();
+        }
       } else {
         if (existsSync(configPath)) {
           task.output = `${configPath} already exists, ensuring strict mode is enabled`;

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -30,6 +30,11 @@ export async function depInstallTask(
       if (ctx.userConfig?.hasDependencies) {
         task.output = `Install dependencies from config`;
         await ctx.userConfig.install();
+
+        if (ctx.userConfig?.hasPostInstallHook) {
+          task.output = `Run postInstall hook from config`;
+          await ctx.userConfig.postInstall();
+        }
       }
       // even if dependencies are installed, exec this and get the latest patch
       await addDep(REQUIRED_DEPENDENCIES, true, { cwd: options.basePath });

--- a/packages/cli/src/configs/rehearsal-config.ts
+++ b/packages/cli/src/configs/rehearsal-config.ts
@@ -9,17 +9,17 @@ export type HookCommand = {
 };
 
 export type SetupConfig = {
-  ts?: HookCommand;
-  postTsSetup?: HookCommand;
-  lint?: HookCommand;
-  postLintSetup?: HookCommand;
+  ts?: HookCommand | HookCommand[];
+  postTsSetup?: HookCommand | HookCommand[];
+  lint?: HookCommand | HookCommand[];
+  postLintSetup?: HookCommand | HookCommand[];
 };
 
 export type ValidateConfig = () => Promise<void>;
 
 export type CustomCommandConfig = {
   install?: DependencyConfig;
-  postInstall?: HookCommand;
+  postInstall?: HookCommand | HookCommand[];
   setup?: SetupConfig;
 };
 

--- a/packages/cli/src/configs/rehearsal-config.ts
+++ b/packages/cli/src/configs/rehearsal-config.ts
@@ -3,18 +3,23 @@ export type DependencyConfig = {
   devDependencies?: string[];
 };
 
-export type SetupConfigCommand = {
+export type HookCommand = {
   command: string;
   args: string[];
 };
 
 export type SetupConfig = {
-  ts?: SetupConfigCommand;
-  lint?: SetupConfigCommand;
+  ts?: HookCommand;
+  postTsSetup?: HookCommand;
+  lint?: HookCommand;
+  postLintSetup?: HookCommand;
 };
+
+export type ValidateConfig = () => Promise<void>;
 
 export type CustomCommandConfig = {
   install?: DependencyConfig;
+  postInstall?: HookCommand;
   setup?: SetupConfig;
 };
 

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -43,6 +43,11 @@ export class UserConfig {
         await addDep(devDependencies, true, { cwd: this.basePath });
       }
     }
+
+    if (this.config && this.config.postInstall) {
+      const { command, args } = this.config.postInstall;
+      await execa(command, args, { cwd: this.basePath });
+    }
   }
 
   // TODO: how to make setup tasks more generic instead of separated functions?
@@ -53,6 +58,11 @@ export class UserConfig {
     if (this.config?.setup?.ts) {
       const { command, args } = this.config.setup.ts;
       await execa(command, args, { cwd: this.basePath });
+
+      if (this.config.setup.postTsSetup) {
+        const { command, args } = this.config.setup.postTsSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 
@@ -60,6 +70,11 @@ export class UserConfig {
     if (this.config?.setup?.lint) {
       const { command, args } = this.config.setup.lint;
       await execa(command, args, { cwd: this.basePath });
+
+      if (this.config.setup.postLintSetup) {
+        const { command, args } = this.config.setup.postLintSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -24,12 +24,24 @@ export class UserConfig {
     );
   }
 
+  public get hasPostInstallHook(): boolean {
+    return !!this.config?.postInstall;
+  }
+
   public get hasTsSetup(): boolean {
     return !!this.config?.setup?.ts;
   }
 
+  public get hasPostTsSetupHook(): boolean {
+    return !!this.config?.setup?.postTsSetup;
+  }
+
   public get hasLintSetup(): boolean {
     return !!this.config?.setup?.lint;
+  }
+
+  public get hasPostLintSetup(): boolean {
+    return !!this.config?.setup?.postLintSetup;
   }
 
   async install(): Promise<void> {
@@ -43,7 +55,9 @@ export class UserConfig {
         await addDep(devDependencies, true, { cwd: this.basePath });
       }
     }
+  }
 
+  async postInstall(): Promise<void> {
     if (this.config && this.config.postInstall) {
       const { command, args } = this.config.postInstall;
       await execa(command, args, { cwd: this.basePath });
@@ -58,11 +72,13 @@ export class UserConfig {
     if (this.config?.setup?.ts) {
       const { command, args } = this.config.setup.ts;
       await execa(command, args, { cwd: this.basePath });
+    }
+  }
 
-      if (this.config.setup.postTsSetup) {
-        const { command, args } = this.config.setup.postTsSetup;
-        await execa(command, args, { cwd: this.basePath });
-      }
+  async postTsSetup(): Promise<void> {
+    if (this.config?.setup?.postTsSetup) {
+      const { command, args } = this.config.setup.postTsSetup;
+      await execa(command, args, { cwd: this.basePath });
     }
   }
 
@@ -70,11 +86,13 @@ export class UserConfig {
     if (this.config?.setup?.lint) {
       const { command, args } = this.config.setup.lint;
       await execa(command, args, { cwd: this.basePath });
+    }
+  }
 
-      if (this.config.setup.postLintSetup) {
-        const { command, args } = this.config.setup.postLintSetup;
-        await execa(command, args, { cwd: this.basePath });
-      }
+  async postLintSetup(): Promise<void> {
+    if (this.config?.setup?.postLintSetup) {
+      const { command, args } = this.config.setup.postLintSetup;
+      await execa(command, args, { cwd: this.basePath });
     }
   }
 

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -59,8 +59,14 @@ export class UserConfig {
 
   async postInstall(): Promise<void> {
     if (this.config && this.config.postInstall) {
-      const { command, args } = this.config.postInstall;
-      await execa(command, args, { cwd: this.basePath });
+      if (Array.isArray(this.config.postInstall)) {
+        for (const { command, args } of this.config.postInstall) {
+          await execa(command, args, { cwd: this.basePath });
+        }
+      } else {
+        const { command, args } = this.config.postInstall;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 
@@ -70,29 +76,57 @@ export class UserConfig {
   // What does upgrade command need for custom config?
   async tsSetup(): Promise<void> {
     if (this.config?.setup?.ts) {
-      const { command, args } = this.config.setup.ts;
-      await execa(command, args, { cwd: this.basePath });
+      const { ts: tsSetup } = this.config.setup;
+      if (Array.isArray(tsSetup)) {
+        for (const { command, args } of tsSetup) {
+          await execa(command, args, { cwd: this.basePath });
+        }
+      } else {
+        const { command, args } = tsSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 
   async postTsSetup(): Promise<void> {
     if (this.config?.setup?.postTsSetup) {
-      const { command, args } = this.config.setup.postTsSetup;
-      await execa(command, args, { cwd: this.basePath });
+      const { postTsSetup } = this.config.setup;
+      if (Array.isArray(postTsSetup)) {
+        for (const { command, args } of postTsSetup) {
+          await execa(command, args, { cwd: this.basePath });
+        }
+      } else {
+        const { command, args } = postTsSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 
   async lintSetup(): Promise<void> {
     if (this.config?.setup?.lint) {
-      const { command, args } = this.config.setup.lint;
-      await execa(command, args, { cwd: this.basePath });
+      const { lint: lintSetup } = this.config.setup;
+      if (Array.isArray(lintSetup)) {
+        for (const { command, args } of lintSetup) {
+          await execa(command, args, { cwd: this.basePath });
+        }
+      } else {
+        const { command, args } = lintSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 
   async postLintSetup(): Promise<void> {
     if (this.config?.setup?.postLintSetup) {
-      const { command, args } = this.config.setup.postLintSetup;
-      await execa(command, args, { cwd: this.basePath });
+      const { postLintSetup } = this.config.setup;
+      if (Array.isArray(postLintSetup)) {
+        for (const { command, args } of postLintSetup) {
+          await execa(command, args, { cwd: this.basePath });
+        }
+      } else {
+        const { command, args } = postLintSetup;
+        await execa(command, args, { cwd: this.basePath });
+      }
     }
   }
 

--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.test.ts.snap
@@ -9,6 +9,16 @@ exports[`Task: config-lint > create .eslintrc.js if not existed 1`] = `
 "
 `;
 
+exports[`Task: config-lint > postLintSetup hook from user config 1`] = `
+"[STARTED] Install dependencies
+[SUCCESS] Install dependencies
+[STARTED] Create eslint config
+[DATA] Create .eslintrc.js from config
+[DATA] Run postLintSetup from config
+[SUCCESS] Create eslint config
+"
+`;
+
 exports[`Task: config-lint > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [SUCCESS] Install dependencies

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
@@ -25,6 +25,14 @@ exports[`Task: config-ts > create tsconfig if not existed 2`] = `
 "
 `;
 
+exports[`Task: config-ts > postTsSetup hook from user config 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[DATA] Run postTsSetup from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config

--- a/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
@@ -12,3 +12,11 @@ exports[`Task: dependency-install > install required dependencies 1`] = `
 [SUCCESS] Install dependencies
 "
 `;
+
+exports[`Task: dependency-install > postInstall hook from user config 1`] = `
+"[STARTED] Install dependencies
+[DATA] Install dependencies from config
+[DATA] Run postInstall hook from config
+[SUCCESS] Install dependencies
+"
+`;

--- a/packages/cli/test/commands/migrate/config-ts.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.test.ts
@@ -80,6 +80,27 @@ describe('Task: config-ts', async () => {
     expect(output).toMatchSnapshot();
   });
 
+  test('postTsSetup hook from user config', async () => {
+    createUserConfig(basePath, {
+      migrate: {
+        setup: {
+          ts: { command: 'touch', args: ['custom-ts-config-script'] },
+          postTsSetup: { command: 'mv', args: ['custom-ts-config-script', 'foo'] },
+        },
+      },
+    });
+
+    const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
+    const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
+    const tasks = [await tsConfigTask(options, { userConfig })];
+    await listrTaskRunner(tasks);
+
+    // This proves the custom command and hook works
+    expect(readdirSync(basePath)).toContain('foo');
+    expect(readdirSync(basePath)).not.toContain('custom-ts-config-script');
+    expect(output).toMatchSnapshot();
+  });
+
   test('stage tsconfig if in git repo', async () => {
     // simulate clean git project
     const git: SimpleGit = simpleGit({


### PR DESCRIPTION
This PR adds hook support in user config:

- postIntall
- postTsSetup
- postLintSetup

Also change all command fields to accept either a `HookCommand` or `HookCommand[]`.