### PR TITLE
chore: extends hookTimeout

### DIFF
--- a/packages/cli/vitest.config.slow.ts
+++ b/packages/cli/vitest.config.slow.ts
@@ -8,7 +8,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testTimeout: 100_000_000,
-    hookTimeout: 50_000,
+    hookTimeout: 100_000_000,
     watchExclude: ['package.json', '**/fixtures/**'],
   },
 });


### PR DESCRIPTION
hookTimeout is causing slow test to fail. See: https://github.com/rehearsal-js/rehearsal-js/actions/runs/4545066769/jobs/8011901026?pr=875

This PR will unblock [PR #875](https://github.com/rehearsal-js/rehearsal-js/pull/875)