### PR TITLE
chore(migration-graph): improve logging for inheritance

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
@@ -1,16 +1,16 @@
 import { resolve } from 'path';
 import { type IResolveOptions } from 'dependency-cruiser';
-import debug from 'debug';
+import debug, { type Debugger } from 'debug';
 
 import { getEmberAddonName } from '../utils/ember';
 import { EmberAddonPackage } from './ember-addon-package';
 import { EmberAppPackageGraph, EmberAppPackageGraphOptions } from './ember-app-package-graph';
 
-const DEBUG_CALLBACK = debug('rehearsal:migration-graph-ember:ember-addon-package-graph');
-
 export type EmberAddonPackageGraphOptions = EmberAppPackageGraphOptions;
 
 export class EmberAddonPackageGraph extends EmberAppPackageGraph {
+  protected debug: Debugger = debug(`rehearsal:migration-graph-ember:${this.constructor.name}`);
+
   constructor(p: EmberAddonPackage, options: EmberAddonPackageGraphOptions = {}) {
     super(p, options);
   }
@@ -26,7 +26,7 @@ export class EmberAddonPackageGraph extends EmberAppPackageGraph {
 
     alias[addonName] = resolve(this.baseDir, 'addon');
 
-    DEBUG_CALLBACK({
+    this.debug({
       baseDir: this.baseDir,
       alias,
     });

--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
+import debug, { type Debugger } from 'debug';
 import { Graph, ModuleNode, readPackageJson } from '@rehearsal/migration-graph-shared';
 
 import {
@@ -20,6 +20,8 @@ export class EmberAddonPackage extends EmberAppPackage {
   #name: string | undefined;
   #moduleName: string | undefined;
   #addonName: string | undefined;
+
+  protected debug: Debugger = debug(`rehearsal:migration-graph-ember:${this.constructor.name}`);
 
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
     super(pathToPackage, {
@@ -77,6 +79,7 @@ export class EmberAddonPackage extends EmberAppPackage {
   }
 
   getModuleGraph(options: EmberAddonPackageGraphOptions = {}): Graph<ModuleNode> {
+    this.debug('getModuleGraph');
     if (this.graph) {
       return this.graph;
     }

--- a/packages/migration-graph-ember/src/entities/ember-addon-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-project-graph.ts
@@ -1,9 +1,12 @@
+import debug, { type Debugger } from 'debug';
 import { EmberAppProjectGraph, EmberAppProjectGraphOptions } from './ember-app-project-graph';
 
 export type EmberAddonProjectGraphOptions = EmberAppProjectGraphOptions;
 
 export class EmberAddonProjectGraph extends EmberAppProjectGraph {
+  protected debug: Debugger = debug(`rehearsal:migration-graph-ember:${this.constructor.name}`);
   constructor(rootDir: string, options?: EmberAddonProjectGraphOptions) {
     super(rootDir, { sourceType: 'Ember Addon', ...options });
+    this.debug(`rootDir: %s, options: %o`, rootDir, options);
   }
 }

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { join, relative } from 'path';
-import debug from 'debug';
+import debug, { type Debugger } from 'debug';
 import {
   cruise,
   ICruiseOptions,
@@ -14,8 +14,6 @@ import { Graph, GraphNode } from '../graph';
 import { Package } from './package';
 import type { ModuleNode, PackageNode } from '../types';
 import type { ProjectGraph } from './project-graph';
-
-const DEBUG_CALLBACK = debug('rehearsal:migration-graph-shared:package-graph');
 
 function isExternalModule(moduleOrDep: IModule | IDependency): boolean {
   // If it's a coreModule like `path` skip;
@@ -32,6 +30,8 @@ export type PackageGraphOptions = {
   project?: ProjectGraph;
 };
 export class PackageGraph {
+  protected debug: Debugger = debug(`rehearsal:migration-graph-sahred:${this.constructor.name}`);
+
   protected baseDir: string;
   protected package: Package;
   protected entrypoint?: string;
@@ -83,10 +83,10 @@ export class PackageGraph {
     const target = entrypoint ? [entrypoint] : [...include];
 
     const resolveOptions = this.resolveOptions;
-    DEBUG_CALLBACK('Executing dependency-cruiser');
-    DEBUG_CALLBACK('Target: %O', target);
-    DEBUG_CALLBACK('cruiseOptions: %O', cruiseOptions);
-    DEBUG_CALLBACK('resolveOptions: %O', resolveOptions);
+    this.debug('Executing dependency-cruiser');
+    this.debug('Target: %O', target);
+    // this.debug('cruiseOptions: %O', cruiseOptions);
+    // this.debug('resolveOptions: %O', { ...resolveOptions, fileSystem: undefined });
 
     try {
       result = cruise(target, cruiseOptions, resolveOptions);
@@ -94,12 +94,12 @@ export class PackageGraph {
       throw new Error(`Unable to cruise: ${error}`);
     }
 
-    DEBUG_CALLBACK(result);
+    this.debug(result);
 
     const output = result.output as ICruiseResult;
 
     output.modules.forEach((m: IModule) => {
-      DEBUG_CALLBACK(m);
+      this.debug(m);
 
       if (isExternalModule(m)) {
         return;
@@ -112,7 +112,7 @@ export class PackageGraph {
       const sourcePath = resolveRelative(baseDir, m.source);
 
       if (this.isFileExternalToPackage(sourcePath)) {
-        DEBUG_CALLBACK(
+        this.debug(
           `The target file "${sourcePath}" is external to package "${this.package.packageName}" (${baseDir}), omitting target file form package-graph.`
         );
         // Should resolve path completely relativeto the project and find which package it belongs to.
@@ -140,7 +140,7 @@ export class PackageGraph {
         const packageName = this.package.packageName;
 
         if (this.isFileExternalToPackage(targetPath)) {
-          DEBUG_CALLBACK(
+          this.debug(
             `The source file "${sourcePath}" is importing a file "${targetPath}" that is external to "${packageName}" package directory (${baseDir}), omitting target file ("${targetPath}") form package-graph.`
           );
           // TODO Should resolve this path to a package in the project?


### PR DESCRIPTION
### Problem
Debugging the creation of `EmberAddonProjectGraph` or EmberAdonPackageGraph` can be tricky since the inheritance chain creates different namespaces for each `DEBUG_CALLBACK` from debug.

Adding `DEBUG=rehearsal:migration-graph-ember:ember-addon-project-graph*` will only emit stuff with that prefix, and that is a very small constructor as it extends `EmberAppProjectGraph`. See https://github.com/rehearsal-js/rehearsal-js/blob/master/packages/migration-graph-ember/src/entities/ember-addon-project-graph.ts

Inheritance chain:

```
EmberAddonProjectGraph -> EmberAppProjectGraph -> ProjectGraph
EmberAddonPackageGraph -> EmberAppPackageGraph -> ProjectGraph
```

### Solution

On all `ProjectGraph` and `PackageGraph` implementations add:

```
protected debug: Debugger = debug(`rehearsal:migration-graph-<shared|ember>:${this.constructor.name}`);
```

Then invoke:
```
  this.debug('some debug %s', 'hello');
```

Where necessary.

### Why?

This will improve debug ability as we start to scan more packages in a monorepo.

### Alternatives
- You could use `DEBUG=rehearsal:migration-graph-ember:*` but you you will never see the logs from the base class implementation in `ProjectGraph` as that's in another package and namespace.
- Alternatively you can filter on `DEBUG=rehearsal:migration-graph*` but this starts to generate all the logs in the migration graph.

### Appendix

#### Example Output 

Showing logging output before:

**Before** 
```
2023-02-24T21:46:07.044Z rehearsal:migration-graph-ember:ember-addon-package-graph {
  baseDir: '/var/folders/9n/72xhx63x5gzcqchlbd5skvz40003jl/T/tmp-37819-PWfRkwygWd7g',
  alias: {
    'addon-template': '/var/folders/9n/72xhx63x5gzcqchlbd5skvz40003jl/T/tmp-37819-PWfRkwygWd7g/addon'
  }
}
2023-02-24T21:46:07.045Z rehearsal:migration-graph-shared:package-graph Executing dependency-cruiser
2023-02-24T21:46:07.045Z rehearsal:migration-graph-shared:package-graph Target: [ '.', '**/*.gjs' ]
2023-02-24T21:46:07.045Z rehearsal:migration-graph-shared:package-graph cruiseOptions: {}
2023-02-24T21:46:07.074Z rehearsal:migration-graph-shared:package-graph 
2023-02-24T21:46:07.074Z rehearsal:migration-graph-ember:ember-app-package-graph >>> attempting to addNode to packageGraph for: addon-template, with path:  addon/components/greet.js
2023-02-24T21:46:07.074Z rehearsal:migration-graph-ember:ember-app-package-graph >>> addNode addon/components/greet.js
2023-02-24T21:46:07.075Z rehearsal:migration-graph-ember:ember-app-package-graph >>> SERVICES DISCOVERD []
2023-02-24T21:46:07.075Z rehearsal:migration-graph-shared:package-graph
```

**After**
```
2023-02-24T22:03:29.370Z rehearsal:migration-graph-ember:EmberAddonPackageGraph {
  baseDir: '/var/folders/9n/72xhx63x5gzcqchlbd5skvz40003jl/T/tmp-37819-PWfRkwygWd7g',
  alias: {
    'addon-template': '/var/folders/9n/72xhx63x5gzcqchlbd5skvz40003jl/T/tmp-37819-PWfRkwygWd7g/addon'
  }
}
2023-02-24T22:03:29.370Z rehearsal:migration-graph-ember:EmberAddonPackageGraph Executing dependency-cruiser
2023-02-24T22:03:29.370Z rehearsal:migration-graph-ember:EmberAddonPackageGraph Target: [ '.', '**/*.gjs' ]
2023-02-24T22:03:29.395Z rehearsal:migration-graph-ember:EmberAddonPackageGraph {
  output: {
    modules: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    summary: {
      violations: [],
      error: 0,
      warn: 0,
      info: 0,
      ignore: 0,
      totalCruised: 7,
      totalDependenciesCruised: 6,
      optionsUsed: [Object]
    }
  },
  exitCode: 0
}
2023-02-24T22:03:29.395Z rehearsal:migration-graph-ember:EmberAddonPackageGraph {
  source: 'addon/components/greet.js',
  dependencies: [
    {
      module: '@glimmer/component',
      moduleSystem: 'es6',
      dynamic: false,
      exoticallyRequired: false,
      resolved: '@glimmer/component',
      coreModule: false,
      followable: false,
      couldNotResolve: true,
      dependencyTypes: [Array],
      matchesDoNotFollow: false,
      circular: false,
      valid: true
    }
  ],
  dependents: [],
  orphan: false,
  valid: true
}
2023-02-24T22:03:29.396Z rehearsal:migration-graph-ember:EmberAddonPackageGraph >>> attempting to addNode to packageGraph for: addon-template, with path:  addon/components/greet.js
2023-02-24T22:03:29.396Z rehearsal:migration-graph-ember:EmberAddonPackageGraph >>> addNode addon/components/greet.js
2023-02-24T22:03:29.396Z rehearsal:migration-graph-ember:EmberAddonPackageGraph >>> SERVICES DISCOVERD []
```
