### PR TITLE
fix: do not skip config-ts if user config exists

### DIFF
--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
@@ -24,6 +24,13 @@ exports[`Task: config-ts ember app > emberAddon > create tsconfig if not existed
 "
 `;
 
+exports[`Task: config-ts ember app > emberAddon > do not skip if custom config exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberAddon > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
@@ -36,12 +43,6 @@ exports[`Task: config-ts ember app > emberAddon > run custom config command with
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
-"
-`;
-
-exports[`Task: config-ts ember app > emberAddon > skip custom config command 1`] = `
-"[STARTED] Create tsconfig.json
-[SKIPPED] Create tsconfig.json
 "
 `;
 

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
@@ -38,6 +38,13 @@ exports[`Task: config-ts ember app > emberApp > create tsconfig if not existed 2
 "
 `;
 
+exports[`Task: config-ts ember app > emberApp > do not skip if custom config exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberApp > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
@@ -50,12 +57,6 @@ exports[`Task: config-ts ember app > emberApp > run custom config command with u
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
-"
-`;
-
-exports[`Task: config-ts ember app > emberApp > skip custom config command 1`] = `
-"[STARTED] Create tsconfig.json
-[SKIPPED] Create tsconfig.json
 "
 `;
 
@@ -121,6 +122,13 @@ exports[`Task: config-ts ember app > emberAppWithInRepoAddon > create tsconfig i
 "
 `;
 
+exports[`Task: config-ts ember app > emberAppWithInRepoAddon > do not skip if custom config exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberAppWithInRepoAddon > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
@@ -133,12 +141,6 @@ exports[`Task: config-ts ember app > emberAppWithInRepoAddon > run custom config
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
-"
-`;
-
-exports[`Task: config-ts ember app > emberAppWithInRepoAddon > skip custom config command 1`] = `
-"[STARTED] Create tsconfig.json
-[SKIPPED] Create tsconfig.json
 "
 `;
 
@@ -204,6 +206,13 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig 
 "
 `;
 
+exports[`Task: config-ts ember app > emberAppwithInRepoEngine > do not skip if custom config exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts ember app > emberAppwithInRepoEngine > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
@@ -216,12 +225,6 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > run custom confi
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
-"
-`;
-
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip custom config command 1`] = `
-"[STARTED] Create tsconfig.json
-[SKIPPED] Create tsconfig.json
 "
 `;
 

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
@@ -24,6 +24,13 @@ exports[`Task: config-ts > create tsconfig if not existed 2`] = `
 "
 `;
 
+exports[`Task: config-ts > do not skip if custom config exists 1`] = `
+"[STARTED] Create tsconfig.json
+[DATA] Create tsconfig from config
+[SUCCESS] Create tsconfig.json
+"
+`;
+
 exports[`Task: config-ts > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
@@ -36,12 +43,6 @@ exports[`Task: config-ts > run custom config command with user config provided 1
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
-"
-`;
-
-exports[`Task: config-ts > skip custom config command 1`] = `
-"[STARTED] Create tsconfig.json
-[SKIPPED] Create tsconfig.json
 "
 `;
 

--- a/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-addon.test.ts
@@ -111,7 +111,7 @@ describe('Task: config-ts ember app', () => {
         expect(output).toMatchSnapshot();
       });
 
-      test('skip custom config command', async () => {
+      test('do not skip if custom config exists', async () => {
         // Prepare old tsconfig
         const oldTsConfig = { compilerOptions: { strict: true } };
         writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
@@ -124,10 +124,15 @@ describe('Task: config-ts ember app', () => {
           },
         });
 
-        await runTsConfig(project.baseDir, { userConfig: 'rehearsal-config.json' });
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
 
         // This proves the custom command works not triggered
-        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(readdirSync(project.baseDir)).toContain('custom-ts-config-script');
         expect(output).toMatchSnapshot();
       });
 

--- a/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
@@ -117,7 +117,7 @@ describe('Task: config-ts ember app', () => {
         expect(output).toMatchSnapshot();
       });
 
-      test('skip custom config command', async () => {
+      test('do not skip if custom config exists', async () => {
         // Prepare old tsconfig
         const oldTsConfig = { compilerOptions: { strict: true } };
         writeJSONSync(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
@@ -130,10 +130,15 @@ describe('Task: config-ts ember app', () => {
           },
         });
 
-        await runTsConfig(project.baseDir, { userConfig: 'rehearsal-config.json' });
+        const options = createMigrateOptions(project.baseDir, {
+          userConfig: 'rehearsal-config.json',
+        });
+        const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
+        const tasks = [tsConfigTask(options, { userConfig })];
+        await listrTaskRunner(tasks);
 
         // This proves the custom command works not triggered
-        expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+        expect(readdirSync(project.baseDir)).toContain('custom-ts-config-script');
         expect(output).toMatchSnapshot();
       });
 

--- a/packages/cli/test/commands/migrate/config-ts.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.test.ts
@@ -110,7 +110,7 @@ describe('Task: config-ts', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test('skip custom config command', async () => {
+  test('do not skip if custom config exists', async () => {
     // Prepare old tsconfig
     const oldTsConfig = { compilerOptions: { strict: true } };
     writeTSConfig(resolve(project.baseDir, 'tsconfig.json'), oldTsConfig);
@@ -126,11 +126,10 @@ describe('Task: config-ts', () => {
     const options = createMigrateOptions(project.baseDir, { userConfig: 'rehearsal-config.json' });
     const userConfig = new UserConfig(project.baseDir, 'rehearsal-config.json', 'migrate');
     const tasks = [tsConfigTask(options, { userConfig })];
-
-    await listrTaskRunner(tasks); // should be skipped
+    await listrTaskRunner(tasks); // should not be skipped
 
     // This proves the custom command works not triggered
-    expect(readdirSync(project.baseDir)).not.toContain('custom-ts-config-script');
+    expect(readdirSync(project.baseDir)).toContain('custom-ts-config-script');
     expect(output).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Fixes #920

`tsConfigTask` should be triggered if:


  - `tsconfig.json` does not exist, Or
  - it is not in strict mode, Or
  - user config for `ts-setup` exists