### PR TITLE
feat: support .gjs in Ember PackageGraphs

### DIFF
--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -18,8 +18,10 @@
     "version": "pnpm version"
   },
   "dependencies": {
+    "@glimmer/syntax": "^0.84.2",
     "@rehearsal/migration-graph-shared": "workspace:*",
     "@swc/core": "^1.3.32",
+    "babel-plugin-htmlbars-inline-precompile": "^5.3.1",
     "debug": "^4.3.4",
     "enhanced-resolve": "^5.12.0",
     "fast-glob": "^3.2.12",

--- a/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
@@ -1,7 +1,5 @@
-import fs from 'fs';
 import { resolve } from 'path';
-import { IResolveOptions } from 'dependency-cruiser';
-import { CachedInputFileSystem } from 'enhanced-resolve';
+import { type IResolveOptions } from 'dependency-cruiser';
 import debug from 'debug';
 
 import { getEmberAddonName } from '../utils/ember';
@@ -33,11 +31,9 @@ export class EmberAddonPackageGraph extends EmberAppPackageGraph {
       alias,
     });
 
-    const options = {
-      fileSystem: new CachedInputFileSystem(fs, 4000),
-      resolveDeprecations: false,
-      alias: alias,
-    };
+    const options = super.resolveOptions;
+
+    options.alias = alias;
 
     return options;
   }

--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { readPackageJson } from '@rehearsal/migration-graph-shared';
+import { Graph, ModuleNode, readPackageJson } from '@rehearsal/migration-graph-shared';
 
 import {
   getEmberAddonName,
@@ -8,6 +8,10 @@ import {
   getNameFromMain,
   isEngine,
 } from '../utils/ember';
+import {
+  EmberAddonPackageGraph,
+  type EmberAddonPackageGraphOptions,
+} from './ember-addon-package-graph';
 import { type EmberPackageOptions, EmberAppPackage } from './ember-app-package';
 
 export class EmberAddonPackage extends EmberAppPackage {
@@ -39,7 +43,7 @@ export class EmberAddonPackage extends EmberAppPackage {
 
     this.excludePatterns = new Set([...excludeDirs, ...excludeFiles]);
 
-    this.includePatterns = new Set(['.']);
+    this.includePatterns = new Set(['.', '**/*.gjs']);
   }
 
   get isEngine(): boolean {
@@ -70,5 +74,15 @@ export class EmberAddonPackage extends EmberAppPackage {
       this.#addonName = getEmberAddonName(this.path);
     }
     return this.#addonName;
+  }
+
+  getModuleGraph(options: EmberAddonPackageGraphOptions = {}): Graph<ModuleNode> {
+    if (this.graph) {
+      return this.graph;
+    }
+
+    this.graph = new EmberAddonPackageGraph(this, options).discover();
+
+    return this.graph;
   }
 }

--- a/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
@@ -306,6 +306,7 @@ export class EmberAppPackageGraph extends PackageGraph {
       fileSystem: new CachedInputFileSystem(fs, 4000),
       resolveDeprecations: false,
       alias: alias,
+      extensions: ['.js', '.gjs'], // Add .gjs extension so this will be crawled by dependency-cruiser
     };
   }
 }

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -30,7 +30,7 @@ export class EmberAppPackage extends Package implements IPackage {
       ...this.addonPaths,
     ]);
 
