### PR TITLE
fix: revert line number

### DIFF
--- a/packages/reporter/src/formatters/sonarqube-formatter.ts
+++ b/packages/reporter/src/formatters/sonarqube-formatter.ts
@@ -69,17 +69,17 @@ export function sonarqubeFormatter(report: Report): string {
 
 function getTextRange(location: PhysicalLocation | undefined): TextRange {
   return {
-    startLine: getNumber(location, 'startLine'),
-    startColumn: getNumber(location, 'startColumn'),
-    endLine: getNumber(location, 'endLine'),
-    endColumn: getNumber(location, 'endColumn'),
+    startLine: location?.region?.startLine || 0,
+    startColumn: decrementByOne(location, 'startColumn'),
+    endLine: location?.region?.endLine || 0,
+    endColumn: decrementByOne(location, 'endColumn'),
   };
 }
 
-//We bump column and line numbers by 1 for sarif reader. Now we revert back the numbers for sonarqube.
-function getNumber(
+//We bump column and line numbers by 1 for sarif reader. Now we revert back the numbers for sonarqube for column.
+function decrementByOne(
   location: PhysicalLocation | undefined,
-  key: 'startLine' | 'startColumn' | 'endLine' | 'endColumn'
+  key: 'startColumn' | 'endColumn'
 ): number {
   const region = location?.region;
   if (region && Number.isInteger(region[key]) && region[key]! > 1) {

--- a/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sonarqube-formatter.test.ts.snap
@@ -12,9 +12,9 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"The declaration 'react' is never read or used. Remove the declaration or use it.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 0,
+          \\"startLine\\": 1,
           \\"startColumn\\": 0,
-          \\"endLine\\": 0,
+          \\"endLine\\": 1,
           \\"endColumn\\": 11
         }
       }
@@ -28,9 +28,9 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"The variable 'a' has type 'number', but 'string' is assigned. Please convert 'string' to 'number' or change variable's type.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 0,
+          \\"startLine\\": 1,
           \\"startColumn\\": 9,
-          \\"endLine\\": 0,
+          \\"endLine\\": 1,
           \\"endColumn\\": 19
         }
       }
@@ -44,9 +44,9 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"Argument of type '{0}' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '({} as string)', or using type guard: 'if ({} instanceof string) { ... }'.\\",
         \\"filePath\\": \\"/base/path/file1.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 0,
+          \\"startLine\\": 1,
           \\"startColumn\\": 9,
-          \\"endLine\\": 0,
+          \\"endLine\\": 1,
           \\"endColumn\\": 25
         }
       }
@@ -60,9 +60,9 @@ exports[`Test sonarqueFormatter > should transform all fields correctly, irregar
         \\"message\\": \\"Unexpected any. Specify a different type.\\",
         \\"filePath\\": \\"/base/path/file2.ts\\",
         \\"textRange\\": {
-          \\"startLine\\": 0,
+          \\"startLine\\": 1,
           \\"startColumn\\": 0,
-          \\"endLine\\": 0,
+          \\"endLine\\": 1,
           \\"endColumn\\": 11
         }
       }


### PR DESCRIPTION
For Sonarqube, line number starts from 1, column number starts from 0. 