### PR TITLE
fix: filter out broken function types comes from JSDocs

### DIFF
--- a/packages/codefixes/src/typescript-codefix-collection.ts
+++ b/packages/codefixes/src/typescript-codefix-collection.ts
@@ -151,6 +151,12 @@ export class TypescriptCodeFixCollection implements CodeFixCollection {
           continue;
         }
 
+        // Covers cases with broken type signatures, like: `() =>`
+        const brokenTypeSignatures = /\(\) =>\s*$/i;
+        if (brokenTypeSignatures.test(textChanges.newText)) {
+          continue;
+        }
+
         safeTextChanges.push(textChanges);
       }
 

--- a/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Test upgrade > should output the correct data from upgrade 1`] = `
 {
-  "fixedItemCount": 68,
+  "fixedItemCount": 69,
   "items": [
     {
       "analysisTarget": "2322.ts",
@@ -1372,6 +1372,24 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       },
       "nodeText": "'O'",
       "ruleId": "TS2345",
+      "type": 0,
+    },
+    {
+      "analysisTarget": "ts-types.ts",
+      "category": "Error",
+      "helpUrl": "https://stackoverflow.com/questions/43064221/typescript-ts7006-parameter-xxx-implicitly-has-an-any-type",
+      "hint": "Parameter 'c' implicitly has an 'any' type.",
+      "hintAdded": true,
+      "message": "Parameter 'c' implicitly has an 'any' type.",
+      "nodeKind": "Parameter",
+      "nodeLocation": {
+        "endColumn": 55,
+        "endLine": 74,
+        "startColumn": 54,
+        "startLine": 74,
+      },
+      "nodeText": "c",
+      "ruleId": "TS7006",
       "type": 0,
     },
     {

--- a/packages/upgrade/test/fixtures/upgrade/ts-types.ts.input
+++ b/packages/upgrade/test/fixtures/upgrade/ts-types.ts.input
@@ -59,3 +59,17 @@ export class Foo {
     }
   }
 }
+
+/**
+ * JSDoc
+ *
+ * @param {number} a
+ * @param {(string|number)} b
+ * @param {<callbackFunction>} c
+ * @param {UnavailableType} d
+ *
+ * @return {void}
+ */
+export function think(a, b, c, d) {
+  return console.log(a, b, c, d);
+}

--- a/packages/upgrade/test/fixtures/upgrade/ts-types.ts.output
+++ b/packages/upgrade/test/fixtures/upgrade/ts-types.ts.output
@@ -59,3 +59,18 @@ export class Foo {
     }
   }
 }
+
+/**
+ * JSDoc
+ *
+ * @param {number} a
+ * @param {(string|number)} b
+ * @param {<callbackFunction>} c
+ * @param {UnavailableType} d
+ *
+ * @return {void}
+ */
+/* @ts-expect-error @rehearsal TODO TS7006: Parameter 'c' implicitly has an 'any' type. */
+export function think(a: number, b: string | number, c, d: UnavailableType): void {
+  return console.log(a, b, c, d);
+}


### PR DESCRIPTION
Fix for a particular case with broken function declaration comes from "Type form JSDoc".

The test case contains another, more broad case where CodeFix returns correct but not existent type from JSDoc will be handled in an [issue](https://github.com/rehearsal-js/rehearsal-js/issues/790)  

Closes #775