-    this.includePatterns = new Set(['.']); // No longer isolate this to the app directory, include all files in dir.
+    this.includePatterns = new Set(['.', '**/*.gjs']); // No longer isolate this to the app directory, include all files in dir.
   }
 
   get addonPaths(): Array<string> {

--- a/packages/migration-graph-ember/src/entities/types.d.ts
+++ b/packages/migration-graph-ember/src/entities/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'babel-plugin-htmlbars-inline-precompile';

--- a/packages/migration-graph-ember/src/utils/transform-gjs.ts
+++ b/packages/migration-graph-ember/src/utils/transform-gjs.ts
@@ -1,0 +1,29 @@
+import { preprocessEmbeddedTemplates as babelPreprocessEmbeddedTemplates } from 'babel-plugin-htmlbars-inline-precompile';
+
+import debug from 'debug';
+
+const DEBUG_CALLBACK = debug('rehearsal:migration-graph-ember:transform-gjs');
+
+const getTemplateLocalsRequirePath = require.resolve('@glimmer/syntax');
+
+const TEMPLATE_TAG_CONFIG = {
+  getTemplateLocalsRequirePath,
+  getTemplateLocalsExportPath: 'getTemplateLocals',
+
+  templateTag: 'template',
+  templateTagReplacement: 'GLIMMER_TEMPLATE',
+
+  includeSourceMaps: false,
+  includeTemplateTokens: false,
+};
+
+export function transformGjs(filename: string, source: string): string {
+  DEBUG_CALLBACK(`transforming %s to .js`, {});
+
+  const { output } = babelPreprocessEmbeddedTemplates(
+    source,
+    Object.assign({ relativePath: filename }, TEMPLATE_TAG_CONFIG)
+  );
+
+  return output;
+}

--- a/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
@@ -4,7 +4,7 @@ import { EmberAddonPackage } from '../../src/entities/ember-addon-package';
 import { EmberAddonPackageGraph } from '../../src/entities/ember-addon-package-graph';
 
 describe('Unit | EmberAddonPackageGraph', () => {
-  test('should create an edge between app/ files in addons module graph', async () => {
+  test('should not include app/ dir in module graph', async () => {
     const project = getEmberProject('addon');
 
     await setupProject(project);
@@ -15,5 +15,65 @@ describe('Unit | EmberAddonPackageGraph', () => {
 
     expect(addonPackageGraph.graph.hasNode('addon/components/greet.js')).toBeTruthy();
     expect(addonPackageGraph.graph.hasNode('app/components/greet.js')).toBeFalsy();
+  });
+
+  test('should create an edge between files when path references moduleName', async () => {
+    // Some addons
+    // Use Case where an addon is reference files from within the addon but using the modulenName in the path
+    // e.g. moduleName of some-module
+    // Som
+    // `import MyComponent from 'some-module/components/some-component';
+
+    const project = getEmberProject('addon');
+
+    project.mergeFiles({
+      addon: {
+        components: {
+          'trunk.gjs': `
+            import Branch from 'addon-template/components/branch'; 
+
+            <template>
+              <Branch/>
+            </template>
+          `,
+          'branch.gjs': `
+            import Component from '@glimmer/component';
+            import Leaf from 'addon-template/components/leaf';
+
+            export default class Branch extends Component {
+              <template><Leaf/></template>
+            };
+          `,
+          'leaf.gjs': `
+            const Flea = <template>
+              <p>Hello, {{@name}}!</p>
+            </template>;
+            
+            <template>
+              <Flea @name="Littlest"/>
+            </template>
+          `,
+        },
+      },
+    });
+
+    await setupProject(project);
+
+    const addonPackage = new EmberAddonPackage(project.baseDir);
+    const addonPackageGraph = new EmberAddonPackageGraph(addonPackage);
+    const graph = addonPackageGraph.discover();
+
+    const trunkNode = graph.getNode('addon/components/trunk.gjs');
+    const branchNode = graph.getNode('addon/components/branch.gjs');
+    const leafNode = graph.getNode('addon/components/leaf.gjs');
+
+    expect(
+      trunkNode.adjacent.has(branchNode),
+      'root.gjs should have edge with branch.gjs'
+    ).toBeTruthy();
+    expect(
+      branchNode.adjacent.has(leafNode),
+      'branch.gjs should have edge with leaf.gjs'
+    ).toBeTruthy();
   });
 });

--- a/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
@@ -579,4 +579,97 @@ describe('Unit | EmberAppPackageGraph', () => {
 
     expect(someNode.content.synthetic, 'the node on the graph should be replaced').toBeFalsy();
   });
+
+  describe('support .gjs file format', () => {
+    test('should parse a .gjs file', async () => {
+      const project = getEmberProject('app');
+
+      project.mergeFiles({
+        app: {
+          components: {
+            'example.gjs': `
+              import Component from '@glimmer/component';
+
+              const divide = () => 4 / 2;
+          
+              const First = <template>Hello</template>
+          
+              class Second extends Component {
+                <template>world</template>
+              }
+          
+              <template>
+                <First/>, <Second/>!
+              </template>
+            `,
+          },
+        },
+      });
+
+      await setupProject(project);
+      const p = new EmberAppPackage(project.baseDir);
+      const packageGraph: Graph<ModuleNode> = new EmberAppPackageGraph(p).discover();
+
+      expect(packageGraph.hasNode('app/components/example.gjs')).toBeTruthy();
+    });
+
+    test('should have edges between imports from .gjs file', async () => {
+      const project = getEmberProject('app');
+
+      project.mergeFiles({
+        app: {
+          components: {
+            'trunk.gjs': `
+              import Branch from './branch'; 
+
+              <template>
+                <Branch/>
+              </template>
+            `,
+            'branch.gjs': `
+              import Component from '@glimmer/component';
+              import Leaf from './leaf';
+
+              export default class Branch extends Component {
+
+                get name() {
+                  return 'Littlest';
+                }
+
+                <template><Leaf @name={{this.name}}/></template>
+              };
+            `,
+            'leaf.gjs': `
+              const Flea = <template>
+                <p>Hello, {{@name}}!</p>
+              </template>;
+              
+              <template>
+                <Flea @name={{@name}}/>
+              </template>
+            `,
+          },
+        },
+      });
+
+      await setupProject(project);
+
+      const p = new EmberAppPackage(project.baseDir);
+      const options = {};
+      const packageGraph: Graph<ModuleNode> = new EmberAppPackageGraph(p, options).discover();
+
+      const trunkNode = packageGraph.getNode('app/components/trunk.gjs');
+      const branchNode = packageGraph.getNode('app/components/branch.gjs');
+      const leafNode = packageGraph.getNode('app/components/leaf.gjs');
+
+      expect(
+        trunkNode.adjacent.has(branchNode),
+        'root.gjs should have edge with branch.gjs'
+      ).toBeTruthy();
+      expect(
+        branchNode.adjacent.has(leafNode),
+        'branch.gjs should have edge with leaf.gjs'
+      ).toBeTruthy();
+    });
+  });
 });

--- a/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
@@ -46,7 +46,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     ]);
   });
 
