### PR TITLE
fix(migration-graoph): change path for service resolution to addon dir

### DIFF
--- a/packages/migration-graph-ember/src/entities/ember-addon-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package.ts
@@ -6,6 +6,7 @@ import {
   getNameFromMain,
   isEngine,
 } from '../utils/ember.js';
+import { getEmberExcludePatterns } from '../utils/excludes.js';
 import { type EmberPackageOptions, EmberAppPackage } from './ember-app-package.js';
 import {
   EmberAddonPackageGraph,
@@ -26,22 +27,10 @@ export class EmberAddonPackage extends EmberAppPackage {
       ...options,
     });
 
-    const excludeDirs = [
-      'dist',
-      'config',
-      'ember-config',
-      '@ember/*',
-      'public',
+    this.excludePatterns = new Set([
+      ...getEmberExcludePatterns(),
       '^app', // Addons ^app/ folder should not be converted to TS. https://docs.ember-cli-typescript.com/ts/with-addons#key-differences-from-apps
-    ];
-
-    const excludeFiles = [
-      'ember-cli-build.js',
-      'testem.js',
-      'index.js', // Ignore index.js because it's a CJS use to interact with the build pipeline.
-    ];
-
-    this.excludePatterns = new Set([...excludeDirs, ...excludeFiles]);
+    ]);
 
     this.includePatterns = new Set(['.', '**/*.gjs']);
   }

