### PR TITLE
chore: cleanup async issues in cli

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2022,
-    project: ['./packages/*/tsconfig.json', './packages/*/test/tsconfig.json'],
+    project: ['./packages/*/tsconfig.json', './packages/*/test/tsconfig.json', './tsconfig.eslint.json'],
   },
   plugins: ['@typescript-eslint', 'import', 'prettier', 'filenames'],
   extends: [
@@ -104,5 +104,5 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': ['off'],
     '@typescript-eslint/no-inferrable-types': ['off'],
   },
-  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*', 'release.js', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*', 'release.js', '.eslintrc.cjs', 'packages/test-support/scripts/setup-fixtures.js'],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,13 +19,13 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2022,
+    project: ['./packages/*/tsconfig.json', './packages/*/test/tsconfig.json'],
   },
   plugins: ['@typescript-eslint', 'import', 'prettier', 'filenames'],
   extends: [
     'eslint:recommended',
     'plugin:prettier/recommended',
     'prettier',
-    'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:import/typescript',
     'plugin:import/recommended',
@@ -33,7 +33,9 @@ module.exports = {
   overrides: [
     {
       files: ['./packages/cli/**/*.ts'],
+      extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
       rules: {
+        '@typescript-eslint/restrict-template-expressions': ['off'],
         'no-restricted-imports': [
           'error',
           ...packages,
@@ -102,5 +104,5 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': ['off'],
     '@typescript-eslint/no-inferrable-types': ['off'],
   },
-  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*', 'release.js'],
+  ignorePatterns: ['dist', 'node_modules', 'fixtures', '*.config.*', 'release.js', '.eslintrc.cjs'],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp/
 **/.yarn/**
 .yarnrc.yml
 yarn.lock
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "lint": "pnpm lint:package-json && pnpm recursive run lint",
+    "lint": "pnpm lint:package-json && eslint --fix . --cache",
     "lint:package-json": "sort-package-json package.json packages/*/package.json",
     "prepare": "husky install",
     "test": "pnpm build && pnpm recursive run test",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,8 @@
     "typescript": "^4.9.5",
     "which": "^3.0.0",
     "winston": "^3.8.2",
-    "yaml": "^2.2.1"
+    "yaml": "^2.2.1",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@rehearsal/test-support": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,6 @@
     "build:schema": "typescript-json-schema \"src/configs/rehearsal-config.ts\" IRehearsalConfig --out ./rehearsal-config-schema.json",
     "docs": "api-extractor run --typescript-compiler-folder ./node_modules/typescript && api-documenter markdown -i ./temp -o ./docs",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,6 @@
     "semver": "^7.3.8",
     "simple-git": "^3.16.0",
     "tmp": "^0.2.1",
-    "typescript": "^4.9.5",
     "which": "^3.0.0",
     "winston": "^3.8.2",
     "yaml": "^2.2.1",
@@ -71,6 +70,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/which": "^2.0.1",
     "fixturify": "^3.0.0",
+    "typescript": "^4.9.5",
     "typescript-json-schema": "^0.55.0",
     "vitest": "^0.28.5"
   },

--- a/packages/cli/src/commands/migrate/init-command.ts
+++ b/packages/cli/src/commands/migrate/init-command.ts
@@ -68,6 +68,8 @@ export async function initCommandHandler(options: MigrateCommandOptions): Promis
       `The project is ready for migration. Please run "rehearsal migrate" to start the migration.`
     );
   } catch (e) {
-    logger.error(`${e}`);
+    if (e instanceof Error) {
+      logger.error(`${e.message + '\n' + (e.stack || '')}`);
+    }
   }
 }

--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -16,6 +16,7 @@ import {
   MigrateCommandContext,
   MigrateCommandOptions,
   PackageSelection,
+  TSConfig,
 } from '../../../types.js';
 
 const DEBUG_CALLBACK = debug('rehearsal:migrate:analyze');
@@ -102,7 +103,7 @@ export function analyzeTask(
         task.output = `Running migration on ${ctx.targetPackagePath}`;
       } else {
         ctx.targetPackagePath = options.basePath;
-        task.output = `Running migration on ${projectName}`;
+        task.output = `Running migration on ${projectName || 'project'}`;
       }
 
       // construct migration strategy and prepare all the files needs to be migrated
@@ -150,7 +151,7 @@ export function analyzeTask(
  */
 export function addFilesToIncludes(fileList: string[], configPath: string): void {
   if (existsSync(configPath)) {
-    const tsConfig = readJSONSync(configPath);
+    const tsConfig = readJSONSync(configPath) as TSConfig;
     if (!tsConfig.include) {
       tsConfig.include = fileList;
     } else if (Array.isArray(tsConfig.include) && !tsConfig.include.length) {
@@ -160,7 +161,7 @@ export function addFilesToIncludes(fileList: string[], configPath: string): void
         // if a file from fileList matches any file/glob in "include"
         // will keep it as unique file
         return (
-          tsConfig.include.filter((glob: string) => {
+          tsConfig.include?.filter((glob: string) => {
             return minimatch(f, glob);
           }).length === 0
         );

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -50,7 +50,7 @@ export function shouldRunLintConfigTask(
       const projectName = determineProjectName(basePath);
       const explorerSync = cosmiconfigSync(projectName || '');
       const loaded = explorerSync.load(relativeConfigPath);
-      const oldConfig = loaded?.config;
+      const oldConfig = loaded?.config as { extends: string[] };
       return (
         // check if .eslintrc exists
         // or its extends has ".rehearsal-eslintrc"
@@ -135,7 +135,7 @@ async function extendsRehearsalInCurrentConfig(
   const projectName = determineProjectName(basePath);
   const explorerSync = cosmiconfigSync(projectName || '');
   const loaded = explorerSync.load(configPath);
-  const oldConfig = loaded?.config;
+  const oldConfig = loaded?.config as { extends: string[] };
 
   let newConfig;
   if (oldConfig) {

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -1,10 +1,9 @@
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { ListrTask } from 'listr2';
-import { readJSONSync } from 'fs-extra/esm';
 
 import { addDep } from '@rehearsal/utils';
-import type { MigrateCommandContext, MigrateCommandOptions } from '../../../types.js';
+import { MigrateCommandContext, MigrateCommandOptions, PackageJson } from '../../../types.js';
 
 export const REQUIRED_DEPENDENCIES = [
   '@types/node',
@@ -45,7 +44,7 @@ export function shouldRunDepInstallTask(
 
   const packageJsonPath = resolve(basePath, 'package.json');
   if (existsSync(packageJsonPath)) {
-    const packageJson = readJSONSync(packageJsonPath);
+    const packageJson = PackageJson.parse(packageJsonPath);
     for (const d of dependencies) {
       if (!packageJson.dependencies || !packageJson.dependencies[extractDepName(d)]) {
         return true;

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import { ListrTask } from 'listr2';
 
 import { addDep } from '@rehearsal/utils';
@@ -28,10 +28,10 @@ function extractDepName(dep: string): string {
 
 // check if package.json has all required dependecies
 // from rehearsal default and user config
-export function shouldRunDepInstallTask(
+export async function shouldRunDepInstallTask(
   options: MigrateCommandOptions,
   context: Partial<MigrateCommandContext> = {}
-): boolean {
+): Promise<boolean> {
   const { basePath } = options;
   // add extra required dependencies from user config if there is any
   let dependencies: string[] = [];
@@ -44,7 +44,7 @@ export function shouldRunDepInstallTask(
 
   const packageJsonPath = resolve(basePath, 'package.json');
   if (existsSync(packageJsonPath)) {
-    const packageJson = PackageJson.parse(packageJsonPath);
+    const packageJson = PackageJson.parse(JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')));
     for (const d of dependencies) {
       if (!packageJson.dependencies || !packageJson.dependencies[extractDepName(d)]) {
         return true;
@@ -70,7 +70,8 @@ export function depInstallTask(
   return {
     title: 'Install dependencies',
     enabled: (): boolean => !options.dryRun,
-    skip: (ctx: MigrateCommandContext): boolean => !shouldRunDepInstallTask(options, ctx),
+    skip: async (ctx: MigrateCommandContext): Promise<boolean> =>
+      !(await shouldRunDepInstallTask(options, ctx)),
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
       // If context is provide via external parameter, merge with existed
       if (context) {

--- a/packages/cli/src/commands/migrate/tasks/initialize.ts
+++ b/packages/cli/src/commands/migrate/tasks/initialize.ts
@@ -29,7 +29,7 @@ export function initTask(
       const projectName = determineProjectName(options.basePath);
       DEBUG_CALLBACK('projectName', projectName);
 
-      task.output = `Setting up config for ${projectName}`;
+      task.output = `Setting up config for ${projectName || 'project'}`;
     },
     options: {
       // options for dryRun, since we need to keep the output to see the list of files

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
 import { compare } from 'compare-versions';
@@ -24,7 +24,9 @@ import {
 import { PackageJson, UpgradeCommandContext, UpgradeCommandOptions } from '../types.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
-const { version } = PackageJson.parse(resolve(__dirname, '../../package.json'));
+const { version } = PackageJson.parse(
+  JSON.parse(await fs.readFile(resolve(__dirname, '../../package.json'), 'utf-8'))
+);
 
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
 export const upgradeCommand = new Command();
@@ -61,7 +63,7 @@ upgradeCommand
 
     basePath = resolve(basePath);
 
-    console.log(`@rehearsal/upgrade ${version.trim()}`);
+    console.log(`@rehearsal/upgrade ${version?.trim()}`);
 
     // WARN: is git dirty check and exit if dirty
     if (!options.dryRun) {

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -7,7 +7,6 @@ import debug from 'debug';
 import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
 import { execa } from 'execa';
-import { readJSONSync } from 'fs-extra/esm';
 import {
   addDep,
   determineProjectName,
@@ -22,10 +21,10 @@ import {
   parseTsVersion,
 } from '@rehearsal/utils';
 
-import type { UpgradeCommandContext, UpgradeCommandOptions } from '../types.js';
+import { PackageJson, UpgradeCommandContext, UpgradeCommandOptions } from '../types.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
-const { version } = readJSONSync(resolve(__dirname, '../../package.json')) as { version: string };
+const { version } = PackageJson.parse(resolve(__dirname, '../../package.json'));
 
 const DEBUG_CALLBACK = debug('rehearsal:upgrade');
 export const upgradeCommand = new Command();
@@ -91,7 +90,7 @@ upgradeCommand
       [
         {
           title: 'Setting TypeScript version for rehearsal',
-          task: (_ctx: UpgradeCommandContext, task): Listr =>
+          task: (_ctx: UpgradeCommandContext, task) =>
             task.newListr((parent) => [
               {
                 title: options.tsVersion
@@ -136,7 +135,7 @@ upgradeCommand
         {
           title: `Bumping TypeScript Dev-Dependency`,
           skip: (ctx): boolean => ctx.skip,
-          task: (ctx: UpgradeCommandContext, task): Listr =>
+          task: (ctx: UpgradeCommandContext, task) =>
             task.newListr(() => [
               {
                 title: `Bumping TypeScript Dev-Dependency to typescript@${ctx.tsVersion}`,
@@ -169,7 +168,7 @@ upgradeCommand
         {
           title: 'Checking for compilation errors',
           skip: (ctx): boolean => ctx.skip,
-          task: (_ctx: UpgradeCommandContext, task): Listr =>
+          task: (_ctx: UpgradeCommandContext, task) =>
             task.newListr(
               () => [
                 {
@@ -246,7 +245,9 @@ upgradeCommand
       const reportOutputPath = resolve(basePath, options.outputPath);
       generateReports('upgrade', reporter, reportOutputPath, options.format);
     } catch (e) {
-      logger.error(`${e}`);
+      if (e instanceof Error) {
+        logger.error(`${e.message + '\n' + (e.stack || '')}`);
+      }
     }
 
     return;

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -79,6 +79,7 @@ export class State {
 
   // verify and update state based on files on disk
   getVerifiedStore(): Store {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const store: Store = readJSONSync(this.configPath);
     for (const f in store.files) {
       const status = store.files[f];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,14 +1,20 @@
 import { URL } from 'node:url';
 import { resolve } from 'node:path';
+import assert from 'node:assert';
+import { promises as fs } from 'node:fs';
 import { Command } from 'commander';
 import { migrateCommand } from './commands/migrate/index.js';
 import { upgradeCommand } from './commands/upgrade.js';
 import { PackageJson } from './types.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
-const { version } = PackageJson.parse(resolve(__dirname, '../package.json'));
+const { version } = PackageJson.parse(
+  JSON.parse(await fs.readFile(resolve(__dirname, '../package.json'), 'utf-8'))
+);
 
 const program = new Command();
+
+assert(version, 'Has a rehearsal version');
 
 program.name('rehearsal').version(version).addCommand(migrateCommand).addCommand(upgradeCommand);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,12 @@
 import { URL } from 'node:url';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
-import { readJSONSync } from 'fs-extra/esm';
 import { migrateCommand } from './commands/migrate/index.js';
 import { upgradeCommand } from './commands/upgrade.js';
+import { PackageJson } from './types.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
-const { version } = readJSONSync(resolve(__dirname, '../package.json')) as { version: string };
+const { version } = PackageJson.parse(resolve(__dirname, '../package.json'));
 
 const program = new Command();
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -74,14 +74,16 @@ export type PreviousRuns = {
   previousFixedCount: number;
 };
 
-export const PackageJson = z.object({
+const PackageJsonSchema = z.object({
   version: z.string(),
   scripts: z.optional(z.record(z.string(), z.string())),
   devDependencies: z.optional(z.record(z.string())),
   dependencies: z.optional(z.record(z.string(), z.string())),
 });
 
-export const ReportJson = z.object({
+export const PackageJson = PackageJsonSchema.partial();
+
+const ReportJsonSchema = z.object({
   summary: z.array(
     z.object({
       basePath: z.string(),
@@ -91,3 +93,5 @@ export const ReportJson = z.object({
   fixedItemCount: z.number(),
   items: z.array(z.unknown()),
 });
+
+export const ReportJson = ReportJsonSchema.partial();

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { MigrationStrategy } from '@rehearsal/migration-graph';
 import type { UserConfig } from './user-config.js';
 import type { State } from './helpers/state.js';
@@ -60,6 +61,7 @@ export type TSConfig = {
   compilerOptions: {
     strict: boolean;
   };
+  include?: string[];
 };
 
 export type RunPath = {
@@ -71,3 +73,21 @@ export type PreviousRuns = {
   paths: RunPath[];
   previousFixedCount: number;
 };
+
+export const PackageJson = z.object({
+  version: z.string(),
+  scripts: z.optional(z.record(z.string(), z.string())),
+  devDependencies: z.optional(z.record(z.string())),
+  dependencies: z.optional(z.record(z.string(), z.string())),
+});
+
+export const ReportJson = z.object({
+  summary: z.array(
+    z.object({
+      basePath: z.string(),
+      entrypoint: z.string(),
+    })
+  ),
+  fixedItemCount: z.number(),
+  items: z.array(z.unknown()),
+});

--- a/packages/cli/src/user-config.ts
+++ b/packages/cli/src/user-config.ts
@@ -15,7 +15,7 @@ export class UserConfig {
   public config?: MigrateCommandConfig | UpgradeCommandConfig;
 
   constructor(basePath: string, configPath: string, command: CliCommand) {
-    const config: CustomConfig = readJSONSync(resolve(basePath, configPath));
+    const config = readJSONSync(resolve(basePath, configPath)) as CustomConfig;
 
     this.config = config[command];
 

--- a/packages/cli/test/commands/migrate/analyze.test.ts
+++ b/packages/cli/test/commands/migrate/analyze.test.ts
@@ -14,7 +14,7 @@ import {
   isActionSelection,
 } from '../../test-helpers/index.js';
 
-describe('Task: analyze', async () => {
+describe('Task: analyze', () => {
   let basePath = '';
   let output = '';
   let outputStream = createOutputStream();
@@ -41,7 +41,7 @@ describe('Task: analyze', async () => {
 
   test('get files that will be migrated', async () => {
     const options = createMigrateOptions(basePath, { ci: true });
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     expect(ctx.targetPackagePath).toBe(`${basePath}`);
@@ -57,17 +57,16 @@ describe('Task: analyze', async () => {
     writeJSONSync(configPath, {});
 
     const options = createMigrateOptions(basePath, { ci: true });
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     await listrTaskRunner(tasks);
 
     // check include tsconfig.json
-    const config = readJSONSync(configPath);
-    expect(config).matchSnapshot();
+    expect(readJSONSync(configPath)).matchSnapshot();
   });
 
   test('print files will be attempted to migrate with --dryRun', async () => {
     const options = createMigrateOptions(basePath, { ci: true, dryRun: true });
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).matchSnapshot();
@@ -87,7 +86,7 @@ describe('Task: analyze', async () => {
     });
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     // test message and package selection prompt
@@ -130,7 +129,7 @@ describe('Task: analyze', async () => {
     });
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     // test message and package selection prompt
@@ -192,7 +191,7 @@ describe('Task: analyze', async () => {
     writeJSONSync(resolve(basePath, '.rehearsal', 'migrate-state.json'), previousState);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     // test message and package selection prompt
@@ -245,7 +244,7 @@ describe('Task: analyze', async () => {
     writeJSONSync(resolve(basePath, '.rehearsal', 'migrate-state.json'), previousState);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await analyzeTask(options)];
+    const tasks = [analyzeTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     // test message and package selection prompt
@@ -262,30 +261,30 @@ describe('Task: analyze', async () => {
   });
 });
 
-describe('Helper: addFilesToIncludes', async () => {
+describe('Helper: addFilesToIncludes', () => {
   let basePath = '';
 
   beforeEach(() => {
     basePath = prepareTmpDir('basic');
   });
 
-  test('do nothing with no tsconfig', async () => {
+  test('do nothing with no tsconfig', () => {
     const configPath = resolve(basePath, 'tsconfig.json');
     addFilesToIncludes([], configPath);
     expect(existsSync(configPath)).toBeFalsy();
   });
 
-  test('repalce include if no include in tsconfig', async () => {
+  test('repalce include if no include in tsconfig', () => {
     const configPath = resolve(basePath, 'tsconfig.json');
     writeJSONSync(configPath, {});
     const fileList = ['foo', 'bar'];
     addFilesToIncludes(fileList, configPath);
 
-    const config = readJSONSync(configPath);
+    const config = readJSONSync(configPath) as { include: string[] };
     expect(config.include).toStrictEqual(fileList);
   });
 
-  test('only append unique files to existed include', async () => {
+  test('only append unique files to existed include', () => {
     const configPath = resolve(basePath, 'tsconfig.json');
     const oldInclude = ['lib/*.ts', 'test/**/*.ts'];
     writeJSONSync(configPath, {
@@ -301,7 +300,7 @@ describe('Helper: addFilesToIncludes', async () => {
     ];
     addFilesToIncludes(fileList, configPath);
 
-    const config = readJSONSync(configPath);
+    const config = readJSONSync(configPath) as { include: string[] };
     expect(config.include).toStrictEqual([...oldInclude, 'lib/foo/a.ts', 'index.ts']);
   });
 });

--- a/packages/cli/test/commands/migrate/config-lint.test.ts
+++ b/packages/cli/test/commands/migrate/config-lint.test.ts
@@ -14,7 +14,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe('Task: config-lint', async () => {
+describe('Task: config-lint', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -39,7 +39,7 @@ describe('Task: config-lint', async () => {
   test('create .eslintrc.js if not existed', async () => {
     const options = createMigrateOptions(basePath);
     // lint task requires dependencies installed first
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc.js');
@@ -56,7 +56,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // lint task requires dependencies installed first
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc.js');
@@ -65,7 +65,7 @@ describe('Task: config-lint', async () => {
     expect(output).toContain('extending Rehearsal default eslint-related config');
 
     /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-    const newConfig = require(resolve(basePath, '.eslintrc.js'));
+    const newConfig = require(resolve(basePath, '.eslintrc.js')) as { extends: string[] };
     expect(newConfig.extends).toStrictEqual(['./.rehearsal-eslintrc.js']);
   });
 
@@ -79,7 +79,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // this validation does not need depInstallTask
-    const tasks = [await lintConfigTask(options)];
+    const tasks = [lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).toContain('[SKIPPED] Create eslint config');
@@ -92,7 +92,7 @@ describe('Task: config-lint', async () => {
     writeFileSync(resolve(basePath, '.eslintrc'), oldConfig);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc');
@@ -102,7 +102,7 @@ describe('Task: config-lint', async () => {
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(basePath, '.eslintrc'));
-    const newConfig = loaded?.config;
+    const newConfig = loaded?.config as { extends: string[] };
     expect(newConfig.extends).toStrictEqual(['./.rehearsal-eslintrc']);
   });
 
@@ -116,7 +116,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // this validation does not need depInstallTask
-    const tasks = [await lintConfigTask(options)];
+    const tasks = [lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).toContain('[SKIPPED] Create eslint config');
@@ -129,7 +129,7 @@ describe('Task: config-lint', async () => {
     writeFileSync(resolve(basePath, '.eslintrc.json'), oldConfig);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc.json');
@@ -139,7 +139,7 @@ describe('Task: config-lint', async () => {
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(basePath, '.eslintrc.json'));
-    const newConfig = loaded?.config;
+    const newConfig = loaded?.config as { extends: string[] };
     expect(newConfig.extends).toStrictEqual(['./.rehearsal-eslintrc.json']);
   });
 
@@ -153,7 +153,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // this validation does not need depInstallTask
-    const tasks = [await lintConfigTask(options)];
+    const tasks = [lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).toContain('[SKIPPED] Create eslint config');
@@ -166,7 +166,7 @@ describe('Task: config-lint', async () => {
     writeFileSync(resolve(basePath, '.eslintrc.yml'), oldConfig);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc.yml');
@@ -176,7 +176,7 @@ describe('Task: config-lint', async () => {
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(basePath, '.eslintrc.yml'));
-    const config = loaded?.config;
+    const config = loaded?.config as { extends: string[] };
 
     /* eslint-disable-next-line @typescript-eslint/no-var-requires */
     expect(config.extends).toStrictEqual(['./.rehearsal-eslintrc.yml']);
@@ -192,7 +192,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // this validation does not need depInstallTask
-    const tasks = [await lintConfigTask(options)];
+    const tasks = [lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).toContain('[SKIPPED] Create eslint config');
@@ -205,7 +205,7 @@ describe('Task: config-lint', async () => {
     writeFileSync(resolve(basePath, '.eslintrc.yaml'), oldConfig);
 
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options), await lintConfigTask(options)];
+    const tasks = [depInstallTask(options), lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(readdirSync(basePath)).toContain('.eslintrc.yaml');
@@ -215,7 +215,7 @@ describe('Task: config-lint', async () => {
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(basePath, '.eslintrc.yaml'));
-    const config = loaded?.config;
+    const config = loaded?.config as { extends: string[] };
 
     /* eslint-disable-next-line @typescript-eslint/no-var-requires */
     expect(config.extends).toStrictEqual(['./.rehearsal-eslintrc.yaml']);
@@ -231,7 +231,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath);
     // this validation does not need depInstallTask
-    const tasks = [await lintConfigTask(options)];
+    const tasks = [lintConfigTask(options)];
     await listrTaskRunner(tasks);
 
     expect(output).toContain('[SKIPPED] Create eslint config');
@@ -248,7 +248,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await depInstallTask(options), await lintConfigTask(options, { userConfig })];
+    const tasks = [depInstallTask(options), lintConfigTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     // This proves the custom command works
@@ -268,7 +268,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await depInstallTask(options), await lintConfigTask(options, { userConfig })];
+    const tasks = [depInstallTask(options), lintConfigTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     // This proves the custom command and hook works
@@ -294,7 +294,7 @@ describe('Task: config-lint', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await lintConfigTask(options, { userConfig })];
+    const tasks = [lintConfigTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     // This proves the custom command works

--- a/packages/cli/test/commands/migrate/config-ts.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import { tsConfigTask } from '../../../src/commands/migrate/tasks/index.js';
 import { prepareTmpDir, listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
-import { CustomConfig } from '../../../src/types.js';
+import { CustomConfig, TSConfig } from '../../../src/types.js';
 import { UserConfig } from '../../../src/user-config.js';
 
 function createUserConfig(basePath: string, config: CustomConfig): void {
@@ -12,7 +12,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe('Task: config-ts', async () => {
+describe('Task: config-ts', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -34,12 +34,10 @@ describe('Task: config-ts', async () => {
   test('create tsconfig if not existed', async () => {
     const options = createMigrateOptions(basePath);
     const context = { sourceFilesWithRelativePath: [] };
-    const tasks = [await tsConfigTask(options, context)];
+    const tasks = [tsConfigTask(options, context)];
     await listrTaskRunner(tasks);
 
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
-
-    expect(tsConfig).matchSnapshot();
+    expect(readJSONSync(resolve(basePath, 'tsconfig.json'))).matchSnapshot();
     expect(output).matchSnapshot();
   });
 
@@ -50,10 +48,10 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath);
     const context = { sourceFilesWithRelativePath: [] };
-    const tasks = [await tsConfigTask(options, context)];
+    const tasks = [tsConfigTask(options, context)];
     await listrTaskRunner(tasks);
 
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
 
     expect(tsConfig.compilerOptions.strict).toBeTruthy();
     // Do not use snapshot here since there is absolute path in output
@@ -67,10 +65,10 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath);
     const context = { sourceFilesWithRelativePath: [] };
-    const tasks = [await tsConfigTask(options, context)];
+    const tasks = [tsConfigTask(options, context)];
     await listrTaskRunner(tasks);
 
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
 
     expect(tsConfig.compilerOptions.strict).toBeTruthy();
     // Do not use snapshot here since there is absolute path in output
@@ -84,7 +82,7 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath);
     const context = { sourceFilesWithRelativePath: [] };
-    const tasks = [await tsConfigTask(options, context)];
+    const tasks = [tsConfigTask(options, context)];
     await listrTaskRunner(tasks);
 
     await listrTaskRunner(tasks); // should be skipped
@@ -102,7 +100,7 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await tsConfigTask(options, { userConfig })];
+    const tasks = [tsConfigTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     // This proves the custom command works
@@ -125,7 +123,7 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await tsConfigTask(options, { userConfig })];
+    const tasks = [tsConfigTask(options, { userConfig })];
 
     await listrTaskRunner(tasks); // should be skipped
 
@@ -146,7 +144,7 @@ describe('Task: config-ts', async () => {
 
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
-    const tasks = [await tsConfigTask(options, { userConfig })];
+    const tasks = [tsConfigTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     // This proves the custom command and hook works

--- a/packages/cli/test/commands/migrate/convert.test.ts
+++ b/packages/cli/test/commands/migrate/convert.test.ts
@@ -24,12 +24,13 @@ import {
   isPackageSelection,
   isActionSelection,
 } from '../../test-helpers/index.js';
+import { TSConfig } from '../../../src/types.js';
 
 const logger = createLogger({
   transports: [new transports.Console({ format: format.cli() })],
 });
 
-describe('Task: convert', async () => {
+describe('Task: convert', () => {
   let basePath = '';
   let output = '';
   let outputStream = createOutputStream();
@@ -62,12 +63,12 @@ describe('Task: convert', async () => {
     const options = createMigrateOptions(basePath, { ci: true });
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
     await listrTaskRunner(tasks);
 
@@ -81,7 +82,7 @@ describe('Task: convert', async () => {
     expect(fileList).not.toContain('foo.js');
     expect(fileList).not.toContain('depends-on-foo.js');
 
-    const config = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const config = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
     expect(config.include).toContain('index.ts');
     expect(config.include).toContain('foo.ts');
     expect(config.include).toContain('depends-on-foo.ts');
@@ -91,12 +92,12 @@ describe('Task: convert', async () => {
     const options = createMigrateOptions(basePath, { entrypoint: 'depends-on-foo.js', ci: true });
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
     await listrTaskRunner(tasks);
 
@@ -109,7 +110,7 @@ describe('Task: convert', async () => {
     expect(fileList).not.toContain('depends-on-foo.js');
     expect(fileList).not.toContain('foo.js');
 
-    const config = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const config = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
     expect(config.include).toContain('depends-on-foo.ts');
     expect(config.include).toContain('foo.ts');
   });
@@ -121,12 +122,12 @@ describe('Task: convert', async () => {
     });
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
     await listrTaskRunner(tasks);
 
@@ -156,12 +157,12 @@ describe('Task: convert', async () => {
     });
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
 
     await listrTaskRunner(tasks);
@@ -223,12 +224,12 @@ describe('Task: convert', async () => {
 
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
 
     await listrTaskRunner(tasks);
@@ -285,12 +286,12 @@ describe('Task: convert', async () => {
     });
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
 
     await listrTaskRunner(tasks);
@@ -326,12 +327,12 @@ describe('Task: convert', async () => {
 
     // Get context for convert task from previous tasks
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
 
     // use try catch since it would be killed via ctrl c

--- a/packages/cli/test/commands/migrate/create-scripts.test.ts
+++ b/packages/cli/test/commands/migrate/create-scripts.test.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { promises as fs } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { writeJSONSync } from 'fs-extra/esm';
 
@@ -30,7 +31,9 @@ describe('Task: create-scripts', () => {
     const tasks = [createScriptsTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
 
     expect(output).matchSnapshot();
@@ -41,7 +44,9 @@ describe('Task: create-scripts', () => {
     const tasks = [createScriptsTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     writeJSONSync(resolve(basePath, 'package.json'), {
       scripts: { 'lint:tsc': 'foo' },
       ...packageJson,

--- a/packages/cli/test/commands/migrate/create-scripts.test.ts
+++ b/packages/cli/test/commands/migrate/create-scripts.test.ts
@@ -1,11 +1,12 @@
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
+import { writeJSONSync } from 'fs-extra/esm';
 
 import { createScriptsTask } from '../../../src/commands/migrate/tasks/index.js';
 import { prepareTmpDir, listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
+import { PackageJson } from '../../../src/types.js';
 
-describe('Task: create-scripts', async () => {
+describe('Task: create-scripts', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -26,26 +27,26 @@ describe('Task: create-scripts', async () => {
 
   test('add lint:tsc in package.json', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await createScriptsTask(options)];
+    const tasks = [createScriptsTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
 
     expect(output).matchSnapshot();
   });
 
   test('replace if the script exists', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await createScriptsTask(options)];
+    const tasks = [createScriptsTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     writeJSONSync(resolve(basePath, 'package.json'), {
       scripts: { 'lint:tsc': 'foo' },
       ...packageJson,
     });
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
 
     expect(output).matchSnapshot();
   });

--- a/packages/cli/test/commands/migrate/dependency-install.test.ts
+++ b/packages/cli/test/commands/migrate/dependency-install.test.ts
@@ -70,7 +70,7 @@ describe('Task: dependency-install', () => {
       devDependencies: requiredDevDepsMap,
     });
 
-    expect(shouldRunDepInstallTask(options)).toBeFalsy();
+    expect(await shouldRunDepInstallTask(options)).toBeFalsy();
   });
 
   test('skip install required dependencies', async () => {
@@ -146,7 +146,7 @@ describe('Task: dependency-install', () => {
       dependencies: requiredDepsMap,
       devDependencies: requiredDevDepsMap,
     });
-    expect(shouldRunDepInstallTask(options, { userConfig })).toBeFalsy();
+    expect(await shouldRunDepInstallTask(options, { userConfig })).toBeFalsy();
   });
 
   test('skip install custom deps', async () => {

--- a/packages/cli/test/commands/migrate/dependency-install.test.ts
+++ b/packages/cli/test/commands/migrate/dependency-install.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
+import { writeJSONSync } from 'fs-extra/esm';
 
 import {
   REQUIRED_DEPENDENCIES,
@@ -9,7 +9,7 @@ import {
   shouldRunDepInstallTask,
 } from '../../../src/commands/migrate/tasks/index.js';
 import { prepareTmpDir, listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
-import { CustomConfig } from '../../../src/types.js';
+import { CustomConfig, PackageJson } from '../../../src/types.js';
 import { UserConfig } from '../../../src/user-config.js';
 
 function createUserConfig(basePath: string, config: CustomConfig): void {
@@ -17,7 +17,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe('Task: dependency-install', async () => {
+describe('Task: dependency-install', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -42,17 +42,17 @@ describe('Task: dependency-install', async () => {
 
   test('install required dependencies', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options)];
+    const tasks = [depInstallTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
 
-    expect(Object.keys(devDeps).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
     expect(output).matchSnapshot();
   });
 
-  test('shouldRunDepInstallTask should skip', async () => {
+  test('shouldRunDepInstallTask should skip', () => {
     const options = createMigrateOptions(basePath);
 
     // convert array of deps to object-ish
@@ -62,7 +62,7 @@ describe('Task: dependency-install', async () => {
     );
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = readJSONSync(packageJsonPath);
+    const packageJson = PackageJson.parse(packageJsonPath);
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       devDependencies: requiredDevDepsMap,
@@ -73,7 +73,7 @@ describe('Task: dependency-install', async () => {
 
   test('skip install required dependencies', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await depInstallTask(options)];
+    const tasks = [depInstallTask(options)];
 
     // convert array of deps to object-ish
     const requiredDevDepsMap = REQUIRED_DEPENDENCIES.reduce(
@@ -82,7 +82,7 @@ describe('Task: dependency-install', async () => {
     );
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = readJSONSync(packageJsonPath);
+    const packageJson = PackageJson.parse(packageJsonPath);
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       devDependencies: requiredDevDepsMap,
@@ -103,21 +103,21 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
     const deps = packageJson.dependencies;
 
-    expect(Object.keys(devDeps).sort()).toEqual(['tmp', ...REQUIRED_DEPENDENCIES].sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(['tmp', ...REQUIRED_DEPENDENCIES].sort());
 
     expect(devDeps).toHaveProperty('tmp');
     expect(deps).toHaveProperty('fs-extra');
     expect(output).matchSnapshot();
   });
 
-  test('shouldRunDepInstallTask should skip with custom deps', async () => {
+  test('shouldRunDepInstallTask should skip with custom deps', () => {
     createUserConfig(basePath, {
       migrate: {
         install: {
@@ -136,7 +136,7 @@ describe('Task: dependency-install', async () => {
     const requiredDepsMap = { 'fs-extra': '2.0.0' };
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = readJSONSync(packageJsonPath);
+    const packageJson = PackageJson.parse(packageJsonPath);
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       dependencies: requiredDepsMap,
@@ -156,7 +156,7 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     // convert array of deps to object-ish
     const requiredDevDepsMap = {
       ...REQUIRED_DEPENDENCIES.reduce((map, d) => ({ ...map, [d]: '1.0.0' }), {}),
@@ -165,7 +165,7 @@ describe('Task: dependency-install', async () => {
     const requiredDepsMap = { 'fs-extra': '2.0.0' };
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = readJSONSync(packageJsonPath);
+    const packageJson = PackageJson.parse(packageJsonPath);
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       dependencies: requiredDepsMap,
@@ -187,7 +187,7 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     // await listrTaskRunner(tasks);
 
     await expect(() => listrTaskRunner(tasks)).rejects.toThrowErrorMatchingSnapshot();
@@ -208,10 +208,10 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
     expect(devDeps).toHaveProperty('fs-extra');
 
@@ -240,7 +240,7 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     expect(existsSync(resolve(basePath, 'foo')));
@@ -260,7 +260,7 @@ describe('Task: dependency-install', async () => {
     });
     const userConfig = new UserConfig(basePath, 'rehearsal-config.json', 'migrate');
     const options = createMigrateOptions(basePath, { userConfig: 'rehearsal-config.json' });
-    const tasks = [await depInstallTask(options, { userConfig })];
+    const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
     expect(output).matchSnapshot();

--- a/packages/cli/test/commands/migrate/dependency-install.test.ts
+++ b/packages/cli/test/commands/migrate/dependency-install.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { writeJSONSync } from 'fs-extra/esm';
 
@@ -45,14 +45,16 @@ describe('Task: dependency-install', () => {
     const tasks = [depInstallTask(options)];
     await listrTaskRunner(tasks);
 
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
 
     expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
     expect(output).matchSnapshot();
   });
 
-  test('shouldRunDepInstallTask should skip', () => {
+  test('shouldRunDepInstallTask should skip', async () => {
     const options = createMigrateOptions(basePath);
 
     // convert array of deps to object-ish
@@ -62,7 +64,7 @@ describe('Task: dependency-install', () => {
     );
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = PackageJson.parse(packageJsonPath);
+    const packageJson = PackageJson.parse(JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')));
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       devDependencies: requiredDevDepsMap,
@@ -82,7 +84,7 @@ describe('Task: dependency-install', () => {
     );
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = PackageJson.parse(packageJsonPath);
+    const packageJson = PackageJson.parse(JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')));
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       devDependencies: requiredDevDepsMap,
@@ -106,7 +108,9 @@ describe('Task: dependency-install', () => {
     const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     const deps = packageJson.dependencies;
 
@@ -117,7 +121,7 @@ describe('Task: dependency-install', () => {
     expect(output).matchSnapshot();
   });
 
-  test('shouldRunDepInstallTask should skip with custom deps', () => {
+  test('shouldRunDepInstallTask should skip with custom deps', async () => {
     createUserConfig(basePath, {
       migrate: {
         install: {
@@ -136,7 +140,7 @@ describe('Task: dependency-install', () => {
     const requiredDepsMap = { 'fs-extra': '2.0.0' };
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = PackageJson.parse(packageJsonPath);
+    const packageJson = PackageJson.parse(JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')));
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       dependencies: requiredDepsMap,
@@ -165,7 +169,7 @@ describe('Task: dependency-install', () => {
     const requiredDepsMap = { 'fs-extra': '2.0.0' };
     // update package.json with required deps
     const packageJsonPath = resolve(basePath, 'package.json');
-    const packageJson = PackageJson.parse(packageJsonPath);
+    const packageJson = PackageJson.parse(JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')));
     writeJSONSync(packageJsonPath, {
       ...packageJson,
       dependencies: requiredDepsMap,
@@ -211,7 +215,9 @@ describe('Task: dependency-install', () => {
     const tasks = [depInstallTask(options, { userConfig })];
     await listrTaskRunner(tasks);
 
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     expect(devDeps).toHaveProperty('fs-extra');
 

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -9,11 +9,11 @@ import fixturify from 'fixturify';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install.js';
 
 import { runBin, prepareTmpDir, cleanOutput } from '../../test-helpers/index.js';
-import { CustomConfig } from '../../../src/types.js';
+import { CustomConfig, PackageJson, TSConfig } from '../../../src/types.js';
 
 setGracefulCleanup();
 
-describe('migrate - validation', async () => {
+describe('migrate - validation', () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -152,7 +152,7 @@ describe('migrate - validation', async () => {
   });
 });
 
-describe('migrate: e2e', async () => {
+describe('migrate: e2e', () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -184,16 +184,16 @@ describe('migrate: e2e', async () => {
     expect(readFileSync(resolve(basePath, 'index.ts'), { encoding: 'utf-8' })).toMatchSnapshot();
 
     // Dependencies
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
-    expect(Object.keys(devDeps).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
     // report
     const reportPath = resolve(basePath, '.rehearsal');
     expect(readdirSync(reportPath)).toContain('migrate-report.sarif');
 
     // tsconfig.json
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = PackageJson.parse(resolve(basePath, 'tsconfig.json'));
     expect(tsConfig).matchSnapshot();
 
     // lint config
@@ -207,7 +207,7 @@ describe('migrate: e2e', async () => {
     expect(lintConfigDefualt).toMatchSnapshot();
 
     // new scripts
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
   });
 
   test('migrate would skip steps after migrate init', async () => {
@@ -219,12 +219,12 @@ describe('migrate: e2e', async () => {
     let fileList = readdirSync(basePath);
 
     // Dependencies
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
-    expect(Object.keys(devDeps).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
     // tsconfig.json
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
     expect(tsConfig).matchSnapshot();
 
     // lint config
@@ -238,7 +238,7 @@ describe('migrate: e2e', async () => {
     expect(lintConfigDefualt).toMatchSnapshot();
 
     // new scripts
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
 
     // run migrate
     const { stdout } = await runBin('migrate', ['--ci'], {
@@ -322,7 +322,7 @@ describe('migrate: e2e', async () => {
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
   });
 
-  describe('user defined options passed by --user-config -u', async () => {
+  describe('user defined options passed by --user-config -u', () => {
     function createUserConfig(basePath: string, config: CustomConfig): void {
       const configPath = resolve(basePath, 'rehearsal-config.json');
       writeJSONSync(configPath, config);

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, promises as fs } from 'node:fs';
 import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import { setGracefulCleanup, dirSync } from 'tmp';
 import { beforeEach, describe, expect, test } from 'vitest';
@@ -184,7 +184,9 @@ describe('migrate: e2e', () => {
     expect(readFileSync(resolve(basePath, 'index.ts'), { encoding: 'utf-8' })).toMatchSnapshot();
 
     // Dependencies
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
@@ -193,7 +195,7 @@ describe('migrate: e2e', () => {
     expect(readdirSync(reportPath)).toContain('migrate-report.sarif');
 
     // tsconfig.json
-    const tsConfig = PackageJson.parse(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
     expect(tsConfig).matchSnapshot();
 
     // lint config
@@ -219,7 +221,9 @@ describe('migrate: e2e', () => {
     let fileList = readdirSync(basePath);
 
     // Dependencies
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 

--- a/packages/cli/test/commands/migrate/init-command.test.ts
+++ b/packages/cli/test/commands/migrate/init-command.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install.js';
 
 import { runBin, prepareTmpDir, cleanOutput } from '../../test-helpers/index.js';
-import { CustomConfig } from '../../../src/types.js';
+import { CustomConfig, PackageJson, TSConfig } from '../../../src/types.js';
 
 setGracefulCleanup();
 
@@ -15,7 +15,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
   writeJSONSync(configPath, config);
 }
 
-describe('migrate init', async () => {
+describe('migrate init', () => {
   let basePath = '';
 
   beforeEach(() => {
@@ -34,12 +34,12 @@ describe('migrate init', async () => {
     const fileList = readdirSync(basePath);
 
     // Dependencies
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
-    expect(Object.keys(devDeps).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
     // tsconfig.json
-    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json'));
+    const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
     expect(tsConfig).matchSnapshot();
 
     // lint config
@@ -53,7 +53,7 @@ describe('migrate init', async () => {
     expect(lintConfigDefualt).toMatchSnapshot();
 
     // new scripts
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
   });
 
   test('pass user config', async () => {
@@ -77,10 +77,10 @@ describe('migrate init', async () => {
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
 
     // Dependencies
-    const packageJson = readJSONSync(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
     const devDeps = packageJson.devDependencies;
     const deps = packageJson.dependencies;
-    expect(Object.keys(devDeps).sort()).toEqual(['tmp', ...REQUIRED_DEPENDENCIES].sort());
+    expect(Object.keys(devDeps!).sort()).toEqual(['tmp', ...REQUIRED_DEPENDENCIES].sort());
     expect(deps).toHaveProperty('fs-extra');
 
     // ts config
@@ -90,7 +90,7 @@ describe('migrate init', async () => {
     expect(readdirSync(basePath)).toContain('custom-lint-config-script');
 
     // new scripts
-    expect(packageJson.scripts['lint:tsc']).toBe('tsc --noEmit');
+    expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
   });
 
   test('skip dep install, ts config, and lint config if exists', async () => {

--- a/packages/cli/test/commands/migrate/init-command.test.ts
+++ b/packages/cli/test/commands/migrate/init-command.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, promises as fs } from 'node:fs';
 import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import { setGracefulCleanup } from 'tmp';
 import { beforeEach, describe, expect, test } from 'vitest';
@@ -34,7 +34,9 @@ describe('migrate init', () => {
     const fileList = readdirSync(basePath);
 
     // Dependencies
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     expect(Object.keys(devDeps!).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
@@ -77,7 +79,9 @@ describe('migrate init', () => {
     expect(cleanOutput(stdout, basePath)).toMatchSnapshot();
 
     // Dependencies
-    const packageJson = PackageJson.parse(resolve(basePath, 'package.json'));
+    const packageJson = PackageJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, 'package.json'), 'utf-8'))
+    );
     const devDeps = packageJson.devDependencies;
     const deps = packageJson.dependencies;
     expect(Object.keys(devDeps!).sort()).toEqual(['tmp', ...REQUIRED_DEPENDENCIES].sort());

--- a/packages/cli/test/commands/migrate/initialize.test.ts
+++ b/packages/cli/test/commands/migrate/initialize.test.ts
@@ -14,7 +14,7 @@ function createUserConfig(
   writeJSONSync(configPath, config);
 }
 
-describe('Task: initialize', async () => {
+describe('Task: initialize', () => {
   let basePath = '';
   let output = '';
 
@@ -52,7 +52,7 @@ describe('Task: initialize', async () => {
     });
 
     const options = createMigrateOptions(basePath, { ci: true });
-    const tasks = [await initTask(options)];
+    const tasks = [initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     expect.assertions(9);
@@ -90,7 +90,7 @@ describe('Task: initialize', async () => {
     );
 
     const options = createMigrateOptions(basePath, { ci: true, userConfig: 'another-config.json' });
-    const tasks = [await initTask(options)];
+    const tasks = [initTask(options)];
     const ctx = await listrTaskRunner(tasks);
 
     expect.assertions(9);

--- a/packages/cli/test/commands/migrate/regen.test.ts
+++ b/packages/cli/test/commands/migrate/regen.test.ts
@@ -44,7 +44,7 @@ describe('Task: regen', () => {
     const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [initTask(options), regenTask(options, logger)];
 
-    await expect(() => listrTaskRunner(tasks)).rejects.toThrowError(
+    await expect(async () => await listrTaskRunner(tasks)).rejects.toThrowError(
       `Config file 'tsconfig.json' not found`
     );
   });

--- a/packages/cli/test/commands/migrate/regen.test.ts
+++ b/packages/cli/test/commands/migrate/regen.test.ts
@@ -17,7 +17,7 @@ const logger = createLogger({
   transports: [new transports.Console({ format: format.cli() })],
 });
 
-describe('Task: regen', async () => {
+describe('Task: regen', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -42,7 +42,7 @@ describe('Task: regen', async () => {
 
   test('throw error with no tsconfig.json', async () => {
     const options = createMigrateOptions(basePath, { ci: true });
-    const tasks = [await initTask(options), await regenTask(options, logger)];
+    const tasks = [initTask(options), regenTask(options, logger)];
 
     await expect(() => listrTaskRunner(tasks)).rejects.toThrowError(
       `Config file 'tsconfig.json' not found`
@@ -51,11 +51,7 @@ describe('Task: regen', async () => {
 
   test('no effect on JS filse before conversion', async () => {
     const options = createMigrateOptions(basePath, { ci: true });
-    const tasks = [
-      await initTask(options),
-      await tsConfigTask(options),
-      await regenTask(options, logger),
-    ];
+    const tasks = [initTask(options), tsConfigTask(options), regenTask(options, logger)];
 
     await listrTaskRunner(tasks);
     expect(output).matchSnapshot();
@@ -64,16 +60,16 @@ describe('Task: regen', async () => {
   test('update ts and lint errors based on previous conversion', async () => {
     const options = createMigrateOptions(basePath, { ci: true });
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await convertTask(options, logger),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      convertTask(options, logger),
     ];
 
     await listrTaskRunner(tasks);
-    await listrTaskRunner([await regenTask(options, logger)]);
+    await listrTaskRunner([regenTask(options, logger)]);
     expect(output).matchSnapshot();
   });
 });

--- a/packages/cli/test/commands/migrate/sequential.test.ts
+++ b/packages/cli/test/commands/migrate/sequential.test.ts
@@ -1,7 +1,6 @@
 import { resolve } from 'node:path';
 import { readdirSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { readJSONSync } from 'fs-extra/esm';
 import { createLogger, format, transports } from 'winston';
 import {
   analyzeTask,
@@ -18,12 +17,13 @@ import {
   listrTaskRunner,
   prepareTmpDir,
 } from '../../test-helpers/index.js';
+import { ReportJson } from '../../../src/types.js';
 
 const logger = createLogger({
   transports: [new transports.Console({ format: format.cli() })],
 });
 
-describe('Task: sequential', async () => {
+describe('Task: sequential', () => {
   let basePath = '';
   let output = '';
 
@@ -61,12 +61,12 @@ describe('Task: sequential', async () => {
       paths: [{ basePath, entrypoint: 'depends-on-foo.ts' }],
     };
     const tasks = [
-      await initTask(options),
-      await depInstallTask(options),
-      await tsConfigTask(options),
-      await lintConfigTask(options),
-      await analyzeTask(options),
-      await sequentialTask(options, logger, previousRuns),
+      initTask(options),
+      depInstallTask(options),
+      tsConfigTask(options),
+      lintConfigTask(options),
+      analyzeTask(options),
+      sequentialTask(options, logger, previousRuns),
     ];
 
     await listrTaskRunner(tasks);
@@ -77,7 +77,7 @@ describe('Task: sequential', async () => {
     expect(fileList).toContain('foo.ts');
     expect(fileList).toContain('index.ts');
 
-    const report = readJSONSync(resolve(basePath, '.rehearsal', 'migrate-report.json'));
+    const report = ReportJson.parse(resolve(basePath, '.rehearsal', 'migrate-report.json'));
     const { summary, fixedItemCount, items } = report;
     expect(summary.length).toBe(2);
     expect(summary[0].basePath).toEqual(summary[1].basePath);

--- a/packages/cli/test/commands/migrate/sequential.test.ts
+++ b/packages/cli/test/commands/migrate/sequential.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readdirSync } from 'node:fs';
+import { readdirSync, promises as fs } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createLogger, format, transports } from 'winston';
 import {
@@ -77,13 +77,15 @@ describe('Task: sequential', () => {
     expect(fileList).toContain('foo.ts');
     expect(fileList).toContain('index.ts');
 
-    const report = ReportJson.parse(resolve(basePath, '.rehearsal', 'migrate-report.json'));
+    const report = ReportJson.parse(
+      JSON.parse(await fs.readFile(resolve(basePath, '.rehearsal', 'migrate-report.json'), 'utf-8'))
+    );
     const { summary, fixedItemCount, items } = report;
-    expect(summary.length).toBe(2);
-    expect(summary[0].basePath).toEqual(summary[1].basePath);
-    expect(summary[0].entrypoint).toBe('depends-on-foo.ts');
-    expect(summary[1].entrypoint).toBe('index.ts');
+    expect(summary?.length).toBe(2);
+    expect(summary?.[0].basePath).toEqual(summary?.[1].basePath);
+    expect(summary?.[0].entrypoint).toBe('depends-on-foo.ts');
+    expect(summary?.[1].entrypoint).toBe('index.ts');
     expect(fixedItemCount).toBe(4);
-    expect(items.length).toBe(2);
+    expect(items?.length).toBe(2);
   });
 });

--- a/packages/cli/test/commands/migrate/validate.test.ts
+++ b/packages/cli/test/commands/migrate/validate.test.ts
@@ -16,7 +16,7 @@ const logger = createLogger({
   transports: [new transports.Console({ format: format.cli() })],
 });
 
-describe('Task: validate', async () => {
+describe('Task: validate', () => {
   let basePath = '';
   let output = '';
   vi.spyOn(console, 'info').mockImplementation((chunk) => {
@@ -49,7 +49,7 @@ describe('Task: validate', async () => {
 
   test('pass with package.json', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await validateTask(options, logger)];
+    const tasks = [validateTask(options, logger)];
 
     await listrTaskRunner(tasks);
     expect(cleanOutput(output, basePath)).toMatchSnapshot();
@@ -57,7 +57,7 @@ describe('Task: validate', async () => {
 
   test('error if no package.json', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await validateTask(options, logger)];
+    const tasks = [validateTask(options, logger)];
 
     rmSync(resolve(basePath, 'package.json'));
 
@@ -66,7 +66,7 @@ describe('Task: validate', async () => {
 
   test('error if .gitignore has .rehearsal', async () => {
     const options = createMigrateOptions(basePath);
-    const tasks = [await validateTask(options, logger)];
+    const tasks = [validateTask(options, logger)];
 
     const gitignore = `.rehearsal\nfoo\nbar`;
     const gitignorePath = resolve(basePath, '.gitignore');
@@ -79,7 +79,7 @@ describe('Task: validate', async () => {
 
   test('show warning message for missing files in --regen', async () => {
     const options = createMigrateOptions(basePath, { regen: true });
-    const tasks = [await validateTask(options, logger)];
+    const tasks = [validateTask(options, logger)];
 
     await listrTaskRunner(tasks);
     expect(cleanOutput(output, basePath)).toMatchSnapshot();
@@ -87,7 +87,7 @@ describe('Task: validate', async () => {
 
   test('pass with all config files in --regen', async () => {
     const options = createMigrateOptions(basePath, { regen: true });
-    const tasks = [await validateTask(options, logger)];
+    const tasks = [validateTask(options, logger)];
 
     createFileSync(resolve(basePath, '.eslintrc.js'));
     createFileSync(resolve(basePath, 'tsconfig.json'));

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -41,7 +41,7 @@ const afterEachCleanup = async (): Promise<void> => {
 // Revert to development version of TSC
 afterAll(async (): Promise<void> => {
   await execa(PNPM_PATH, ['remove', '-D', `typescript`]);
-  await execa(PNPM_PATH, ['add', `typescript@${ORIGIN_TSC_VERSION}`]);
+  await execa(PNPM_PATH, ['add', '-D', `typescript@${ORIGIN_TSC_VERSION}`]);
   await execa(PNPM_PATH, ['install']);
 });
 

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -47,7 +47,7 @@ afterAll(async (): Promise<void> => {
 
 describe.each(['rc', 'latest', 'beta', 'latestBeta'])(
   'upgrade:command typescript@%s',
-  async (buildTag) => {
+  (buildTag) => {
     beforeEach(beforeEachPrep);
     afterEach(afterEachCleanup);
 
@@ -65,7 +65,7 @@ describe.each(['rc', 'latest', 'beta', 'latestBeta'])(
 
       expect(result.stdout).contain(`Rehearsing with typescript@${latestPublishedTSVersion}`);
       expect(result.stdout).to.contain(`Codefixes applied successfully`);
-      expect(existsSync(reportFile)).toBeTruthy;
+      expect(existsSync(reportFile)).toBeTruthy();
 
       const report = readJSONSync(reportFile) as import('@rehearsal/reporter').Report;
       expect(report).to.exist;
@@ -76,7 +76,7 @@ describe.each(['rc', 'latest', 'beta', 'latestBeta'])(
   }
 );
 
-describe('upgrade:command typescript@next', async () => {
+describe('upgrade:command typescript@next', () => {
   beforeEach(beforeEachPrep);
   afterEach(afterEachCleanup);
 
@@ -93,14 +93,14 @@ describe('upgrade:command typescript@next', async () => {
     const reportFile = join(FIXTURE_APP_PATH, '.rehearsal', 'upgrade-report.sarif');
 
     expect(result.stdout).contain(`Rehearsing with typescript@${latestPublishedTSVersion}`);
-    expect(existsSync(reportFile)).toBeTruthy;
+    expect(existsSync(reportFile)).toBeTruthy();
 
     const report = readJSONSync(reportFile) as import('@rehearsal/reporter').Report;
     expect(report).to.exist;
   });
 });
 
-describe('upgrade:command tsc version check', async () => {
+describe('upgrade:command tsc version check', () => {
   beforeEach(beforeEachPrep);
   afterEach(afterEachCleanup);
 
@@ -108,6 +108,7 @@ describe('upgrade:command tsc version check', async () => {
     try {
       await runBin('upgrade', [FIXTURE_APP_PATH, '--tsVersion', ''], { cwd: FIXTURE_APP_PATH });
     } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       expect(`${error}`).to.contain(
         `The tsVersion specified is an invalid string. Please specify a valid version as n.n.n`
       );
@@ -116,6 +117,7 @@ describe('upgrade:command tsc version check', async () => {
     try {
       await runBin('upgrade', [FIXTURE_APP_PATH, '--tsVersion', '0'], { cwd: FIXTURE_APP_PATH });
     } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       expect(`${error}`).to.contain(
         `The tsVersion specified is an invalid string. Please specify a valid version as n.n.n`
       );

--- a/packages/cli/test/helpers/state.test.ts
+++ b/packages/cli/test/helpers/state.test.ts
@@ -13,14 +13,14 @@ function prepareTmpDir(): string {
   return targetDir;
 }
 
-describe('state', async () => {
+describe('state', () => {
   let basePath = '';
 
   beforeEach(() => {
     basePath = prepareTmpDir();
   });
 
-  test('constructor should init state to disk', async () => {
+  test('constructor should init state to disk', () => {
     const configPath = resolve(basePath, 'state.json');
     const { packages, files } = new State('foo', basePath, [], configPath);
 
@@ -30,7 +30,7 @@ describe('state', async () => {
     expect(readJSONSync(configPath)).matchSnapshot();
   });
 
-  test('constructor should load existed state', async () => {
+  test('constructor should load existed state', () => {
     const configPath = resolve(basePath, 'state.json');
     const fooPath = resolve(basePath, 'foo');
     const existedStore: Store = {
@@ -59,7 +59,7 @@ describe('state', async () => {
     expect(readJSONSync(configPath)).toMatchSnapshot();
   });
 
-  test('getVerifiedStore', async () => {
+  test('getVerifiedStore', () => {
     const configPath = resolve(basePath, 'state.json');
     const existedStore: Store = {
       name: 'bar',
@@ -87,7 +87,7 @@ describe('state', async () => {
     expect(readJSONSync(configPath)).toMatchSnapshot();
   });
 
-  test('addFilesToPackages', async () => {
+  test('addFilesToPackages', () => {
     const configPath = resolve(basePath, 'state.json');
     const fooPath = resolve(basePath, 'foo');
 
@@ -103,7 +103,7 @@ describe('state', async () => {
     expect(readJSONSync(configPath)).toMatchSnapshot();
   });
 
-  test('calculateTSIgnoreCount', async () => {
+  test('calculateTSIgnoreCount', () => {
     const foo = '@rehearsal TODO foo bar';
     const fooPath = resolve(basePath, 'foo');
 
@@ -117,7 +117,7 @@ describe('state', async () => {
     expect(calculateTSIgnoreCount(barPath)).toBe(2);
   });
 
-  test('getPackageMigrateProgress', async () => {
+  test('getPackageMigrateProgress', () => {
     const configPath = resolve(basePath, 'state.json');
 
     const fooPath = resolve(basePath, 'foo.ts');
@@ -162,7 +162,7 @@ describe('state', async () => {
     expect(readJSONSync(configPath)).toMatchSnapshot();
   });
 
-  test('getPackageErrorCount', async () => {
+  test('getPackageErrorCount', () => {
     const configPath = resolve(basePath, 'state.json');
 
     const foo = '@rehearsal TODO foo bar';
@@ -181,7 +181,7 @@ describe('state', async () => {
     expect(state.getPackageErrorCount('sample-package')).toStrictEqual(3);
   });
 
-  test('does not contain absolute paths in state file', async () => {
+  test('does not contain absolute paths in state file', () => {
     const configPath = resolve(basePath, 'state.json');
     const fooPath = resolve(basePath, 'foo');
     const barPath = resolve(basePath, 'bar');

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -110,7 +110,7 @@ export async function listrTaskRunner(tasks: ListrTask[]): Promise<MigrateComman
     exitOnError: true,
     renderer: 'verbose',
   };
-  return await new Listr(tasks, defaultListrOption).run();
+  return (await new Listr(tasks, defaultListrOption).run()) as Promise<MigrateCommandContext>;
 }
 
 // keycode for interactive mode test

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -61,7 +61,7 @@ export const beforeEachPrep = async (): Promise<void> => {
   const { current } = await git.branchLocal();
   WORKING_BRANCH = current;
   // install the test version of tsc
-  await execa(PNPM_PATH, ['add', '-w', `typescript@${TEST_TSC_VERSION}`]);
+  await execa(PNPM_PATH, ['add', '-w', '-D', `typescript@${TEST_TSC_VERSION}`]);
   await execa(PNPM_PATH, ['install']);
   // clean any report files
   rmSync(join(FIXTURE_APP_PATH, '.rehearsal'), { recursive: true, force: true });

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/migration-graph-ember/package.json
+++ b/packages/migration-graph-ember/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/migration-graph-shared/package.json
+++ b/packages/migration-graph-shared/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -17,7 +17,6 @@
     "build": "tsc -b",
     "clean": "rm -rf fixtures/ember/*/node_modules",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/regen/package.json
+++ b/packages/regen/package.json
@@ -32,7 +32,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/regen/test/.eslintrc.json
+++ b/packages/regen/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
+  "root": true,
   "parserOptions": {
     "sourceType": "module"
   },

--- a/packages/regen/test/__snapshots__/index.test.ts.snap
+++ b/packages/regen/test/__snapshots__/index.test.ts.snap
@@ -59,6 +59,24 @@ exports[`regen > should generate correct rehearsal comments for a group of files
   {
     \\"analysisTarget\\": \\"tmp/test3.ts\\",
     \\"type\\": 1,
+    \\"ruleId\\": \\"no-unused-vars\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'baz' is assigned a value but never used.\\",
+    \\"hint\\": \\"'baz' is assigned a value but never used.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 11,
+      \\"startColumn\\": 1,
+      \\"endLine\\": 11,
+      \\"endColumn\\": 4
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test3.ts\\",
+    \\"type\\": 1,
     \\"ruleId\\": \\"@typescript-eslint/no-unused-vars\\",
     \\"category\\": \\"Error\\",
     \\"message\\": \\"'baz' is assigned a value but never used.\\",
@@ -95,6 +113,114 @@ exports[`regen > should report lint errors 1`] = `
       \\"startColumn\\": 26,
       \\"endLine\\": 1,
       \\"endColumn\\": 29
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 3,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 3,
+      \\"endColumn\\": 12
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 5,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 5,
+      \\"endColumn\\": 12
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 7,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 7,
+      \\"endColumn\\": 12
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 9,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 9,
+      \\"endColumn\\": 12
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 11,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 11,
+      \\"endColumn\\": 12
+    }
+  },
+  {
+    \\"analysisTarget\\": \\"tmp/test4.ts\\",
+    \\"type\\": 1,
+    \\"ruleId\\": \\"no-undef\\",
+    \\"category\\": \\"Error\\",
+    \\"message\\": \\"'console' is not defined.\\",
+    \\"hint\\": \\"'console' is not defined.\\",
+    \\"hintAdded\\": false,
+    \\"nodeKind\\": \\"Identifier\\",
+    \\"nodeText\\": \\"\\",
+    \\"helpUrl\\": \\"\\",
+    \\"nodeLocation\\": {
+      \\"startLine\\": 13,
+      \\"startColumn\\": 5,
+      \\"endLine\\": 13,
+      \\"endColumn\\": 12
     }
   }
 ]"

--- a/packages/regen/test/fixtures/output/test3.ts.output
+++ b/packages/regen/test/fixtures/output/test3.ts.output
@@ -6,6 +6,6 @@ function add(foo: number, bar: number): number {
 add('5', 10);
 
 /* @ts-expect-error @rehearsal TODO TS6133: The variable 'baz' is never read or used. Remove the variable or use it. */
-let baz: string = '';
+let baz = '';
 /* @ts-expect-error @rehearsal TODO TS2322: The variable 'baz' has type 'string', but 'number' is assigned. Please convert 'number' to 'string' or change variable's type. */
 baz = 2;

--- a/packages/regen/test/fixtures/src/test3.ts
+++ b/packages/regen/test/fixtures/src/test3.ts
@@ -5,5 +5,5 @@ function add(foo: number, bar: number): number {
 /* @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('5' as string)', or using type guard: 'if ('5' instanceof string) { ... }'. */
 add('5', 10);
 
-let baz: string = '';
+let baz = '';
 baz = 2;

--- a/packages/regen/test/index.test.ts
+++ b/packages/regen/test/index.test.ts
@@ -34,6 +34,7 @@ describe('regen', () => {
       sourceFiles: [],
       reporter,
       entrypoint: '',
+      eslintOptions: { cwd: __dirname },
     };
   });
 

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -22,7 +22,6 @@
     "fixtures:prepare": "node ./scripts/setup-fixtures.js ./fixtures/ember/app-template ./fixtures/ember/addon-template",
     "postinstall": "pnpm fixtures:prepare",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/ts-utils/package.json
+++ b/packages/ts-utils/package.json
@@ -32,7 +32,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,6 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "npm-run-all lint:*",
-    "lint:eslint": "eslint --fix . --ext .ts",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
     "test": "vitest --run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,7 @@ importers:
       which: ^3.0.0
       winston: ^3.8.2
       yaml: ^2.2.1
+      zod: ^3.21.4
     dependencies:
       '@microsoft/api-documenter': 7.21.5
       '@rehearsal/migrate': link:../migrate
@@ -171,6 +172,7 @@ importers:
       which: 3.0.0
       winston: 3.8.2
       yaml: 2.2.1
+      zod: 3.21.4
     devDependencies:
       '@rehearsal/test-support': link:../test-support
       '@types/js-yaml': 4.0.5
@@ -5867,3 +5869,7 @@ packages:
       validator: 13.9.0
     optionalDependencies:
       commander: 9.5.0
+
+  /zod/3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,7 +168,6 @@ importers:
       semver: 7.3.8
       simple-git: 3.16.1
       tmp: 0.2.1
-      typescript: 4.9.5
       which: 3.0.0
       winston: 3.8.2
       yaml: 2.2.1
@@ -178,6 +177,7 @@ importers:
       '@types/js-yaml': 4.0.5
       '@types/which': 2.0.2
       fixturify: 3.0.0
+      typescript: 4.9.5
       typescript-json-schema: 0.55.0
       vitest: 0.28.5
 
@@ -5456,6 +5456,7 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /ufo/1.1.0:
     resolution: {integrity: sha512-LQc2s/ZDMaCN3QLpa+uzHUOQ7SdV0qgv3VBXOolQGXTaaZpIur6PwUclF5nN2hNkiTRcUugXd1zFOW3FLJ135Q==}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+   // extend your base config to share compilerOptions, etc
+   "extends": "./tsconfig.base.json",
+   "compilerOptions": {
+     // ensure that nobody can accidentally use this config for a build
+     "noEmit": true
+   },
+}


### PR DESCRIPTION
This is start of the cleanup to fix all the async issues and places where `any` types have leaked into the codebase.

In future PRs we need to expand the packages and files that we use "[recommended-using-type-checking](https://typescript-eslint.io/linting/configs#recommended-requiring-type-checking)"

I also removed the eslint-recommended because the recommended config inherits from it.

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts

## What's Going On Here

We were marking things like tasks as `async` functions but they are actually sync functions that return a task object that has an async task method. With the introduction to this lint config it will point to all of these issues.

<img width="1027" alt="Screenshot 2023-03-14 at 1 03 57 PM" src="https://user-images.githubusercontent.com/183799/225082755-2d1018de-4c9f-43ac-b56e-f53382824a24.png">

<img width="1057" alt="Screenshot 2023-03-14 at 1 04 51 PM" src="https://user-images.githubusercontent.com/183799/225082851-4a68e21a-3dad-422c-a6cb-305862d19e45.png">
