### PR TITLE
feat(cli): clear messages in bottom bar after completion

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -113,7 +113,7 @@ export function lintConfigTask(
         }
       }
     },
-    options: { persistentOutput: true, bottomBar: Infinity },
+    options: { persistentOutput: false, bottomBar: Infinity },
   };
 }
 

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -70,6 +70,6 @@ export function tsConfigTask(
         }
       }
     },
-    options: { persistentOutput: true, bottomBar: Infinity },
+    options: { persistentOutput: false, bottomBar: Infinity },
   };
 }

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -119,7 +119,7 @@ export function depInstallTask(
       }
     },
     // will print and keep what dpe is currently installing at bottom bar
-    options: { persistentOutput: true, bottomBar: Infinity },
+    options: { persistentOutput: false, bottomBar: Infinity },
   };
 }
 


### PR DESCRIPTION
![Screenshot 2023-03-26 at 11 19 51](https://user-images.githubusercontent.com/2744803/227796016-9873e274-932f-4a27-b088-326c4583790e.png)

Clear bottom bar messages after completion. e.g. the `tsconfig.json already exists` message at the bottom in the above screenshot should be removed after it's done.
