### PR TITLE
fix: use service to read file text for diagnostics

### DIFF
--- a/packages/migrate/test/fixtures/project/src/salutation.hbs
+++ b/packages/migrate/test/fixtures/project/src/salutation.hbs
@@ -1,0 +1,1 @@
+<span>Hello {{this.name}}</span>

--- a/packages/migrate/test/fixtures/project/src/salutation.js
+++ b/packages/migrate/test/fixtures/project/src/salutation.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Salutation extends Component {
+  @service locale;
+  get name() {
+    if (this.locale.current() == 'en-US') {
+      return 'Bob';
+    }
+    return 'Unknown';
+  }
+}

--- a/packages/plugins/src/plugins/diagnostic-check.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-check.plugin.ts
@@ -45,7 +45,8 @@ export class DiagnosticCheckPlugin implements Plugin<DiagnosticCheckPluginOption
       const hint = hints.getHint(diagnostic);
 
       if (options.addHints) {
-        const text = this.addHintComment(diagnostic, hint, options.commentTag);
+        const text = this.addHintComment(context.service, diagnostic, hint, options.commentTag);
+
         context.service.setFileText(fileName, text);
 
         allFixedFiles.add(fileName);
@@ -162,7 +163,12 @@ export class DiagnosticCheckPlugin implements Plugin<DiagnosticCheckPluginOption
   /**
    * Builds and adds a `@rehearsal` comment above the affected node
    */
-  addHintComment(diagnostic: DiagnosticWithContext, hint: string, tag: string): string {
+  addHintComment(
+    service: Service,
+    diagnostic: DiagnosticWithContext,
+    hint: string,
+    tag: string
+  ): string {
     // Search for a position to add comment - the first element at the line with affected node
     let line = getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start).line;
 
@@ -185,7 +191,7 @@ export class DiagnosticCheckPlugin implements Plugin<DiagnosticCheckPluginOption
     // Make sure the comment is a single because we have to place @ tags right above the issue
     comment = comment.replace(/(\n|\r|\r\n)/gm, ' ');
 
-    const text = diagnostic.file.getFullText();
+    const text = service.getFileText(diagnostic.file.fileName);
 
     return text.slice(0, positionToAddComment) + comment + '\n' + text.slice(positionToAddComment);
   }


### PR DESCRIPTION
Should fix the issue where `migrate` was stalling out when converting TS/HBS file pairs.

When running the `diagnostic-check` plugin, we'd get the file's contents by calling `diagnostic.file.getFullText()`. In regular JS files, this is fine, but when you have a `gjs` file or `ts`/`hbs` pair, `getFullText` returns the Glint-transformed version of the file (which is basically unusable to the rest of rehearsal).

To handle this, we can instead use `service.getFileText` and pass in the filename from `diagnostic.file`.