### PR TITLE
fix: unable to get bin path with npm@9

### DIFF
--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -60,6 +60,8 @@ describe('utils', () => {
     expect(end).toBeGreaterThan(start);
   });
 
+  // TODO: add tests for different scenarios
+  // e.g. multiple package managers existed with different version
   test('getPathToBinary()', async () => {
     const project = new Project('my-project', '0.0.0', {
       files: {


### PR DESCRIPTION
We cannot rely on using `<package manager> bin` to get the bin dir for executables, since `npm>=9` already dropped the subcommand `bin`.

Assuming there is a executable `foo`:
I think it still better to try `<package manager> bin foo` first, then fallback to check if `foo` exists in `node_modules/.bin/foo` and return `node_modules/.bin` as the dir.

It is complicated to test in different scenarios, since we need to create "fake" `npm/yarn/pnpm` with different versions. There would be a high risk to pollute other tests and cause conflict so I just added a TODO in the test.