### PR TITLE
fix: refactor to use json5.parse for read of tsconfig

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,6 @@
     "fs-extra": "^11.1.0",
     "get-tsconfig": "^4.4.0",
     "js-yaml": "^4.1.0",
-    "json5": "2.2.3",
     "listr2": "^5.0.7",
     "minimatch": "^7.4.2",
     "semver": "^7.3.8",

--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -5,9 +5,8 @@ import {
   getMigrationStrategy,
   SourceFile,
 } from '@rehearsal/migration-graph';
-import { determineProjectName } from '@rehearsal/utils';
+import { determineProjectName, readTSConfig, writeTSConfig } from '@rehearsal/utils';
 import debug from 'debug';
-import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import { ListrDefaultRenderer, ListrTask } from 'listr2';
 import { minimatch } from 'minimatch';
 import { State } from '../../../helpers/state.js';
@@ -162,7 +161,6 @@ export function analyzeTask(
     },
   };
 }
-
 /**
  * Update "include" in tsconfig.json
  * @param fileList array of relative file paths to the root
@@ -170,7 +168,7 @@ export function analyzeTask(
  */
 export function addFilesToIncludes(fileList: string[], configPath: string): void {
   if (existsSync(configPath)) {
-    const tsConfig = readJSONSync(configPath) as TSConfig;
+    const tsConfig = readTSConfig<TSConfig>(configPath);
     if (!tsConfig.include) {
       tsConfig.include = fileList;
     } else if (Array.isArray(tsConfig.include) && !tsConfig.include.length) {
@@ -187,6 +185,6 @@ export function addFilesToIncludes(fileList: string[], configPath: string): void
       });
       tsConfig.include = [...tsConfig.include, ...uniqueFiles];
     }
-    writeJSONSync(configPath, tsConfig, { spaces: 2 });
+    writeTSConfig(configPath, tsConfig);
   }
 }

