### PR TITLE
test: add config-ts ember tests

### DIFF
--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
@@ -52,3 +52,19 @@ exports[`Task: config-ts ember app > emberAddon > skip if tsconfig.json exists w
 [SKIPPED] Create tsconfig.json
 "
 `;
+
+exports[`Task: config-ts ember app > emberAddon > update tsconfig if exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAddon > update tsconfig if invalid extends exist 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Task: config-ts ember app > emberAddon > create tsconfig if not existed 1`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2021",
+  },
+}
+`;
+
+exports[`Task: config-ts ember app > emberAddon > create tsconfig if not existed 2`] = `
+"[STARTED] Create tsconfig.json
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAddon > postTsSetup hook from user config 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[DATA] Run postTsSetup from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAddon > run custom config command with user config provided 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAddon > skip custom config command 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAddon > skip if tsconfig.json exists with strict on 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
@@ -1,0 +1,202 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Task: config-ts ember app > emberApp > create tsconfig if not existed 1`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "importsNotUsedAsValues": "error",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "preserveValueImports": true,
+    "strict": true,
+    "target": "es2020",
+  },
+  "display": "Ember App",
+  "extends": "../base.tsconfig.json",
+  "glint": {
+    "environment": {
+      "ember-loose": {},
+      "ember-template-imports": {},
+    },
+  },
+}
+`;
+
+exports[`Task: config-ts ember app > emberApp > create tsconfig if not existed 2`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberApp > postTsSetup hook from user config 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[DATA] Run postTsSetup from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberApp > run custom config command with user config provided 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberApp > skip custom config command 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberApp > skip if tsconfig.json exists with strict on 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > create tsconfig if not existed 1`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "importsNotUsedAsValues": "error",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "preserveValueImports": true,
+    "strict": true,
+    "target": "es2020",
+  },
+  "display": "Ember App",
+  "extends": "../base.tsconfig.json",
+  "glint": {
+    "environment": {
+      "ember-loose": {},
+      "ember-template-imports": {},
+    },
+  },
+}
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > create tsconfig if not existed 2`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > postTsSetup hook from user config 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[DATA] Run postTsSetup from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > run custom config command with user config provided 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > skip custom config command 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > skip if tsconfig.json exists with strict on 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig if not existed 1`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "importsNotUsedAsValues": "error",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "preserveValueImports": true,
+    "strict": true,
+    "target": "es2020",
+  },
+  "display": "Ember App",
+  "extends": "../base.tsconfig.json",
+  "glint": {
+    "environment": {
+      "ember-loose": {},
+      "ember-template-imports": {},
+    },
+  },
+}
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig if not existed 2`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > postTsSetup hook from user config 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[DATA] Run postTsSetup from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > run custom config command with user config provided 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip custom config command 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip if tsconfig.json exists with strict on 1`] = `
+"[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+[STARTED] Create tsconfig.json
+[SKIPPED] Create tsconfig.json
+"
+`;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
@@ -67,6 +67,22 @@ exports[`Task: config-ts ember app > emberApp > skip if tsconfig.json exists wit
 "
 `;
 
+exports[`Task: config-ts ember app > emberApp > update tsconfig if exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberApp > update tsconfig if invalid extends exist 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberAppWithInRepoAddon > create tsconfig if not existed 1`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",
@@ -134,6 +150,22 @@ exports[`Task: config-ts ember app > emberAppWithInRepoAddon > skip if tsconfig.
 "
 `;
 
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > update tsconfig if exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > update tsconfig if invalid extends exist 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig if not existed 1`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",
@@ -198,5 +230,21 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip if tsconfig
 [SKIPPED] Create tsconfig.json
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > update tsconfig if exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
+"
+`;
+
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > update tsconfig if invalid extends exist 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
+[TITLE] Update tsconfig.json
+[SUCCESS] Update tsconfig.json
 "
 `;

--- a/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
@@ -25,11 +25,13 @@ describe('Task: config-ts ember app', () => {
         await project.write();
 
         output = '';
-        vi.spyOn(console, 'info').mockImplementation((chunk) => {
+        vi.spyOn(console, 'info').mockImplementation((chunk: string) => {
+          chunk = chunk.replace(new RegExp(`${project.baseDir}`, 'g'), '<tmp-path>');
           output += `${chunk}\n`;
         });
 
-        vi.spyOn(console, 'log').mockImplementation((chunk) => {
+        vi.spyOn(console, 'log').mockImplementation((chunk: string) => {
+          chunk = chunk.replace(new RegExp(`${project.baseDir}`, 'g'), '<tmp-path>');
           output += `${chunk}\n`;
         });
       });
@@ -61,8 +63,7 @@ describe('Task: config-ts ember app', () => {
         const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
 
         expect(tsConfig.compilerOptions.strict).toBeTruthy();
-        // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('ensuring strict mode is enabled');
+        expect(output).toMatchSnapshot();
       });
 
       test('update tsconfig if invalid extends exist', async () => {
@@ -75,8 +76,7 @@ describe('Task: config-ts ember app', () => {
         const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
 
         expect(tsConfig.compilerOptions.strict).toBeTruthy();
-        // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('ensuring strict mode is enabled');
+        expect(output).toMatchSnapshot();
       });
 
       test('skip if tsconfig.json exists with strict on', async () => {
@@ -148,7 +148,6 @@ describe('Task: config-ts ember app', () => {
         const tasks = [tsConfigTask(options, { userConfig })];
         await listrTaskRunner(tasks);
 
-        // This proves the custom command and hook works
         expect(readdirSync(project.baseDir)).toContain('foo');
         expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
         expect(output).toMatchSnapshot();

--- a/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
@@ -1,0 +1,158 @@
+import { resolve } from 'node:path';
+import { readdirSync } from 'node:fs';
+import { afterEach, beforeEach, afterAll, describe, expect, test, vi } from 'vitest';
+import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
+import { getEmberAddonProject } from '@rehearsal/test-support';
+import { Project } from 'fixturify-project';
+import { tsConfigTask } from '../../../src/commands/migrate/tasks/index.js';
+import { listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
+import { runTsConfig, createUserConfig } from '../../test-helpers/config-ts-test-utils.js';
+import { TSConfig } from '../../../src/types.js';
+import { UserConfig } from '../../../src/user-config.js';
+
+const projects = {
+  emberAddon: getEmberAddonProject(),
+};
+
+describe('Task: config-ts ember app', () => {
+  for (const [name, originalProject] of Object.entries(projects)) {
+    describe(name, () => {
+      let project: Project;
+      let output = '';
+
+      beforeEach(async () => {
+        project = originalProject.clone();
+        await project.write();
+
+        output = '';
+        vi.spyOn(console, 'info').mockImplementation((chunk) => {
+          output += `${chunk}\n`;
+        });
+
+        vi.spyOn(console, 'log').mockImplementation((chunk) => {
+          output += `${chunk}\n`;
+        });
+      });
+
+      afterEach(() => {
+        vi.clearAllMocks();
+        output = '';
+        project.dispose();
+      });
+
+      afterAll(() => {
+        originalProject.dispose();
+      });
+
+      test('create tsconfig if not existed', async () => {
+        await runTsConfig(project.baseDir);
+
+        expect(readJSONSync(resolve(project.baseDir, 'tsconfig.json'))).matchSnapshot();
+        expect(output).matchSnapshot();
+      });
+
+      test('update tsconfig if exists', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: false } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+
+        const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+
+        expect(tsConfig.compilerOptions.strict).toBeTruthy();
+        // Do not use snapshot here since there is absolute path in output
+        expect(output).toContain('ensuring strict mode is enabled');
+      });
+
+      test('update tsconfig if invalid extends exist', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { extends: 'invalid-tsconfig.json' };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+
+        const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+
+        expect(tsConfig.compilerOptions.strict).toBeTruthy();
+        // Do not use snapshot here since there is absolute path in output
+        expect(output).toContain('ensuring strict mode is enabled');
+      });
+
+      test('skip if tsconfig.json exists with strict on', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: true } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+        await runTsConfig(project.baseDir); //should be skipped
+
+        expect(output).toMatchSnapshot();
+      });
+
+      test('run custom config command with user config provided', async () => {
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+            },
+          },
+        });
+
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
+
+        // This proves the custom command works
+        expect(readdirSync(project.baseDir)).toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+
+      test('skip custom config command', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: true } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+            },
+          },
+        });
+
+        await runTsConfig(project.baseDir, { userConfig: 'rehearsal-config.json' });
+
+        // This proves the custom command works not triggered
+        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+
+      test('postTsSetup hook from user config', async () => {
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+              postTsSetup: { command: 'mv', args: ['custom-ts-config-script', 'foo'] },
+            },
+          },
+        });
+
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
+
+        // This proves the custom command and hook works
+        expect(readdirSync(project.baseDir)).toContain('foo');
+        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+    });
+  }
+});

