### PR TITLE
feat(cli): migrate default interactive - optional ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Rehearsal Migrate has performed the following tasks:
 
 ## Interactive Mode - Migrate
 
-With the interactive mode flag `--interactive` or `-i`, Rehearsal will prompt you to confirm each step of the migration process. This is useful if you want to review the changes before committing.
+Interactive mode will run by default. Rehearsal will prompt you to confirm each step of the migration process. This is useful if you want to review the changes before committing. If you want to skip interactive mode, you can use the flag `--ci`.
 
 ## Migrate by Directory
 
-With the flag `--entrypoint` or `-e`, Rehearsal will migrate by directory. If you run `migrate -e directoryA` and `migrate -e directoryB` sequentially, Rehearsal will give you a report that merge both runs. 
+With the flag `--entrypoint` or `-e`, Rehearsal will migrate by directory. If you run `migrate -e directoryA` and `migrate -e directoryB` sequentially, Rehearsal will give you a report that merge both runs.
 
 ## Rehearsal Reports
 
@@ -90,6 +90,7 @@ In combination with the VSCode SARIF Viewer extension, you can view the SARIF re
 Rehearsal also can read from a custom user config file. This is useful if you want to customize the migration process. For example, you can add additional dependencies to be installed during the migration process. You can also add custom setup tasks to be run during the migration process. The config file is a JSON file with the following structure:
 
 **rehearsal-config.json**
+
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/rehearsal-js/rehearsal-js/master/packages/cli/rehearsal-config-schema.json",

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -59,7 +59,7 @@ migrateCommand
     'path to rehearsal config',
     'rehearsal-config.json'
   )
-  .option('-i, --interactive', 'interactive mode')
+  .option('--ci', 'non-interactive mode')
   .option('-v, --verbose', 'print debugging logs')
   .option('-d, --dryRun', 'print files that will be attempted to migrate', false)
   .option('-r, --regen', 'print out current migration status')
