### PR TITLE
fix: exclude only root app dir in EmberAddonPackage

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -32,7 +32,7 @@ export class EmberAddonPackage extends EmberAppPackage {
       'ember-config',
       '@ember/*',
       'public',
-      'app', // Addons app/ folder should not be converted to TS. https://docs.ember-cli-typescript.com/ts/with-addons#key-differences-from-apps
+      '^app', // Addons ^app/ folder should not be converted to TS. https://docs.ember-cli-typescript.com/ts/with-addons#key-differences-from-apps
     ];
 
     const excludeFiles = [

--- a/packages/migration-graph-ember/test/entities/ember-addon-project-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-project-graph.test.ts
@@ -28,6 +28,8 @@ describe('Unit | EmberAddonProjectGraph', () => {
     ).toStrictEqual([
       'addon/components/greet.js',
       'tests/acceptance/addon-template-test.js',
+      'tests/dummy/app/app.js',
+      'tests/dummy/app/router.js',
       'tests/test-helper.js',
     ]);
   });

--- a/packages/migration-graph/test/migration-strategy.test.ts
+++ b/packages/migration-graph/test/migration-strategy.test.ts
@@ -233,6 +233,8 @@ describe('migration-strategy', () => {
       expect(actual).toStrictEqual([
         'addon/components/greet.js',
         'tests/acceptance/addon-template-test.js',
+        'tests/dummy/app/app.js',
+        'tests/dummy/app/router.js',
         'tests/test-helper.js',
       ]);
       expect(strategy.sourceType).toBe(SourceType.EmberAddon);


### PR DESCRIPTION
Address bug found in #761 

In an `EmberAddonPackage` we ignore the `app` directory, this creates a problem as **dependency-cuiser** will ignore all directories that are named `app`.

**dependency-cruiser** users regex for all paths. So we can add a caret to `^app` so all paths leading with that will be dropped from the search.