--- a/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
@@ -32,11 +32,12 @@ describe('Task: config-ts ember app', () => {
         output = '';
 
         vi.spyOn(console, 'info').mockImplementation((chunk: string) => {
-          chunk = chunk.replace(new RegExp(project.baseDir, 'g'), '<tmp-path>');
+          chunk = chunk.replace(new RegExp(`${project.baseDir}`, 'g'), '<tmp-path>');
           output += `${chunk}\n`;
         });
 
-        vi.spyOn(console, 'log').mockImplementation((chunk) => {
+        vi.spyOn(console, 'log').mockImplementation((chunk: string) => {
+          chunk = chunk.replace(new RegExp(`${project.baseDir}`, 'g'), '<tmp-path>');
           output += `${chunk}\n`;
         });
       });
@@ -68,8 +69,7 @@ describe('Task: config-ts ember app', () => {
         const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
 
         expect(tsConfig.compilerOptions.strict).toBeTruthy();
-        // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('ensuring strict mode is enabled');
+        expect(output).toMatchSnapshot();
       });
 
       test('update tsconfig if invalid extends exist', async () => {
@@ -82,8 +82,7 @@ describe('Task: config-ts ember app', () => {
         const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
 
         expect(tsConfig.compilerOptions.strict).toBeTruthy();
-        // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('ensuring strict mode is enabled');
+        expect(output).toMatchSnapshot();
       });
 
       test('skip if tsconfig.json exists with strict on', async () => {

--- a/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
@@ -1,0 +1,165 @@
+import { resolve } from 'node:path';
+import { readdirSync } from 'node:fs';
+import { afterEach, beforeEach, afterAll, describe, expect, test, vi } from 'vitest';
+import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
+import {
+  getEmberAppProject,
+  getEmberAppWithInRepoAddonProject,
+  getEmberAppWithInRepoEngineProject,
+} from '@rehearsal/test-support';
+import { Project } from 'fixturify-project';
+import { tsConfigTask } from '../../../src/commands/migrate/tasks/index.js';
+import { listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
+import { runTsConfig, createUserConfig } from '../../test-helpers/config-ts-test-utils.js';
+import { TSConfig } from '../../../src/types.js';
+import { UserConfig } from '../../../src/user-config.js';
+
+const projects = {
+  emberApp: getEmberAppProject(),
+  emberAppWithInRepoAddon: getEmberAppWithInRepoAddonProject(),
+  emberAppwithInRepoEngine: getEmberAppWithInRepoEngineProject(),
+};
+
+describe('Task: config-ts ember app', () => {
+  for (const [name, originalProject] of Object.entries(projects)) {
+    describe(name, () => {
+      let project: Project;
+      let output = '';
+
+      beforeEach(async () => {
+        project = originalProject.clone();
+        await project.write();
+        output = '';
+
+        vi.spyOn(console, 'info').mockImplementation((chunk: string) => {
+          chunk = chunk.replace(new RegExp(project.baseDir, 'g'), '<tmp-path>');
+          output += `${chunk}\n`;
+        });
+
+        vi.spyOn(console, 'log').mockImplementation((chunk) => {
+          output += `${chunk}\n`;
+        });
+      });
+
+      afterEach(() => {
+        vi.clearAllMocks();
+        output = '';
+        project.dispose();
+      });
+
+      afterAll(() => {
+        originalProject.dispose();
+      });
+
+      test('create tsconfig if not existed', async () => {
+        await runTsConfig(project.baseDir);
+
+        expect(readJSONSync(resolve(project.baseDir, 'tsconfig.json'))).matchSnapshot();
+        expect(output).matchSnapshot();
+      });
+
+      test('update tsconfig if exists', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: false } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+
+        const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+
+        expect(tsConfig.compilerOptions.strict).toBeTruthy();
+        // Do not use snapshot here since there is absolute path in output
+        expect(output).toContain('ensuring strict mode is enabled');
+      });
+
+      test('update tsconfig if invalid extends exist', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { extends: 'invalid-tsconfig.json' };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+
+        const tsConfig = readJSONSync(resolve(project.baseDir, 'tsconfig.json')) as TSConfig;
+
+        expect(tsConfig.compilerOptions.strict).toBeTruthy();
+        // Do not use snapshot here since there is absolute path in output
+        expect(output).toContain('ensuring strict mode is enabled');
+      });
+
+      test('skip if tsconfig.json exists with strict on', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: true } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        await runTsConfig(project.baseDir);
+        await runTsConfig(project.baseDir); //should be skipped
+
+        expect(output).toMatchSnapshot();
+      });
+
+      test('run custom config command with user config provided', async () => {
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+            },
+          },
+        });
+
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
+
+        // This proves the custom command works
+        expect(readdirSync(project.baseDir)).toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+
+      test('skip custom config command', async () => {
+        // Prepare old tsconfig
+        const oldTsConfig = { compilerOptions: { strict: true } };
+        writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
+
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+            },
+          },
+        });
+
+        await runTsConfig(project.baseDir, { userConfig: 'rehearsal-config.json' });
+
+        // This proves the custom command works not triggered
+        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+
+      test('postTsSetup hook from user config', async () => {
+        createUserConfig(project.baseDir, {
+          migrate: {
+            setup: {
+              ts: { command: 'touch', args: ['custom-ts-config-script'] },
+              postTsSetup: { command: 'mv', args: ['custom-ts-config-script', 'foo'] },
+            },
+          },
+        });
+
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
+
+        // This proves the custom command and hook works
+        expect(readdirSync(project.baseDir)).toContain('foo');
+        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(output).toMatchSnapshot();
+      });
+    });
+  }
+});