@@ -143,7 +143,7 @@ async function migrate(options: MigrateCommandOptions): Promise<void> {
   ];
 
   try {
-    if (options.interactive) {
+    if (!options.ci) {
       // For issue #549, have to use simple renderer for the interactive edit flow
       // previous ctx is needed for the isolated convertTask
       const ctx = await new Listr(tasks, defaultListrOption).run();

--- a/packages/cli/src/commands/migrate/init-command.ts
+++ b/packages/cli/src/commands/migrate/init-command.ts
@@ -39,6 +39,9 @@ initCommand
   });
 
 export async function initCommandHandler(options: MigrateCommandOptions): Promise<void> {
+  // init should never run in interactive mode
+  options.ci = true;
+
   const loggerLevel = options.verbose ? 'debug' : 'info';
   const logger = createLogger({
     transports: [new transports.Console({ format: format.cli(), level: loggerLevel })],

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -45,7 +45,7 @@ export async function convertTask(
       );
 
       if (ctx.sourceFilesWithAbsolutePath) {
-        if (options.interactive) {
+        if (!options.ci) {
           // In interactive mode, go through files one by one
           // and ask user for actions: Accept/Edit/Discard
           for (const f of ctx.sourceFilesWithAbsolutePath) {

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -43,7 +43,7 @@ export async function initTask(
       const packages = discoverEmberPackages(options.basePath); // TODO we should ask the migration-strategy for this data.
       DEBUG_CALLBACK('projectName', projectName);
 
-      if (options.interactive) {
+      if (!options.ci) {
         // Init state and store
         const state = new State(
           projectName,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -15,7 +15,7 @@ export type MigrateCommandOptions = {
   outputPath: string;
   verbose: boolean | undefined;
   userConfig: string | undefined;
-  interactive: boolean | undefined;
+  ci: boolean | undefined;
   dryRun: boolean;
   regen: boolean | undefined;
 };

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -454,22 +454,22 @@ exports[`migrate: e2e > migrate would skip steps after migrate init 4`] = `
 [DATA] processing file: /index.ts
 [TITLE] Migration Complete
 [TITLE]   3 JS files converted to TS
-[TITLE]   2 errors caught by rehearsal
-[TITLE]   1 have been fixed by rehearsal
+[TITLE]   4 errors caught by rehearsal
+[TITLE]   3 have been fixed by rehearsal
 [TITLE]   1 errors need to be fixed manually
 [TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Migration Complete
 [SUCCESS]   3 JS files converted to TS
-[SUCCESS]   2 errors caught by rehearsal
-[SUCCESS]   1 have been fixed by rehearsal
+[SUCCESS]   4 errors caught by rehearsal
+[SUCCESS]   3 have been fixed by rehearsal
 [SUCCESS]   1 errors need to be fixed manually
 [SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
 exports[`migrate: e2e > migrate would skip steps after migrate init 5`] = `
-"export function foo(name = \\"World\\") {
+"export function foo(name = \\"World\\"): string {
   return \`Hello \${name}\`;
 }
 "
@@ -485,7 +485,7 @@ console.log(foo(\\"hello\\"));
 exports[`migrate: e2e > migrate would skip steps after migrate init 7`] = `
 "import { foo } from \\"./foo\\";
 
-export function run(baz: string | undefined) {
+export function run(baz: string | undefined): string {
   return foo(baz);
 }
 "

--- a/packages/cli/test/commands/migrate/config-ts.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.test.ts
@@ -62,7 +62,7 @@ describe('Task: config-ts', async () => {
 
   test('update tsconfig if invalid extends exist', async () => {
     // Prepare old tsconfig
-    const oldTsConfig = { extends: 'invalid-tsconfig.json'};
+    const oldTsConfig = { extends: 'invalid-tsconfig.json' };
     writeJSONSync(resolve(basePath, 'tsconfig.json'), oldTsConfig);
 
     const options = createMigrateOptions(basePath);

--- a/packages/cli/test/commands/migrate/convert.test.ts
+++ b/packages/cli/test/commands/migrate/convert.test.ts
@@ -58,7 +58,7 @@ describe('Task: convert', async () => {
   });
 
   test('migrate from default all files .js in root', async () => {
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     // Get context for convert task from previous tasks
     const tasks = [
       await initTask(options),
@@ -86,7 +86,7 @@ describe('Task: convert', async () => {
   });
 
   test('migrate from specific entrypoint', async () => {
-    const options = createMigrateOptions(basePath, { entrypoint: 'depends-on-foo.js' });
+    const options = createMigrateOptions(basePath, { entrypoint: 'depends-on-foo.js', ci: true });
     // Get context for convert task from previous tasks
     const tasks = [
       await initTask(options),
@@ -114,6 +114,7 @@ describe('Task: convert', async () => {
   test('generate reports', async () => {
     const options = createMigrateOptions(basePath, {
       format: ['json', 'md', 'sarif'],
+      ci: true,
     });
     // Get context for convert task from previous tasks
     const tasks = [
@@ -136,7 +137,7 @@ describe('Task: convert', async () => {
   });
 
   test('accept changes without git', async () => {
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
 
     // prompt control flow
     outputStream.on('data', (line: string) => {
@@ -185,7 +186,7 @@ describe('Task: convert', async () => {
       .add('./*')
       .commit('first commit!');
 
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
     let fileCount = 1; // file counter in prompt selection
 
     // prompt control flow
@@ -247,7 +248,7 @@ describe('Task: convert', async () => {
     // 3. Also tried EDITOR = 'echo foo >>', to append string to a file so we know it would change, but it doesn't work (probably related to all stdio config)
     // For now EDITOR is set to be 'rm', which would remove the selected file so we know the edit command works
     process.env['EDITOR'] = 'rm';
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
 
     let fileCount = 1; // file counter in prompt selection
 
@@ -302,7 +303,7 @@ describe('Task: convert', async () => {
   });
 
   test('cancel prompt in interactive mode', async () => {
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
 
     // prompt control flow
     outputStream.on('data', (line: string) => {

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -22,7 +22,7 @@ describe('migrate - validation', async () => {
   });
 
   test('pass in a non git project', async () => {
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
 
@@ -41,7 +41,7 @@ describe('migrate - validation', async () => {
       .addConfig('user.email', 'tester@tester.com')
       .commit('test');
 
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
 
@@ -55,7 +55,7 @@ describe('migrate - validation', async () => {
     } as Partial<SimpleGitOptions>);
     await git.init().add('package.json');
 
-    const { stdout } = await runBin('migrate', ['-d'], {
+    const { stdout } = await runBin('migrate', ['-d', '--ci'], {
       cwd: basePath,
     });
 
@@ -75,13 +75,13 @@ describe('migrate - validation', async () => {
       .addConfig('user.email', 'tester@tester.com')
       .commit('test');
 
-    const { stdout: firstRunStdout } = await runBin('migrate', [], {
+    const { stdout: firstRunStdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
 
     expect(firstRunStdout).toContain('Migration Complete');
 
-    const { stdout: secondRunStdout } = await runBin('migrate', [], {
+    const { stdout: secondRunStdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
     expect(cleanOutput(secondRunStdout, basePath)).toMatchSnapshot();
@@ -104,7 +104,7 @@ describe('migrate - validation', async () => {
     };
     fixturify.writeSync(basePath, files);
 
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: resolve(basePath, 'packages', 'package-a'),
     });
     expect(stdout).toContain('migrate command needs to be running at project root with workspaces');
@@ -127,7 +127,7 @@ describe('migrate - validation', async () => {
     };
     fixturify.writeSync(basePath, files);
 
-    const { stdout: secondRunStdout } = await runBin('migrate', [], {
+    const { stdout: secondRunStdout } = await runBin('migrate', ['--ci'], {
       cwd: resolve(basePath, 'packages', 'package-a'),
     });
     expect(cleanOutput(secondRunStdout, basePath)).toMatchSnapshot();
@@ -152,7 +152,7 @@ describe('migrate - validation', async () => {
     };
     fixturify.writeSync(basePath, files);
 
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: resolve(basePath, 'packages', 'package-a'),
     });
     expect(stdout).toContain('migrate command needs to be running at project root with workspaces');
@@ -177,7 +177,7 @@ describe('migrate - validation', async () => {
     };
     fixturify.writeSync(basePath, files);
 
-    const { stdout: secondRunStdout } = await runBin('migrate', [], {
+    const { stdout: secondRunStdout } = await runBin('migrate', ['--ci'], {
       cwd: resolve(basePath, 'packages', 'package-a'),
     });
     expect(cleanOutput(secondRunStdout, basePath)).toMatchSnapshot();
@@ -186,7 +186,7 @@ describe('migrate - validation', async () => {
   test('relative entrypoint inside project root works', async () => {
     basePath = prepareTmpDir('basic');
 
-    const { stdout } = await runBin('migrate', ['-e', 'foo.js'], {
+    const { stdout } = await runBin('migrate', ['-e', 'foo.js', '--ci'], {
       cwd: basePath,
     });
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
@@ -195,7 +195,7 @@ describe('migrate - validation', async () => {
   test('absolute entrypoint inside project root works', async () => {
     basePath = prepareTmpDir('basic');
 
-    const { stdout } = await runBin('migrate', ['-e', resolve(basePath, 'foo.js')], {
+    const { stdout } = await runBin('migrate', ['-e', resolve(basePath, 'foo.js'), '--ci'], {
       cwd: basePath,
     });
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
@@ -204,7 +204,7 @@ describe('migrate - validation', async () => {
   test('entrypoint outside project root does not work', async () => {
     basePath = prepareTmpDir('basic');
 
-    const { stdout } = await runBin('migrate', ['-e', resolve(__dirname, 'e2e.test.ts')], {
+    const { stdout } = await runBin('migrate', ['-e', resolve(__dirname, 'e2e.test.ts'), '--ci'], {
       cwd: basePath,
     });
     expect(stdout).toContain('Could not find entrypoint');
@@ -230,7 +230,7 @@ describe('migrate: e2e', async () => {
       .addConfig('user.email', 'tester@tester.com')
       .commit('test');
 
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
 
@@ -311,7 +311,7 @@ describe('migrate: e2e', async () => {
     expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
 
     // run migrate
-    const { stdout } = await runBin('migrate', [], {
+    const { stdout } = await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
     // migrate init output
@@ -342,7 +342,7 @@ describe('migrate: e2e', async () => {
   test('--skip-init option', async () => {
     // run migrate with --skip-init
     // this command should fail
-    const { stdout } = await runBin('migrate', ['--skip-init'], {
+    const { stdout } = await runBin('migrate', ['--skip-init', '--ci'], {
       cwd: basePath,
     });
 
@@ -358,7 +358,7 @@ describe('migrate: e2e', async () => {
   });
 
   test('Print debug messages with --verbose', async () => {
-    const { stdout } = await runBin('migrate', ['--verbose'], {
+    const { stdout } = await runBin('migrate', ['--verbose', '--ci'], {
       cwd: basePath,
     });
 
@@ -366,7 +366,7 @@ describe('migrate: e2e', async () => {
   });
 
   test('show warning message for missing config with --regen', async () => {
-    const { stdout } = await runBin('migrate', ['-r'], {
+    const { stdout } = await runBin('migrate', ['-r', '--ci'], {
       cwd: basePath,
     });
     expect(stdout).toContain('Eslint config (.eslintrc.{js,yml,json,yaml}) does not exist');
@@ -389,7 +389,7 @@ describe('migrate: e2e', async () => {
     await runBin('migrate', [], {
       cwd: basePath,
     });
-    const { stdout } = await runBin('migrate', ['-r'], {
+    const { stdout } = await runBin('migrate', ['-r', '--ci'], {
       cwd: basePath,
     });
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
@@ -416,7 +416,7 @@ describe('migrate: e2e', async () => {
         },
       });
 
-      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json'], {
+      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json', '--ci'], {
         cwd: basePath,
       });
 
@@ -447,7 +447,7 @@ describe('migrate: e2e', async () => {
         },
       });
 
-      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json'], {
+      const result = await runBin('migrate', ['-d', '-u', 'rehearsal-config.json', '--ci'], {
         cwd: basePath,
       });
 

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -386,7 +386,7 @@ describe('migrate: e2e', async () => {
       .commit('test');
 
     // first run without --regen
-    await runBin('migrate', [], {
+    await runBin('migrate', ['--ci'], {
       cwd: basePath,
     });
     const { stdout } = await runBin('migrate', ['-r', '--ci'], {

--- a/packages/cli/test/commands/migrate/initialize.test.ts
+++ b/packages/cli/test/commands/migrate/initialize.test.ts
@@ -50,7 +50,7 @@ describe('Task: initialize', async () => {
   });
 
   test('get files that will be migrated', async () => {
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -78,7 +78,7 @@ describe('Task: initialize', async () => {
       },
     });
 
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -114,7 +114,7 @@ describe('Task: initialize', async () => {
       'another-config.json'
     );
 
-    const options = createMigrateOptions(basePath, { userConfig: 'another-config.json' });
+    const options = createMigrateOptions(basePath, { ci: true, userConfig: 'another-config.json' });
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -131,7 +131,7 @@ describe('Task: initialize', async () => {
   });
 
   test('print files will be attempted to migrate with --dryRun', async () => {
-    const options = createMigrateOptions(basePath, { dryRun: true });
+    const options = createMigrateOptions(basePath, { ci: true, dryRun: true });
     const tasks = [await initTask(options)];
     await listrTaskRunner(tasks);
 
@@ -151,7 +151,7 @@ describe('Task: initialize', async () => {
       }
     });
 
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -194,7 +194,7 @@ describe('Task: initialize', async () => {
       }
     });
 
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -256,7 +256,7 @@ describe('Task: initialize', async () => {
     mkdirSync(resolve(basePath, '.rehearsal'));
     writeJSONSync(resolve(basePath, '.rehearsal', 'migrate-state.json'), previousState);
 
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
@@ -309,7 +309,7 @@ describe('Task: initialize', async () => {
     mkdirSync(resolve(basePath, '.rehearsal'));
     writeJSONSync(resolve(basePath, '.rehearsal', 'migrate-state.json'), previousState);
 
-    const options = createMigrateOptions(basePath, { interactive: true });
+    const options = createMigrateOptions(basePath);
     const tasks = [await initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 

--- a/packages/cli/test/commands/migrate/regen.test.ts
+++ b/packages/cli/test/commands/migrate/regen.test.ts
@@ -40,7 +40,7 @@ describe('Task: regen', async () => {
   });
 
   test('throw error with no tsconfig.json', async () => {
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [await initTask(options), await regenTask(options, logger)];
 
     try {
@@ -51,7 +51,7 @@ describe('Task: regen', async () => {
   });
 
   test('no effect on JS filse before conversion', async () => {
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [
       await initTask(options),
       await tsConfigTask(options),
@@ -63,7 +63,7 @@ describe('Task: regen', async () => {
   });
 
   test('update ts and lint errors based on previous conversion', async () => {
-    const options = createMigrateOptions(basePath);
+    const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [
       await initTask(options),
       await depInstallTask(options),

--- a/packages/cli/test/commands/migrate/sequential.test.ts
+++ b/packages/cli/test/commands/migrate/sequential.test.ts
@@ -54,7 +54,7 @@ describe('Task: sequential', async () => {
   });
 
   test('sequential run regen on the existing report, and run migrate on current base path and entrypoint', async () => {
-    const options = createMigrateOptions(basePath, { entrypoint: 'index.ts' });
+    const options = createMigrateOptions(basePath, { entrypoint: 'index.ts', ci: true });
     const previousRuns = {
       previousFixedCount: 1,
       paths: [{ basePath, entrypoint: 'depends-on-foo.ts' }],

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -96,7 +96,7 @@ export function createMigrateOptions(
     outputPath: '.rehearsal',
     verbose: false,
     userConfig: 'rehearsal-config.json',
-    interactive: undefined,
+    ci: false,
     dryRun: false,
     regen: false,
     ...options,

--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance/index.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance/index.ts
@@ -1,7 +1,13 @@
 import { ChangesFactory } from '@rehearsal/ts-utils';
-import type { CodeFixAction, MethodDeclaration, ParameterDeclaration, Signature, TypeChecker } from 'typescript';
 import ts from 'typescript';
 import { createCodeFixAction } from '../../hints-codefix-collection.js';
+import type {
+  CodeFixAction,
+  MethodDeclaration,
+  ParameterDeclaration,
+  Signature,
+  TypeChecker,
+} from 'typescript';
 import type { CodeFix, DiagnosticWithContext } from '../../types.js';
 
 const { findAncestor, isClassDeclaration, isMethodDeclaration, isParameter } = ts;

--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints/index.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints/index.ts
@@ -1,7 +1,7 @@
 import { ChangesFactory } from '@rehearsal/ts-utils';
-import type { CodeFixAction } from 'typescript';
 import ts from 'typescript';
 import { createCodeFixAction } from '../../hints-codefix-collection.js';
+import type { CodeFixAction } from 'typescript';
 import type { CodeFix, DiagnosticWithContext } from '../../types.js';
 
 const { isMethodDeclaration, isFunctionDeclaration } = ts;

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -132,8 +132,6 @@ describe('Test reporter', function () {
     rmSync(testAddLintItemFile);
   });
 
-
-
   test('getFileNames', async () => {
     reporter!.saveCurrentRunToReport(runBasePath, runEntrypoint, timestamp);
     assert.deepEqual(reporter!.getFileNames(), ['/base/path/file1.ts', '/base/path/file2.ts']);

--- a/packages/service/src/rehearsal-service.ts
+++ b/packages/service/src/rehearsal-service.ts
@@ -1,3 +1,6 @@
+import ts from 'typescript';
+
+import { RehearsalServiceHost } from './rehearsal-service-host.js';
 import type {
   CompilerOptions,
   Diagnostic,
@@ -6,9 +9,6 @@ import type {
   Node,
   SourceFile,
 } from 'typescript';
-import ts from 'typescript';
-
-import { RehearsalServiceHost } from './rehearsal-service-host.js';
 
 const {
   DiagnosticCategory,
@@ -107,7 +107,7 @@ export class RehearsalService {
           length: node.getEnd() - node.getStart(),
           category: DiagnosticCategory.Suggestion,
           code: 7050,
-          messageText: `${node.name.getText()} don't have a return type, but the type may be inferred from usage.`
+          messageText: `${node.name.getText()} don't have a return type, but the type may be inferred from usage.`,
         });
 
         return undefined;


### PR DESCRIPTION
This PR makes `--interactive` the default and removes the need for the flag. Additionally it adds a new flag `--ci` which is the inverse of interactive.

@chadhietala `--ci` will need to be updated for all automated scripts / actions