--- a/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
@@ -170,7 +170,8 @@ export class EmberAppPackageGraph extends PackageGraph {
           if (!synthetic) {
             const emberAddonPackage = pkg as EmberAddonPackage;
 
-            const key = `app/services/${s.serviceName}.js`;
+            // Looking for the implementation at addon/ becase some addons may not have an app/ for re-exports of the service
+            const key = `addon/services/${s.serviceName}.js`;
 
             const someServiceInAnInRepoAddon = join(emberAddonPackage.path, key);
 
@@ -180,8 +181,11 @@ export class EmberAppPackageGraph extends PackageGraph {
             if (key) {
               const dest = emberAddonPackage.getModuleGraph().hasNode(key);
               if (!dest) {
+                const sourceFile = join(this.baseDir, moduleNodeKey);
+                const destFile = join(emberAddonPackage.path);
+
                 throw new Error(
-                  `Unexpected Error; Unable to retreive node ${key} from package ${emberAddonPackage.name}`
+                  `Unexpected error when parsing ${sourceFile}. Attempting to resolve service "${s.serviceName}" from module/package name "${s.addonName}" in package: ${destFile}.`
                 );
               }
 

--- a/packages/migration-graph-ember/src/entities/ember-app-package.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package.ts
@@ -6,6 +6,7 @@ import {
   IPackage,
 } from '@rehearsal/migration-graph-shared';
 import { getEmberAddonPaths } from '../utils/ember.js';
+import { getEmberExcludePatterns } from '../utils/excludes.js';
 import { EmberAppPackageGraph, EmberAppPackageGraphOptions } from './ember-app-package-graph.js';
 
 export type EmberPackageOptions = PackageOptions;
@@ -14,21 +15,7 @@ export class EmberAppPackage extends Package implements IPackage {
   constructor(pathToPackage: string, options: EmberPackageOptions = {}) {
     super(pathToPackage, { ...options });
 
-    this.excludePatterns = new Set([
-      // files
-      '.ember-cli.js',
-      'ember-cli-build.js',
-      'ember-config.js',
-      'index.js',
-      'testem.js',
-      // Directories
-      'dist',
-      'config',
-      'ember-config',
-      '@ember/*',
-      'public',
-      ...this.addonPaths,
-    ]);
+    this.excludePatterns = new Set([...getEmberExcludePatterns(), ...this.addonPaths]);
 
     this.includePatterns = new Set(['.', '**/*.gjs']); // No longer isolate this to the app directory, include all files in dir.
   }

--- a/packages/migration-graph-ember/src/utils/excludes.ts
+++ b/packages/migration-graph-ember/src/utils/excludes.ts
@@ -2,7 +2,7 @@ import { getExcludePatterns } from '@rehearsal/migration-graph-shared';
 
 const EMBER_FILES = [
   '.ember-cli.js',
-  '.template-lint.js', // ember-template-lint
+  '.template-lintrc.js', // ember-template-lint
   'ember-cli-build.js',
   'ember-config.js',
   'index.js', // Ignore index.js because it's a CJS use to interact with the build pipeline.

--- a/packages/migration-graph-ember/src/utils/excludes.ts
+++ b/packages/migration-graph-ember/src/utils/excludes.ts
@@ -1,0 +1,16 @@
+import { getExcludePatterns } from '@rehearsal/migration-graph-shared';
+
+const EMBER_FILES = [
+  '.ember-cli.js',
+  '.template-lint.js', // ember-template-lint
+  'ember-cli-build.js',
+  'ember-config.js',
+  'index.js', // Ignore index.js because it's a CJS use to interact with the build pipeline.
+  'testem.js',
+];
+const EMBER_DIRS = ['config', 'ember-config', 'public'];
+const EMBER_PACKAGE_NAMESPACE = ['@ember/*'];
+
+export function getEmberExcludePatterns(): string[] {
+  return [...getExcludePatterns(), ...EMBER_DIRS, ...EMBER_FILES, ...EMBER_PACKAGE_NAMESPACE];
+}

--- a/packages/migration-graph-ember/test/entities/ember-addon-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-package.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 import { EmberAddonPackage } from '../../src/entities/ember-addon-package.js';
 import { FIXTURE_NAMES, FIXTURES } from '../fixtures/package-fixtures.js';
+import { getEmberExcludePatterns } from '../../src/utils/excludes.js';
 
 setGracefulCleanup();
 
@@ -46,5 +47,29 @@ describe('Unit | Entities | EmberAddonPackage', () => {
     expect(
       new EmberAddonPackage(resolve(pathToPackage, FIXTURE_NAMES.ADDON_WITH_MODULE_NAME)).moduleName
     ).toBe(`${FIXTURE_NAMES.ADDON_WITH_MODULE_NAME}-SPECIFIED-IN-MODULENAME`);
+  });
+
+  test('should have common ember excludes', () => {
+    const pkg = new EmberAddonPackage(resolve(pathToPackage, FIXTURE_NAMES.ADDON_WITH_MODULE_NAME));
+
+    const excludes = getEmberExcludePatterns();
+
+    expect.assertions(excludes.length);
+
+    excludes.forEach((pattern) => {
+      expect(
+        pkg.excludePatterns.has(pattern),
+        `expect EmberrAddonPackage to exclude ${pattern}`
+      ).toBeTruthy();
+    });
+  });
+
+  test('should explicitly exclude root app dir in addon', () => {
+    const pkg = new EmberAddonPackage(resolve(pathToPackage, FIXTURE_NAMES.ADDON_WITH_MODULE_NAME));
+
+    expect(
+      pkg.excludePatterns.has(`^app`),
+      'to exclude app directory in root of addon'
+    ).toBeTruthy();
   });
 });

--- a/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
@@ -4,6 +4,7 @@ import { writeSync } from 'fixturify';
 import { DirResult, dirSync, setGracefulCleanup } from 'tmp';
 import { FIXTURES, FIXTURE_NAMES } from '../fixtures/package-fixtures.js';
 import { EmberAppPackage } from '../../src/entities/ember-app-package.js';
+import { getEmberExcludePatterns } from '../../src/utils/excludes.js';
 
 setGracefulCleanup();
 
@@ -33,6 +34,28 @@ describe('Unit | Entities | EmberAppPackage', () => {
   test('should return addonPaths from package.json', () => {
     const emberAppPackage = new EmberAppPackage(rootDir);
     expect(emberAppPackage.addonPaths).toStrictEqual([]);
+  });
+
+  test('should have common ember excludes', () => {
+    const pkg = new EmberAppPackage(rootDir);
+
+    const excludes = getEmberExcludePatterns();
+
+    expect.assertions(excludes.length);
+
+    excludes.forEach((pattern) => {
+      expect(
+        pkg.excludePatterns.has(pattern),
+        `expect EmberrAddonPackage to exclude ${pattern}`
+      ).toBeTruthy();
+    });
+  });
+
+  test('should exclude addonPaths', () => {
+    rootDir = getPathToPackage(FIXTURE_NAMES.APP_WITH_IN_REPO_ADDONS);
+    const emberAppPackage = new EmberAppPackage(rootDir);
+    expect(emberAppPackage.excludePatterns.has('lib/some-addon')).toBe(true);
+    expect(emberAppPackage.excludePatterns.has('lib/some-engine')).toBe(true);
   });
 
   test.todo('should return a graph of files for the package', () => {

--- a/packages/migration-graph-ember/test/fixtures/package-fixtures.ts
+++ b/packages/migration-graph-ember/test/fixtures/package-fixtures.ts
@@ -14,6 +14,7 @@ const EMBER_FIXTURE_NAMES = {
   SIMPLE_APP: 'simple-app',
   SIMPLE_ADDON: 'simple-addon',
   SIMPLE_ENGINE: 'simple-engine',
+  APP_WITH_IN_REPO_ADDONS: 'app-with-in-repo-addons',
   ADDON_WITH_MODULE_NAME: 'addon-with-module-name',
   ADDON_WITH_SIMPLE_CUSTOM_PACKAGE_MAIN: 'addon-with-simple-custom-module-name',
   ADDON_WITH_COMPLEX_CUSTOM_PACKAGE_MAIN: 'addon-with-complex-custom-module-name',
@@ -188,6 +189,24 @@ EMBER_FIXTURES[EMBER_FIXTURE_NAMES.ADDON_WITH_COMPLEX_CUSTOM_PACKAGE_MAIN] = {
   }),
 };
 
+EMBER_FIXTURES[EMBER_FIXTURE_NAMES.APP_WITH_IN_REPO_ADDONS] = {
+  'package.json': json({
+    name: EMBER_FIXTURE_NAMES.SIMPLE_APP,
+    version: '1.0.0',
+    dependencies: {},
+    devDependencies: {
+      'ember-source': '^3.28.0',
+    },
+    'ember-addon': {
+      paths: ['lib/some-addon', 'lib/some-engine'],
+    },
+  }),
+  lib: {
+    'some-engine': EMBER_FIXTURES[EMBER_FIXTURE_NAMES.SIMPLE_ADDON],
+    'some-addon': EMBER_FIXTURES[EMBER_FIXTURE_NAMES.SIMPLE_ENGINE],
+  },
+};
+
 EMBER_FIXTURES[EMBER_FIXTURE_NAMES.WORKSPACE_CONTAINER] = {
   'package.json': json({
     name: 'workspace-container',
@@ -224,5 +243,8 @@ EMBER_FIXTURES[EMBER_FIXTURE_NAMES.WORKSPACE_CONTAINER].packages[
     },
   }),
 };
+
+
+
 // export the fixture and names for easier mapping
 export { EMBER_FIXTURES as FIXTURES, EMBER_FIXTURE_NAMES as FIXTURE_NAMES };

--- a/packages/migration-graph-shared/src/entities/package.ts
+++ b/packages/migration-graph-shared/src/entities/package.ts
@@ -6,6 +6,7 @@ import fastGlob from 'fast-glob';
 
 import { removeNestedPropertyValue, setNestedPropertyValue } from '../utils/pojo.js';
 import { getWorkspaceGlobs } from '../utils/workspace.js';
+import { getExcludePatterns } from '../index.js';
 import { PackageGraph, PackageGraphOptions } from './package-graph.js';
 
 import type { IPackage } from './IPackage.js';
@@ -68,24 +69,7 @@ export class Package implements IPackage {
     this.#packageType = packageType;
     this.#name = name;
 
-    const excludeDirs = [
-      '.yarn', // yarn3 directory
-      'dist',
-    ];
-
-    const excludeFiles = [
-      '.eslintrc.*',
-      '.babelrc.*',
-      'babel.config.*', // Babel configs
-      'Brocfile.js',
-      '.prettierrc.*',
-      'prettier.config.*', // Prettier configs
-      'karma.config.*',
-      'webpack.config.js',
-      'vite.config.ts',
-    ];
-
-    this.#excludePatterns = new Set([...excludeDirs, ...excludeFiles]);
+    this.#excludePatterns = new Set([...getExcludePatterns()]);
     this.#includePatterns = new Set(['.']);
 
     // Only add the globs if this path contains a package.json

--- a/packages/migration-graph-shared/src/index.ts
+++ b/packages/migration-graph-shared/src/index.ts
@@ -16,3 +16,5 @@ export { PackageGraph, PackageGraphOptions } from './entities/package-graph.js';
 export { ProjectGraph, ProjectGraphOptions } from './entities/project-graph.js';
 
 export type { IPackage } from './entities/IPackage.js';
+
+export * from './utils/excludes.js';

--- a/packages/migration-graph-shared/src/utils/excludes.ts
+++ b/packages/migration-graph-shared/src/utils/excludes.ts
@@ -1,0 +1,39 @@
+const FILE_PATTERNS = [
+  // ESLint
+  '.eslintrc.*',
+
+  // Babel
+  '.babelrc.*',
+  'babel.config.*',
+
+  // Broccolijs
+  'Brocfile.js',
+
+  // Prettier
+  '.prettierrc.*',
+  'prettier.config.*',
+
+  // Karma
+  'karma.config.*',
+
+  // rehearsal
+  '.rehearsal-eslintrc.js',
+
+  // webpack
+  'webpack.config.js',
+
+  // vite
+  'vite.config.ts',
+];
+
+const DIRECTORY_PATTERNS = [
+  // yarn3
+  '.yarn',
+
+  // build output
+  'dist',
+];
+
+export function getExcludePatterns(): string[] {
+  return [...FILE_PATTERNS, ...DIRECTORY_PATTERNS];
+}

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -51,8 +51,6 @@ describe('Unit | Entities | Package', function () {
       const p = new Package(pathToPackage);
       expect(p.excludePatterns).toStrictEqual(
         new Set([
-          '.yarn',
-          'dist',
           '.eslintrc.*',
           '.babelrc.*',
           'babel.config.*',
@@ -60,8 +58,11 @@ describe('Unit | Entities | Package', function () {
           '.prettierrc.*',
           'prettier.config.*',
           'karma.config.*',
+          '.rehearsal-eslintrc.js',
           'webpack.config.js',
           'vite.config.ts',
+          '.yarn',
+          'dist',
         ])
       );
       expect(p.includePatterns).toStrictEqual(new Set(['.']));
@@ -82,22 +83,7 @@ describe('Unit | Entities | Package', function () {
     test('addExcludePattern', () => {
       const p = new Package(pathToPackage);
       p.addExcludePattern('test-packages');
-      expect(p.excludePatterns).toStrictEqual(
-        new Set([
-          '.yarn',
-          'dist',
-          '.eslintrc.*',
-          '.babelrc.*',
-          'babel.config.*',
-          'Brocfile.js',
-          '.prettierrc.*',
-          'prettier.config.*',
-          'karma.config.*',
-          'webpack.config.js',
-          'vite.config.ts',
-          'test-packages',
-        ])
-      );
+      expect(p.excludePatterns.has('test-packages')).toBeTruthy();
 
       p.addIncludePattern('index.js');
       expect(p.includePatterns).toStrictEqual(new Set(['.', 'index.js']));


### PR DESCRIPTION
This fixes #817 

## Why?
Addons typically will re-rexport all things that can be used in an app in the `app/` at the root of an addon. In some cases internally (learning-web), all the in-repo addons lack a `app/` directory to re-export things. This breaks the migration graph.

## What was done?
- Changing the path lookup to `r/app/addon` for service resolution;
- Improve error message for service resolution with `source` and `dest` files for improved debugging:
```
Error: Unexpected error when parsing /Users/jdoe/Code/some-app/lib/some-addon/addon/components/my-component.js. Attempting to resolve service "user" from module/package name "other-addon" in package: /Users/jdoe/Code/some-app/lib/other-addon.
```

## Tests
- No added tests. The current tests validate that if there was a discovered service dependency we create an edge between each package and not the files.

## Alternatives
We could warn and suggest that the addon needs re-rexports. In this case for learning-web 30+ addons would need to be refactored with re-exports. In the future with v2 addons all these exports are required with the rollup API for exposed entry points. Either way the work has to be done. I am opting against it, as we should not enforce how an ember app's correctness.