### PR TITLE
chore: run smoke on branch

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,11 +11,20 @@ jobs:
     name: Runs the CLI Smoke Test
     runs-on: ubuntu-latest
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      - name: Get branch name
+        uses: tj-actions/branch-names@v6
+        id: branch-name
+
+      - name: echo name
+        run: |
+            echo '${{ steps.branch-name.outputs.current_branch }}'
+      - name: Running Smoke Tests
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: rehearsal-js
           repo: smoke-test
           github_token: ${{ secrets.G_ACCESS_TOKEN }}
           github_user: lynchbomb
           workflow_file_name: 48689645
+          client_payload: '{ "client_payload": "${{ steps.branch-name.outputs.current_branch }}" }'
           ref: master

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,4 +1,4 @@
-# name: Smoke Test
+name: E2E Smoke Test
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Runs the CLI Smoke Test
+    name: Runs CLI In Smoke Test Repo
     runs-on: ubuntu-latest
     steps:
       - name: Get branch name

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: echo name
         run: |
-            echo '${{ steps.branch-name.outputs.current_branch }}'
+          echo '${{ steps.branch-name.outputs.current_branch }}'
       - name: Running Smoke Tests
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -26,5 +26,5 @@ jobs:
           github_token: ${{ secrets.G_ACCESS_TOKEN }}
           github_user: lynchbomb
           workflow_file_name: 48689645
-          client_payload: '{ "client_payload": "${{ steps.branch-name.outputs.current_branch }}" }'
+          client_payload: '{ "branch_name": "${{ steps.branch-name.outputs.current_branch }}" }'
           ref: master

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test Suite
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-and-lint:
-    name: Runs Test Suite with Linting
+    name: Runs Tests with Linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vitest/config';
 
-//eslint-disable-next-line import/no-default-export
 export default defineConfig({
   test: {
     testTimeout: 100_000,


### PR DESCRIPTION
This PR should enable us to run the smoke test against the pr branch. 

## Why
Prior to this commit we would only run the smoke test against the master branch, which would leave us in the state where master was 🔴 . This prevented us from releasing broken software but ideally we want to shift left and test our PRs against the smoke test app prior to merging. 

## What Else

- I added names to the workflow file so they look nicer
<img width="881" alt="Screenshot 2023-03-05 at 7 49 57 PM" src="https://user-images.githubusercontent.com/183799/222996530-43175d50-a051-4de5-8831-019aefea4004.png">
- There is no need to have the vitest config to be a `.ts` file now that we are in ESM. Master seems to be broken because this config can't be loaded.
