### PR TITLE
chore(ci): test against typescript nightly

### DIFF
--- a/.github/failed_cron_job_issue_template.md
+++ b/.github/failed_cron_job_issue_template.md
@@ -1,0 +1,11 @@
+---
+title: Scheduled GitHub Action Failed
+labels: bug, ts-nightly
+---
+
+Oh no, something went wrong in the rehearsal scheduled workflow for {{ env.WORKFLOW }}/{{ env.JOB }}.
+Please look into it:
+
+https://github.com/{{ env.REPO }}/actions/runs/{{ env.ID }}
+
+Feel free to close this issue if this was just a one-off error.

--- a/.github/workflows/ts-nightly-test.yml
+++ b/.github/workflows/ts-nightly-test.yml
@@ -51,3 +51,14 @@ jobs:
         run: pnpm lint
       - name: Test Slow
         run: pnpm test:slow
+      - uses: JasonEtco/create-an-issue@v2
+        name: Create GitHub issue if tests fail
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: ${{ secrets.G_ACCESS_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          JOB: ${{ github.job }}
+          ID: ${{ github.run_id }}
+        with:
+          filename: .github/failed_cron_job_issue_template.md

--- a/.github/workflows/ts-nightly-test.yml
+++ b/.github/workflows/ts-nightly-test.yml
@@ -1,14 +1,12 @@
-name: Test Suite
+name: TypeScript Nightly Test
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+  schedule: # Run every day at midnight
+    - cron: '0 0 * * *'
 
 jobs:
-  test-and-lint:
-    name: Runs Entire Test Suite with Linting
+  test-ts-nightly:
+    name: TypeScript Nightly - Runs Entire Test Suite with Linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,6 +43,8 @@ jobs:
             ${{ runner.os }}-npm-store-
       - name: Install dependencies
         run: pnpm install
+      - name: Install TypeScript Nightly
+        run: pnpm add -d -w typescript@next
       - name: Build
         run: pnpm build
       - name: Lint


### PR DESCRIPTION
> @chadhietala 
> This adds a github action job to run the entire test suite against nightly builds of TypeScript. Ideally in the future we should use rehearsal it self to do this but this will have to work until then.
> 
> This will allows us to get ahead of any breakage since we generously use the compiler api.

This PR includes running typescript@next on a daily cron job rather than against every PR. As TypeScript could introduce a bug in the nightly build which could block PR's.

Replaces #854 