### PR TITLE
test: smoke test gha

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,12 @@
+name: Smoke-Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+  uses:
+    rehearsal-js/smoke-test/.github/workflows/run-smoke-test.yml@run-smoke-test

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  test-and-lint:
+  test:
     name: Runs the CLI Smoke Test
     runs-on: ubuntu-latest
     steps:
@@ -18,3 +18,6 @@ jobs:
           github_token: ${{ secrets.SMOKE_TEST_SECRET }}
           workflow_file_name: run-smoke-test.yml
           ref: master
+          trigger_workflow: true
+          client_payload: '{}'
+          wait_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Runs the CLI Smoke Test
     runs-on: ubuntu-latest
     steps:
-      - uses: convictional/trigger-workflow-and-wait
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: lynchbomb
           repo: rehearsal-js/smoke-test

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           owner: rehearsal-js
           repo: smoke-test
-          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
+          github_token: ${{ secrets.G_ACCESS_TOKEN }}
           workflow_file_name: run-smoke-test.yml
           ref: master
           trigger_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,6 +18,3 @@ jobs:
           github_token: ${{ secrets.G_ACCESS_TOKEN }}
           workflow_file_name: run-smoke-test.yml
           ref: master
-          trigger_workflow: true
-          client_payload: '{}'
-          wait_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,5 +16,7 @@ jobs:
           owner: rehearsal-js
           repo: smoke-test
           github_token: ${{ secrets.SMOKE_TEST_SECRET }}
+          github_user: lynchbomb
           workflow_file_name: run-smoke-test.yml
           ref: master
+          trigger_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
-          owner: lynchbomb
-          repo: rehearsal-js/smoke-test
-          github_token: ${{ secrets.G_ACCESS_TOKEN }}
+          owner: rehearsal-js
+          repo: smoke-test
+          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
           workflow_file_name: run-smoke-test.yml
           ref: master
           trigger_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           owner: lynchbomb
           repo: rehearsal-js/smoke-test
-          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
+          github_token: ${{ secrets.G_ACCESS_TOKEN }}
           workflow_file_name: run-smoke-test.yml
           ref: master
           trigger_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,5 +17,5 @@ jobs:
           repo: smoke-test
           github_token: ${{ secrets.SMOKE_TEST_SECRET }}
           github_user: lynchbomb
-          workflow_file_name: run-smoke-test.yml
+          workflow_file_name: 48689645
           ref: master

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           owner: rehearsal-js
           repo: smoke-test
-          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
+          github_token: ${{ secrets.G_ACCESS_TOKEN }}
           github_user: lynchbomb
           workflow_file_name: 48689645
           ref: master

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,4 +1,4 @@
-name: Smoke-Test
+name: Smoke Test
 
 on:
   push:
@@ -7,6 +7,14 @@ on:
     branches: [master]
 
 jobs:
-  build:
-  uses:
-    rehearsal-js/smoke-test/.github/workflows/run-smoke-test.yml@run-smoke-test
+  test-and-lint:
+    name: Runs the CLI Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait
+        with:
+          owner: lynchbomb
+          repo: rehearsal-js/smoke-test
+          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
+          workflow_file_name: run-smoke-test.yml
+          ref: master

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,4 +19,3 @@ jobs:
           github_user: lynchbomb
           workflow_file_name: run-smoke-test.yml
           ref: master
-          trigger_workflow: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           owner: rehearsal-js
           repo: smoke-test
-          github_token: ${{ secrets.G_ACCESS_TOKEN }}
+          github_token: ${{ secrets.SMOKE_TEST_SECRET }}
           workflow_file_name: run-smoke-test.yml
           ref: master


### PR DESCRIPTION
Fixes: #746 

The intention behind this PR is on every push/pr run this action: https://github.com/rehearsal-js/smoke-test/blob/master/.github/workflows/run-smoke-test.yml. 

The smoke-test-action will:

- download the master branch zip from https://github.com/rehearsal-js/rehearsal-js/archive/refs/heads/master.zip
- pack the tarball for the @rehearsal/cli from zip rather than from NPM and as file:dep
- run test suite from https://github.com/rehearsal-js/smoke-test/tree/master/test
- if the test suite passes this action should pass

The downsides with this implementation:
- we are downloading from master rather than from the PR/commit/branch. as such we will only have an integration pulse after PR merge into master (we still catch way before release and execute manually if needed)
- I would like to also implement a life cycle catch to run the smoke-test on `prepublish`