### PR TITLE
fix: renaming entrypoint from js to ts for migrate

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -133,14 +133,14 @@ async function writeLintConfig(
   outputFileSync(configPath, config);
 
   //yml and ymal don't need formatting. yamlStringify does the formatting already.
-  if (format === FORMAT.JS || format === FORMAT.JSON) {
-    const formattedConfig = await lintConfig(config, configPath, basePath);
+  if (format === FORMAT.JS) {
+    const formattedConfig = await lintJSConfig(config, configPath, basePath);
     formattedConfig && outputFileSync(configPath, formattedConfig);
   }
   await gitAddIfInRepo(configPath, basePath); // stage .eslintrc.js if in a git repo
 }
 
-async function lintConfig(
+async function lintJSConfig(
   configStr: string,
   filePath: string,
   basePath: string

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -39,11 +39,11 @@ export async function convertTask(
 
       const projectName = determineProjectName() || '';
       const { basePath, entrypoint } = options;
-      const tscPath = await getPathToBinary('tsc', { cwd: options.basePath });
+      const tscPath = await getPathToBinary('tsc', { cwd: basePath });
       const { stdout } = await execa(tscPath, ['--version']);
       const tsVersion = stdout.split(' ')[1];
       const reporter = new Reporter(
-        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate', entrypoint },
+        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate' },
         logger
       );
 
@@ -58,7 +58,7 @@ export async function convertTask(
 
             const input = {
               basePath: ctx.targetPackagePath,
-              entrypoint: options.entrypoint,
+              entrypoint,
               sourceFiles: [f],
               logger: logger,
               reporter,
@@ -115,7 +115,7 @@ export async function convertTask(
                 completed = true;
               }
             }
-            const reportOutputPath = resolve(options.basePath, options.outputPath);
+            const reportOutputPath = resolve(basePath, options.outputPath);
             generateReports('migrate', reporter, reportOutputPath, options.format);
             gitAddIfInRepo(reportOutputPath, basePath); // stage report if in git repo
             task.title = getReportSummary(reporter.report, migratedFiles.length);
@@ -127,7 +127,7 @@ export async function convertTask(
         } else {
           const input = {
             basePath: ctx.targetPackagePath,
-            entrypoint: options.entrypoint,
+            entrypoint,
             sourceFiles: ctx.sourceFilesWithAbsolutePath,
             logger: logger,
             reporter,

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -27,7 +27,7 @@ export async function regenTask(
       const { stdout } = await execa(tscPath, ['--version']);
       const tsVersion = stdout.split(' ')[1];
       const reporter = new Reporter(
-        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate', entrypoint },
+        { tsVersion, projectName, basePath, commandName: '@rehearsal/migrate' },
         logger
       );
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -28,6 +28,7 @@ import type { UpgradeCommandContext, UpgradeCommandOptions } from '../types';
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
 export const upgradeCommand = new Command();
 
+//TODO: add entrypoint option
 upgradeCommand
   .name('upgrade')
   .description('Upgrade typescript dev-dependency with compilation insights and auto-fix options')
@@ -81,7 +82,7 @@ upgradeCommand
     const projectName = determineProjectName() || '';
 
     const reporter = new Reporter(
-      { tsVersion: '', projectName, basePath, commandName: '@rehearsal/upgrade', entrypoint: '' },
+      { tsVersion: '', projectName, basePath, commandName: '@rehearsal/upgrade' },
       logger
     );
 

--- a/packages/migrate/test/index.test.ts
+++ b/packages/migrate/test/index.test.ts
@@ -52,7 +52,7 @@ describe('migrate', () => {
       {
         tsVersion: '',
         projectName: '@rehearsal/test',
-        basePath,
+        basePath: actualDir,
         commandName: '@rehearsal/migrate',
       },
       logger
@@ -65,11 +65,11 @@ describe('migrate', () => {
 
   test('should move js file to ts extension', async () => {
     const input: MigrateInput = {
-      basePath,
+      basePath: actualDir,
       sourceFiles,
       logger,
       reporter,
-      entrypoint: '',
+      entrypoint: 'index.js',
     };
 
     const output = await migrate(input);
@@ -79,6 +79,7 @@ describe('migrate', () => {
     const report = JSON.parse(readFileSync(jsonReport).toString());
 
     expect(report.summary[0].basePath).toMatch(/migrate/);
+    expect(report.summary[0].entrypoint).toMatch('index.ts');
     expect(migratedFiles).includes(`${actualDir}/index.ts`);
     expect(existsSync(`${actualDir}/index.js`)).toBeFalsy();
     rmSync(jsonReport);

--- a/packages/regen/src/regen.ts
+++ b/packages/regen/src/regen.ts
@@ -25,7 +25,7 @@ export type RegenOutput = {
 export async function regen(input: RegenInput): Promise<RegenOutput> {
   const basePath = resolve(input.basePath);
   const configName = input.configName || 'tsconfig.json';
-  const sourceFiles = input.sourceFiles || ['index.ts'];
+  const sourceFiles = input.sourceFiles || [resolve(basePath, 'index.ts')];
   const reporter = input.reporter;
   const logger = input.logger;
 
@@ -86,7 +86,7 @@ export async function regen(input: RegenInput): Promise<RegenOutput> {
     });
 
   await runner.run(fileNames, { log: (message) => (listrTask.output = message) });
-  reporter.saveCurrentRunToReport(basePath, input.entrypoint);
+  reporter.saveCurrentRunToReport(basePath, input.entrypoint || '');
 
   return {
     basePath,

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -18,7 +18,6 @@ type ReporterMeta = {
   basePath: string;
   commandName: string;
   tsVersion: string;
-  entrypoint?: string;
   previousFixedCount?: number;
 };
 

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -22,7 +22,6 @@ describe('Test reporter', function () {
       tsVersion: '',
       projectName: 'test',
       basePath,
-      entrypoint: '',
       commandName: '@rehearsal/reporter',
     }).loadRun(testDataPath);
   });


### PR DESCRIPTION
1. renaming entry point file extension in the rehearsal report from js to ts after the file has been git moved to ts
2. some other code cleanups.