-  test('should create an edge between a test an app non-relative path', async () => {
+  test('should create an edge between a test file and app file with appName path', async () => {
     const project = await getEmberProjectFixture('app-with-utils');
 
     const p = new EmberAppPackage(project.baseDir);

--- a/packages/migration-graph-ember/test/utils/__snapshots__/transform-gjs.test.ts.snap
+++ b/packages/migration-graph-ember/test/utils/__snapshots__/transform-gjs.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1
+
+exports[`transformGjs > should support .gjs file extension 1`] = `
+"
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      const Greeting = [GLIMMER_TEMPLATE(\`Hello\`)]
+
+      class Salutation extends Component {
+        @service locale;
+
+
+        get thing() {
+          this.locale.getLocale();
+        }
+
+        [GLIMMER_TEMPLATE(\`
+          <Greeting/> from {{this.thing}}
+        \`)]
+      }
+
+      export default Salutation;
+    "
+`;

--- a/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
+++ b/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
@@ -261,4 +261,41 @@ describe('discoverServiceDependencies', () => {
     const discovered = results[0];
     expect(discovered.serviceName).toBe('locale');
   });
+
+  test('should support .gjs file extension', () => {
+    const source = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      const Greeting = <template>Hello</template>
+
+      class Salutation extends Component {
+        @service locale;
+
+
+        get thing() {
+          this.locale.getLocale();
+        }
+
+        <template>
+          <Greeting/> from {{this.thing}}
+        </template>
+      }
+
+      export default Salutation;
+    `;
+
+    const files = {
+      'component.gjs': source,
+    };
+
+    fixturify.writeSync(tmpDir, files);
+
+    const results = discoverServiceDependencies(tmpDir, 'component.gjs');
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    const discovered = results[0];
+    expect(discovered.serviceName).toBe('locale');
+  });
 });

--- a/packages/migration-graph-ember/test/utils/transform-gjs.test.ts
+++ b/packages/migration-graph-ember/test/utils/transform-gjs.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { transformGjs } from '../../src/utils/transform-gjs';
+
+describe('transformGjs', () => {
+  test('should support .gjs file extension', () => {
+    const source = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      const Greeting = <template>Hello</template>
+
+      class Salutation extends Component {
+        @service locale;
+
+
+        get thing() {
+          this.locale.getLocale();
+        }
+
+        <template>
+          <Greeting/> from {{this.thing}}
+        </template>
+      }
+
+      export default Salutation;
+    `;
+
+    const output = transformGjs('component.gjs', source);
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -31,7 +31,6 @@ export type PackageGraphOptions = {
   parent?: GraphNode<PackageNode>;
   project?: ProjectGraph;
 };
-
 export class PackageGraph {
   protected baseDir: string;
   protected package: Package;
@@ -83,12 +82,14 @@ export class PackageGraph {
     // TODO get entrypoint  Package (maybePckage) and instantiate with that value if provided from API.
     const target = entrypoint ? [entrypoint] : [...include];
 
+    const resolveOptions = this.resolveOptions;
     DEBUG_CALLBACK('Executing dependency-cruiser');
     DEBUG_CALLBACK('Target: %O', target);
-    DEBUG_CALLBACK('Options: %O', cruiseOptions);
+    DEBUG_CALLBACK('cruiseOptions: %O', cruiseOptions);
+    DEBUG_CALLBACK('resolveOptions: %O', resolveOptions);
 
     try {
-      result = cruise(target, cruiseOptions, this.resolveOptions);
+      result = cruise(target, cruiseOptions, resolveOptions);
     } catch (error) {
       throw new Error(`Unable to cruise: ${error}`);
     }

--- a/packages/test-support/src/project.ts
+++ b/packages/test-support/src/project.ts
@@ -48,7 +48,7 @@ function addUtilDirectory(project: Project): Project {
             import base from './base';
             export default base;
             `,
-          'base.js': `export default function () => { console.log(1); }`,
+          'base.js': `export default function () { console.log(1); }`,
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,10 +222,12 @@ importers:
 
   packages/migration-graph-ember:
     specifiers:
+      '@glimmer/syntax': ^0.84.2
       '@rehearsal/migration-graph-shared': workspace:*
       '@rehearsal/test-support': workspace:*
       '@swc/core': ^1.3.32
       '@types/lodash.merge': ^4.6.7
+      babel-plugin-htmlbars-inline-precompile: ^5.3.1
       debug: ^4.3.4
       dependency-cruiser: ^12.7.0
       enhanced-resolve: ^5.12.0
@@ -243,8 +245,10 @@ importers:
       vitest: ^0.28.5
       walk-sync: ^3.0.0
     dependencies:
+      '@glimmer/syntax': 0.84.2
       '@rehearsal/migration-graph-shared': link:../migration-graph-shared
       '@swc/core': 1.3.32
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       fast-glob: 3.2.12
@@ -911,6 +915,37 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@glimmer/env/0.1.7:
+    resolution: {integrity: sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==}
+    dev: false
+
+  /@glimmer/interfaces/0.84.2:
+    resolution: {integrity: sha512-tMZxQpOddUVmHEOuripkNqVR7ba0K4doiYnFd4WyswqoHPlxqpBujbIamQ+bWCWEF0U4yxsXKa31ekS/JHkiBQ==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: false
+
+  /@glimmer/syntax/0.84.2:
+    resolution: {integrity: sha512-SPBd1tpIR9XeaXsXsMRCnKz63eLnIZ0d5G9QC4zIBFBC3pQdtG0F5kWeuRVCdfTIFuR+5WBMfk5jvg+3gbQhjg==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+    dev: false
+
+  /@glimmer/util/0.84.2:
+    resolution: {integrity: sha512-VbhzE2s4rmU+qJF3gGBTL1IDjq+/G2Th51XErS8MQVMCmE4CU2pdwSzec8PyOowqCGUOrVIWuMzEI6VoPM4L4w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@simple-dom/interface': 1.4.0
+    dev: false
+
+  /@handlebars/parser/2.0.0:
+    resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
+    dev: false
+
   /@humanwhocodes/config-array/0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -1121,6 +1156,10 @@ packages:
       argparse: 1.0.10
       colors: 1.2.5
       string-argv: 0.3.1
+
+  /@simple-dom/interface/1.4.0:
+    resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
+    dev: false
 
   /@swc/core-darwin-arm64/1.3.32:
     resolution: {integrity: sha512-o19bhlxuUgjUElm6i+QhXgZ0vD6BebiB/gQpK3en5aAwhOvinwr4sah3GqFXsQzz/prKVDuMkj9SW6F/Ug5hgg==}
@@ -1945,7 +1984,24 @@ packages:
   /available-typed-arrays/1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
-    dev: true
+
+  /babel-plugin-ember-modules-api-polyfill/3.5.0:
+    resolution: {integrity: sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dependencies:
+      ember-rfc176-data: 0.3.18
+    dev: false
+
+  /babel-plugin-htmlbars-inline-precompile/5.3.1:
+    resolution: {integrity: sha512-QWjjFgSKtSRIcsBhJmEwS2laIdrA6na8HAlc/pEAhjHgQsah/gMiBFRZvbQTy//hWxR4BMwV7/Mya7q5H8uHeA==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      line-column: 1.0.2
+      magic-string: 0.25.9
+      parse-static-imports: 1.1.0
+      string.prototype.matchall: 4.0.8
+    dev: false
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2012,7 +2068,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.0
-    dev: true
 
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2491,7 +2546,6 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
-    dev: true
 
   /dependency-cruiser/12.7.0:
     resolution: {integrity: sha512-5oq4nhJ2h/bRM8LgB+UfEUEmDtpdBVfuc9bEvkd7w9HaMfbRdcthU0Ek2NOrVNpU1Eiu6U5Y8q1CsDJqD/yO1g==}
@@ -2579,6 +2633,10 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
+  /ember-rfc176-data/0.3.18:
+    resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
+    dev: false
+
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2649,7 +2707,6 @@ packages:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.9
-    dev: true
 
   /es-set-tostringtag/2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -2658,7 +2715,6 @@ packages:
       get-intrinsic: 1.2.0
       has: 1.0.3
       has-tostringtag: 1.0.0
-    dev: true
 
   /es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
@@ -2673,7 +2729,6 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-    dev: true
 
   /esbuild/0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
@@ -3121,7 +3176,6 @@ packages:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
-    dev: true
 
   /foreground-child/2.0.0:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
@@ -3195,11 +3249,9 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.21.1
       functions-have-names: 1.2.3
-    dev: true
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-    dev: true
 
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3215,7 +3267,6 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
-    dev: true
 
   /get-pkg-repo/4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
@@ -3238,7 +3289,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
-    dev: true
 
   /git-hooks-list/1.0.3:
     resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
@@ -3363,7 +3413,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       define-properties: 1.1.4
-    dev: true
 
   /globby/10.0.0:
     resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
@@ -3394,7 +3443,6 @@ packages:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
       get-intrinsic: 1.2.0
-    dev: true
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -3421,7 +3469,6 @@ packages:
 
   /has-bigints/1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
-    dev: true
 
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -3435,24 +3482,20 @@ packages:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.2.0
-    dev: true
 
   /has-proto/1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -3544,7 +3587,6 @@ packages:
       get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
-    dev: true
 
   /interpret/3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -3556,7 +3598,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       is-typed-array: 1.1.10
-    dev: true
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -3569,7 +3610,6 @@ packages:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
       has-bigints: 1.0.2
-    dev: true
 
   /is-boolean-object/1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -3577,12 +3617,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-callable/1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /is-core-module/2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
@@ -3594,7 +3632,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3625,14 +3662,12 @@ packages:
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /is-number-object/1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -3662,13 +3697,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-shared-array-buffer/1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
       call-bind: 1.0.2
-    dev: true
 
   /is-stream/2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3679,14 +3712,12 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-symbol/1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /is-text-path/1.0.1:
     resolution: {integrity: sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==}
@@ -3704,13 +3735,11 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-weakref/1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
-    dev: true
 
   /is-windows/1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -3718,10 +3747,16 @@ packages:
 
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: true
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /isobject/2.1.0:
+    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      isarray: 1.0.0
+    dev: false
 
   /istanbul-lib-coverage/3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -3839,6 +3874,13 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  /line-column/1.0.2:
+    resolution: {integrity: sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==}
+    dependencies:
+      isarray: 1.0.0
+      isobject: 2.1.0
+    dev: false
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -4014,6 +4056,12 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: false
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -4220,12 +4268,10 @@ packages:
 
   /object-inspect/1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-    dev: true
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object.assign/4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
@@ -4235,7 +4281,6 @@ packages:
       define-properties: 1.1.4
       has-symbols: 1.0.3
       object-keys: 1.1.1
-    dev: true
 
   /object.values/1.1.6:
     resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==}
@@ -4378,6 +4423,10 @@ packages:
   /parse-passwd/1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
+
+  /parse-static-imports/1.1.0:
+    resolution: {integrity: sha512-HlxrZcISCblEV0lzXmAHheH/8qEkKgmqkdxyHTPbSqsTUV8GzqmN1L+SSti+VbNPfbBO3bYLPHDiUs2avbAdbA==}
+    dev: false
 
   /path-equal/1.2.5:
     resolution: {integrity: sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==}
@@ -4656,7 +4705,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       functions-have-names: 1.2.3
-    dev: true
 
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
@@ -4775,7 +4823,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       is-regex: 1.1.4
-    dev: true
 
   /safe-regex/2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
@@ -4852,7 +4899,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       object-inspect: 1.12.3
-    dev: true
 
   /siginfo/2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4869,6 +4915,10 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /simple-html-tokenizer/0.5.11:
+    resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
     dev: false
 
   /simple-swizzle/0.2.2:
@@ -4937,6 +4987,11 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: false
 
   /spawn-sync/1.0.15:
     resolution: {integrity: sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==}
@@ -5016,6 +5071,19 @@ packages:
       strip-ansi: 7.0.1
     dev: true
 
+  /string.prototype.matchall/4.0.8:
+    resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
+      get-intrinsic: 1.2.0
+      has-symbols: 1.0.3
+      internal-slot: 1.0.4
+      regexp.prototype.flags: 1.4.3
+      side-channel: 1.0.4
+    dev: false
+
   /string.prototype.padend/3.1.4:
     resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
     engines: {node: '>= 0.4'}
@@ -5031,7 +5099,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: true
 
   /string.prototype.trimstart/1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
@@ -5039,7 +5106,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: true
 
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -5369,7 +5435,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
 
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -5421,7 +5486,6 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-    dev: true
 
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -5714,7 +5778,6 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
-    dev: true
 
   /which-typed-array/1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
@@ -5726,7 +5789,6 @@ packages:
       gopd: 1.0.1
       has-tostringtag: 1.0.0
       is-typed-array: 1.1.10
-    dev: true
 
   /which/1.2.14:
     resolution: {integrity: sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==}


### PR DESCRIPTION
This PR addresses #606 

Adds support for `.gjs` files to Ember PackageGraphs.

- Includes `.gjs` file extension for `EmberAppPackageGraph` and `EmberAddonPackageGraph` resolveOptions passed to dependency-cruiser.
- Added test for `EmberAddonPackage` due to bug found where resolve alias for ember-addon paths starting with moduleName where not mapping back to the addon directory when regressing against internal addon.
- Preprocess/transform `.gjs` files to remove `<template>` tags and use something more es parse-able.

### Testing Done
- Added tests
- Regressed against internal addon `voyager-web/packages/addons/image-view-model` which has `.gjs` files. Produces graph edges correctly. 

### TODO
- [x] Add service discovery support for .gjs files.
- [x] Drop `@glimmer/babel-preset` as we don't need to transform **`hbs`**. 
- [X] Figure out how to infer `@glimmer/syntax` dependency from target package's node_modules so we can use the version related to the ember app.


### ~Concerns/Alternatives~ 
**This is no longer a concern because I removed usage of `futureCruise` api that was experimental/unstable.**

- The `futureCruise` method from `dependency-cruiser` API is experimental/unstable.
- Not currently a problem, but a potential future risk

#### Drop futureCruise API, no need for `@glimmer/babel-preset`
- This may sound odd, but we don't need `@glimmer/babel-preset` to add `.gjs` files to the graph using `dependency-cruiser`
- I was able to implement this without using `@glimmer/babel-preset` because ember  `<template>` tag semantics get seen as JSX TemplateExpressions.
- When `dependency-cruiser` parses these files, it thinks they're JSX like source files and manages to get the import declarations perfectly fine.
- First couple of commits to this PR have just that. ~Last commit of this PR is the refactor to use `futureCruise`.~ We don't use futureCruiser at all. Just plain old cruise. 

#### Find another graph solution
- Some other OTS graph creation tool.
- Pros:
  - Maybe more stable API?
- Cons:
  - Have to find and adapt another solution.
  - Uncertain if it will provide same file level data.
  - Uncertain if it will meet or exceed current perf.


#### Create our own dependency graph solution
- Expand on the naive `swc` es6 entrypoint walker I had before.
- Pros: We control our own crawl tools. Maybe faster.
- Cons:
  - Have to re-invent the wheel.
  - This is a solved problem, by mostly all package managers.
 

#### Explore and emit the resolved graph data from rollup when passed an entrypoint

Implementation:
- fast glob all entrypoints in a project `.` directories and top level files.
- Then iterate with rollup

Pros:
- If it works, a way to customize resolutions for different module environments.
- Well rationalized API.

Cons:
- Perf is uncertain.
- Uncertain of success
- Have to create a new solution.