### PR TITLE
fix: use PAS token

### DIFF
--- a/.github/workflows/get-diagnostics.yml
+++ b/.github/workflows/get-diagnostics.yml
@@ -7,9 +7,13 @@ on:
 jobs:
   get_diagnostics:
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.G_ACCESS_TOKEN }}
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
I believe we need to pass in this PAS token so we don't get [protect brach errors](https://github.com/rehearsal-js/rehearsal-js/actions/runs/4462920273/jobs/7837784315). @lynchbomb is there anything special with permissions to use this token?