### PR TITLE
fix(service): move test-support to devDep

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@rehearsal/reporter": "workspace:*",
-    "@rehearsal/test-support": "workspace:*",
     "@rehearsal/utils": "workspace:*",
     "findup-sync": "^5.0.0",
     "vscode-languageserver": "^8.1.0",
@@ -47,7 +46,8 @@
     "winston": "^3.8.2"
   },
   "devDependencies": {
-    "vitest": "^0.29.2"
+    "vitest": "^0.29.2",
+    "@rehearsal/test-support": "workspace:*"
   },
   "peerDependencies": {
     "@glint/core": "1.0.0-beta.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,13 +429,13 @@ importers:
       winston: ^3.8.2
     dependencies:
       '@rehearsal/reporter': link:../reporter
-      '@rehearsal/test-support': link:../test-support
       '@rehearsal/utils': link:../utils
       findup-sync: 5.0.0
       vscode-languageserver: 8.1.0
       vscode-uri: 3.0.7
       winston: 3.8.2
     devDependencies:
+      '@rehearsal/test-support': link:../test-support
       vitest: 0.29.5
 
   packages/test-support:


### PR DESCRIPTION
This PR fixes an incorrect import of @rehearsal/test-support as a bundled dependency of @rehearsal/service. This should be a dev-dependency only.