### PR TITLE
feat(cli): package option

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -30,7 +30,7 @@ migrateCommand
   // always use default process.cwd()
   .addCommand(initCommand)
   .addOption(
-    new Option('-p, --basePath <project base path>', 'base directory of your project')
+    new Option('-b, --basePath <project base path>', 'base directory of your project')
       .default(process.cwd())
       // use argParser to ensure process.cwd() is basePath
       // even use passes anything accidentally
@@ -48,7 +48,7 @@ migrateCommand
     ''
   )
   .option(
-    '-p, --package <packageName>',
+    '-p, --package <relative path to target package>',
     `run migrate againt a specific package in your project(${process.cwd()}) `,
     ''
   )

--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -48,6 +48,11 @@ migrateCommand
     ''
   )
   .option(
+    '-p, --package <packageName>',
+    `run migrate againt a specific package in your project(${process.cwd()}) `,
+    ''
+  )
+  .option(
     '-f, --format <format>',
     'report format separated by comma, e.g. -f json,sarif,md,sonarqube',
     parseCommaSeparatedList,

--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -33,77 +33,98 @@ export function analyzeTask(
       const projectName = determineProjectName(options.basePath);
       const packages = discoverEmberPackages(options.basePath);
 
-      if (!options.ci) {
-        const state = new State(
-          projectName,
-          options.basePath,
-          packages.map((p) => p.path) // use relative path
-        );
-
-        ctx.state = state;
-
-        const packageSelections: PackageSelection[] = packages.map((p) => {
-          return {
-            name: p.packageName,
-            path: p.path,
-          };
-        });
-
-        // Get the menu text for each package during interactive mode to show:
-        // 1. package has not started any migration before -> no progress found
-        // 2. package had a migration with remaining JS files -> x/x migrated, x rehearsal todos
-        // 3. package had a full migration with rehearsal todos -> all migrated, x rehearsal todos
-        // 4. fully migrated with no JS and rehearsal todo -> do not show the option
-        const menuList = packageSelections.map((p) => {
-          const { migratedFileCount, totalFileCount, isCompleted } =
-            ctx.state.getPackageMigrateProgress(
-              p.path // pacakge fullpath is the key of the packageMap in state
-            );
-          const errorCount = ctx.state.getPackageErrorCount(p.path);
-          // default text to show per package
-          let progressText = `no progress found`;
-          let icon = '';
-          let isOptionDisabled = false;
-          if (totalFileCount !== 0) {
-            // has previous migratoin
-            progressText = `${migratedFileCount} of ${totalFileCount} files migrated, ${errorCount} @ts-expect-error(s) need to be fixed`;
-            icon = IN_PROGRESS_MARK;
-
-            if (isCompleted && errorCount === 0) {
-              icon = COMPLETION_MARK;
-              progressText = `Fully migrated`;
-              isOptionDisabled = true;
-            }
-          }
-          return {
-            name: `${p.name}(${progressText})${icon}`,
-            message: `${p.name}(${progressText})${icon}`,
-            value: p.path,
-            disabled: isOptionDisabled,
-          };
-        });
-
-        // use a map (option display name -> package location pair) to solve an enquirer bug
-        // https://github.com/enquirer/enquirer/issues/121
-        const menuMap = menuList.reduce((map, current) => {
-          map[current.name] = current.value;
-          return map;
-        }, {} as MenuMap);
-
-        ctx.input = await task.prompt([
-          {
-            type: 'Select',
-            name: 'packageSelection',
-            message: 'We have found multiple packages in your project, select the one to migrate:',
-            choices: menuList,
-          },
-        ]);
-        // update basePath based on the selection
-        ctx.targetPackagePath = menuMap[ctx.input as string];
-        task.output = `Running migration on ${ctx.targetPackagePath}`;
+      if (options.package) {
+        // If user passes package option,
+        // make sure it's a valid dir inside current project
+        // and there is package.json inside
+        if (
+          !existsSync(resolve(options.basePath, options.package)) ||
+          !existsSync(resolve(options.basePath, options.package, 'package.json'))
+        ) {
+          throw Error(
+            `Cannot find package ${options.package} in your project. Please make sure it is a valid package and try again.`
+          );
+        }
+        // set targetPackagePath to the absolute path or the package and continue
+        ctx.targetPackagePath = resolve(options.basePath, options.package);
+        task.output = `Running migration on package ${options.package}`;
       } else {
-        ctx.targetPackagePath = options.basePath;
-        task.output = `Running migration on ${projectName || 'project'}`;
+        // no package option
+        if (!options.ci) {
+          const state = new State(
+            projectName,
+            options.basePath,
+            packages.map((p) => p.path) // use relative path
+          );
+
+          ctx.state = state;
+
+          const packageSelections: PackageSelection[] = packages.map((p) => {
+            return {
+              name: p.packageName,
+              path: p.path,
+            };
+          });
+
+          // Get the menu text for each package during interactive mode to show:
+          // 1. package has not started any migration before -> no progress found
+          // 2. package had a migration with remaining JS files -> x/x migrated, x rehearsal todos
+          // 3. package had a full migration with rehearsal todos -> all migrated, x rehearsal todos
+          // 4. fully migrated with no JS and rehearsal todo -> do not show the option
+          const menuList = packageSelections.map((p) => {
+            const { migratedFileCount, totalFileCount, isCompleted } =
+              ctx.state.getPackageMigrateProgress(
+                p.path // pacakge fullpath is the key of the packageMap in state
+              );
+            const errorCount = ctx.state.getPackageErrorCount(p.path);
+            // default text to show per package
+            let progressText = `no progress found`;
+            let icon = '';
+            let isOptionDisabled = false;
+            if (totalFileCount !== 0) {
+              // has previous migratoin
+              progressText = `${migratedFileCount} of ${totalFileCount} files migrated, ${errorCount} @ts-expect-error(s) need to be fixed`;
+              icon = IN_PROGRESS_MARK;
+
+              if (isCompleted && errorCount === 0) {
+                icon = COMPLETION_MARK;
+                progressText = `Fully migrated`;
+                isOptionDisabled = true;
+              }
+            }
+            return {
+              name: `${p.name}(${progressText})${icon}`,
+              message: `${p.name}(${progressText})${icon}`,
+              value: p.path,
+              disabled: isOptionDisabled,
+            };
+          });
+
+          // use a map (option display name -> package location pair) to solve an enquirer bug
+          // https://github.com/enquirer/enquirer/issues/121
+          const menuMap = menuList.reduce((map, current) => {
+            map[current.name] = current.value;
+            return map;
+          }, {} as MenuMap);
+
+          ctx.input = await task.prompt([
+            {
+              type: 'Select',
+              name: 'packageSelection',
+              message:
+                'We have found multiple packages in your project, select the one to migrate:',
+              choices: menuList,
+            },
+          ]);
+          // update basePath based on the selection
+          ctx.targetPackagePath = menuMap[ctx.input as string];
+          task.output = JSON.stringify(menuMap);
+          task.output = ctx.input as string;
+          task.output = `Running migration on ${ctx.targetPackagePath}`;
+        } else {
+          ctx.targetPackagePath = options.basePath;
+          task.output = `Running migration on ${projectName || 'project'}`;
+        }
       }
 
       // construct migration strategy and prepare all the files needs to be migrated

--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -118,8 +118,6 @@ export function analyzeTask(
           ]);
           // update basePath based on the selection
           ctx.targetPackagePath = menuMap[ctx.input as string];
-          task.output = JSON.stringify(menuMap);
-          task.output = ctx.input as string;
           task.output = `Running migration on ${ctx.targetPackagePath}`;
         } else {
           ctx.targetPackagePath = options.basePath;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -11,6 +11,7 @@ export type MigrateCommandOptions = {
   skipInit: boolean;
   basePath: string;
   entrypoint: string;
+  package: string;
   format: Formats[];
   outputPath: string;
   verbose: boolean | undefined;

--- a/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Task: analyze > accept --package option to skip the selection 1`] = `
+[
+  "foo.js",
+  "depends-on-foo.js",
+  "index.js",
+]
+`;
+
+exports[`Task: analyze > accept --package option to skip the selection 2`] = `
+"[STARTED] Analyzing Project
+[DATA] Running migration on package .
+[SUCCESS] Analyzing Project
+"
+`;
+
 exports[`Task: analyze > add files in tsconfig.json include 1`] = `
 {
   "include": [


### PR DESCRIPTION
Fixes #576

- Add new option `-p, --package` for pass package to the CLI
  - In CI mode, now we can run migrate on a specific package
  - In Non CI mode, pass a valid package will skip the "package selection" prompt
- Rename `-p --basePath` to `-b --basePath` to remove the conflict, we don't use and expose `--basePath` now so it should be good.