--- a/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
@@ -1,5 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Helper: addFilesToIncludes > parse tsconfig.json that has a comment /**/ block 1`] = `
+"{
+  \\"include\\": []
+}
+"
+`;
+
 exports[`Task: analyze > accept --package option to skip the selection 1`] = `
 [
   "foo.js",

--- a/packages/cli/test/commands/migrate/convert.test.ts
+++ b/packages/cli/test/commands/migrate/convert.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { readdirSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { readJSONSync } from 'fs-extra/esm';
+import { readTSConfig } from '@rehearsal/utils';
 import { simpleGit, type SimpleGitOptions } from 'simple-git';
 import { createLogger, format, transports } from 'winston';
 
@@ -87,7 +87,7 @@ describe('Task: convert', () => {
     expect(fileList).not.toContain('foo.js');
     expect(fileList).not.toContain('depends-on-foo.js');
 
-    const config = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+    const config = readTSConfig<TSConfig>(resolve(project.baseDir, 'tsconfig.json'));
     expect(config.include).toContain('index.ts');
     expect(config.include).toContain('foo.ts');
     expect(config.include).toContain('depends-on-foo.ts');
@@ -118,7 +118,7 @@ describe('Task: convert', () => {
     expect(fileList).not.toContain('depends-on-foo.js');
     expect(fileList).not.toContain('foo.js');
 
-    const config = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+    const config = readTSConfig<TSConfig>(resolve(project.baseDir, 'tsconfig.json'));
     expect(config.include).toContain('depends-on-foo.ts');
     expect(config.include).toContain('foo.ts');
   });

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -1,14 +1,15 @@
 import { resolve } from 'node:path';
 import { readFileSync, readdirSync, promises as fs } from 'node:fs';
-import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
+import { writeJSONSync } from 'fs-extra/esm';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { getFiles } from '@rehearsal/test-support';
 import yaml from 'js-yaml';
 import { Project } from 'fixturify-project';
+import { readTSConfig } from '@rehearsal/utils';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install.js';
 
 import { runBin, prepareProject, cleanOutput } from '../../test-helpers/index.js';
-import { CustomConfig, TSConfig } from '../../../src/types.js';
+import { CustomConfig } from '../../../src/types.js';
 import type { PackageJson } from 'type-fest';
 
 describe('migrate - validation', () => {
@@ -219,7 +220,7 @@ describe('migrate: e2e', () => {
     expect(readdirSync(reportPath)).toContain('migrate-report.sarif');
 
     // tsconfig.json
-    const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+    const tsConfig = readTSConfig(resolve(project.baseDir, 'tsconfig.json'));
     expect(tsConfig).matchSnapshot();
 
     // lint config
@@ -254,7 +255,7 @@ describe('migrate: e2e', () => {
     expect(Object.keys(devDeps || {}).sort()).toEqual(REQUIRED_DEPENDENCIES.sort());
 
     // tsconfig.json
-    const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+    const tsConfig = readTSConfig(resolve(project.baseDir, 'tsconfig.json'));
     expect(tsConfig).matchSnapshot();
 
     // lint config

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -186,8 +186,7 @@ export function isPackageSelection(currentLine: string): boolean {
 
 // check if current line is the prompt message for selecting Accept/Edit/Discard in interactive mode
 export function isActionSelection(currentLine: string): boolean {
-  const promptRegex =
-    /Select an option to continue:/gm;
+  const promptRegex = /Select an option to continue:/gm;
   return (
     promptRegex.test(currentLine) &&
     currentLine.includes('Accept') &&

--- a/packages/cli/test/test-helpers/init-command-test-utils.ts
+++ b/packages/cli/test/test-helpers/init-command-test-utils.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { readFileSync, readdirSync, promises as fs } from 'node:fs';
-import { readJSONSync, writeJSONSync } from 'fs-extra';
+import { readTSConfig } from '@rehearsal/utils';
+import { writeJSONSync } from 'fs-extra';
 
 import { TSConfig, CustomConfig } from '../../src/types.js';
 import { runBin } from './index.js';
@@ -49,7 +50,7 @@ export async function runDefault(basePath: string): Promise<DefaultRunType> {
 
   const devDeps = packageJson.devDependencies;
 
-  const tsConfig = readJSONSync(resolve(basePath, 'tsconfig.json')) as TSConfig;
+  const tsConfig = readTSConfig<TSConfig>(resolve(basePath, 'tsconfig.json'));
   const lintConfig = readFileSync(resolve(basePath, '.eslintrc.js'), { encoding: 'utf-8' });
   const lintConfigDefault = readFileSync(resolve(basePath, '.rehearsal-eslintrc.js'), {
     encoding: 'utf-8',

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -156,7 +156,7 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
       reportErrors: true,
     });
 
-  yield *runner.run(fileNames, { log: (message) => (listrTask.output = message) });
+  yield* runner.run(fileNames, { log: (message) => (listrTask.output = message) });
   // save report after all yields
   reporter.saveCurrentRunToReport(basePath, entrypoint);
 }

--- a/packages/regen/src/regen.ts
+++ b/packages/regen/src/regen.ts
@@ -96,7 +96,7 @@ export async function regen(input: RegenInput): Promise<RegenOutput> {
   for await (const _ of runner.run(fileNames, { log: (message) => (listrTask.output = message) })) {
     // no ops for yield
   }
-  
+
   reporter.saveCurrentRunToReport(basePath, input.entrypoint || '');
 
   return {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,6 +46,7 @@
     "execa": "^7.0.0",
     "findup-sync": "^5.0.0",
     "fs-extra": "^11.1.0",
+    "get-tsconfig": "^4.4.0",
     "glob": "^8.1.0",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
@@ -61,6 +62,9 @@
     "fixturify": "^3.0.0",
     "tmp": "^0.2.1",
     "vitest": "^0.29.2"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0"
   },
   "packageManager": "pnpm@7.12.1",
   "engines": {

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -96,6 +96,10 @@ export function readJSON<T>(file: string): T | undefined {
   }
 }
 
+export function writeJSON<T>(file: string, contents: T | unknown): void {
+  writeJSONSync(file, contents, { spaces: 2 });
+}
+
 export function readText(file: string): string | undefined {
   return readFile(file, 'utf8');
 }
@@ -420,26 +424,39 @@ export function validateUserConfig(basePath: string, userConfigPath: string): bo
 }
 
 /**
+ * Reads a tsConfig file
+ * @param configPath
+ * @returns
+ */
+export function readTSConfig<T>(configPath: string): T {
+  return json5.parse(readFileSync(configPath, 'utf-8'));
+}
+
+/**
  * Generate tsconfig
  */
-export function writeTSConfig(basePath: string): void {
-  const config = {
-    $schema: 'https://json.schemastore.org/tsconfig',
-    compilerOptions: {
-      strict: true,
-      esModuleInterop: true,
-      noUncheckedIndexedAccess: true,
-      module: 'es2020',
-      moduleResolution: 'node',
-      newLine: 'lf',
-      target: 'ES2021',
-      forceConsistentCasingInFileNames: true,
-      noFallthroughCasesInSwitch: true,
-      noEmit: true,
-    },
-  };
 
-  writeJSONSync(resolve(basePath, 'tsconfig.json'), config, { spaces: 2 });
+export const DEFAULT_TS_CONFIG = {
+  $schema: 'https://json.schemastore.org/tsconfig',
+  compilerOptions: {
+    strict: true,
+    esModuleInterop: true,
+    noUncheckedIndexedAccess: true,
+    module: 'es2020',
+    moduleResolution: 'node',
+    newLine: 'lf',
+    target: 'ES2021',
+    forceConsistentCasingInFileNames: true,
+    noFallthroughCasesInSwitch: true,
+    noEmit: true,
+  },
+};
+
+export function writeTSConfig(configPath: string, config: unknown): void {
+  configPath = configPath.endsWith('tsconfig.json')
+    ? configPath
+    : resolve(configPath, 'tsconfig.json');
+  writeJSON(configPath, config);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,6 @@ importers:
       fs-extra: ^11.1.0
       get-tsconfig: ^4.4.0
       js-yaml: ^4.1.0
-      json5: 2.2.3
       listr2: ^5.0.7
       minimatch: ^7.4.2
       scenario-tester: ^2.1.2
@@ -165,7 +164,6 @@ importers:
       fs-extra: 11.1.0
       get-tsconfig: 4.4.0
       js-yaml: 4.1.0
-      json5: 2.2.3
       listr2: 5.0.7_enquirer@2.3.6
       minimatch: 7.4.2
       semver: 7.3.8
@@ -534,6 +532,7 @@ importers:
       findup-sync: ^5.0.0
       fixturify: ^3.0.0
       fs-extra: ^11.1.0
+      get-tsconfig: ^4.4.0
       glob: ^8.1.0
       js-yaml: ^4.1.0
       json5: ^2.2.3
@@ -551,6 +550,7 @@ importers:
       execa: 7.0.0
       findup-sync: 5.0.0
       fs-extra: 11.1.0
+      get-tsconfig: 4.4.0
       glob: 8.1.0
       js-yaml: 4.1.0
       json5: 2.2.3


### PR DESCRIPTION
In parts of CLI package we were using `readJSONSync` from `fs` for reading `tsconfig.json`. This doesn't work for `.json` files that have comments, or unquoted keys.

See #876 for example where an internal `tsconfig.json` from the jeeves task created config with a comment.

### Added
- **packages/util/** Add `readTSConfig` method using `json5.parse()`
### Changed
- **packages/util** Refactored `writeTSConfig()` to allow for passing of a config data. Expose defaults at DEFAULT_TS_CONFIG.
- **packages/cli** Refactor usages where reading and writing to `tsconfig.json` to use  `readTSConfig` and `writeTSConfig` from `@rehearsal/util`.
- **packages/cli** Refactor tests in `analyze.test.ts` to setup and tear down projects more succinctly using the fixturify API.

### Removed
- Usage of `json5` in **packages/cli** as it's no longer used.

Notes: 
- We should not not drop usage `get-tsconfig` as it it collapses and resolved the tsconfig down to it's final shape. This is critical in it's use case.
- We can't use `get-tsconfig` everywhere because it expands all globs patterns for the tsconfig.include property, which is not what we want in most cases.