--- a/packages/cli/test/test-helpers/config-ts-test-utils.ts
+++ b/packages/cli/test/test-helpers/config-ts-test-utils.ts
@@ -1,14 +1,17 @@
 import { resolve } from 'node:path';
 import { writeJSONSync } from 'fs-extra/esm';
 import { tsConfigTask } from '../../src/commands/migrate/tasks/index.js';
-import { listrTaskRunner, createMigrateOptions } from './index.js';
 import { CustomConfig, MigrateCommandOptions } from '../../src/types.js';
+import { listrTaskRunner, createMigrateOptions } from './index.js';
 
-export async function runTsConfig(basePath: string, opts?: Partial<MigrateCommandOptions>): Promise<void> {
+export async function runTsConfig(
+  basePath: string,
+  opts?: Partial<MigrateCommandOptions>
+): Promise<void> {
   const options = createMigrateOptions(basePath, opts);
-    const context = { sourceFilesWithRelativePath: [] };
-    const tasks = [tsConfigTask(options, context)];
-    await listrTaskRunner(tasks);
+  const context = { sourceFilesWithRelativePath: [] };
+  const tasks = [tsConfigTask(options, context)];
+  await listrTaskRunner(tasks);
 }
 
 export function createUserConfig(basePath: string, config: CustomConfig): void {

--- a/packages/cli/test/test-helpers/config-ts-test-utils.ts
+++ b/packages/cli/test/test-helpers/config-ts-test-utils.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path';
+import { writeJSONSync } from 'fs-extra/esm';
+import { tsConfigTask } from '../../src/commands/migrate/tasks/index.js';
+import { listrTaskRunner, createMigrateOptions } from './index.js';
+import { CustomConfig, MigrateCommandOptions } from '../../src/types.js';
+
+export async function runTsConfig(basePath: string, opts?: Partial<MigrateCommandOptions>): Promise<void> {
+  const options = createMigrateOptions(basePath, opts);
+    const context = { sourceFilesWithRelativePath: [] };
+    const tasks = [tsConfigTask(options, context)];
+    await listrTaskRunner(tasks);
+}
+
+export function createUserConfig(basePath: string, config: CustomConfig): void {
+  const configPath = resolve(basePath, 'rehearsal-config.json');
+  writeJSONSync(configPath, config);
+}


### PR DESCRIPTION
This PR is the most important part of the original PR #870. This PR is created for readability.

It adds ember tests for the `config-ts` task. The iterations look small, but each of them is a full iteration of the `config-ts` task under different conditions. 