### PR TITLE
chore: fix typos

### DIFF
--- a/packages/cli/src/commands/migrate/index.ts
+++ b/packages/cli/src/commands/migrate/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { resolve, relative, isAbsolute } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import { existsSync, promises as fs } from 'node:fs';
 import { Command, Option } from 'commander';
 import { Listr } from 'listr2';
 import { createLogger, format, transports } from 'winston';
-import { parseCommaSeparatedList, gitIsRepoDirty, findWorkspaceRoot } from '@rehearsal/utils';
+import { findWorkspaceRoot, gitIsRepoDirty, parseCommaSeparatedList } from '@rehearsal/utils';
 import { PackageJson } from 'type-fest';
 import { MigrateCommandContext, MigrateCommandOptions, PreviousRuns } from '../../types.js';
 import { initCommand } from './init-command.js';
@@ -49,7 +49,7 @@ migrateCommand
   )
   .option(
     '-p, --package <relative path to target package>',
-    `run migrate againt a specific child-package in your project(${process.cwd()}) `,
+    `run migrate against a specific child-package in your project(${process.cwd()}) `,
     ''
   )
   .option(

--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -73,7 +73,7 @@ export function analyzeTask(
           const menuList = packageSelections.map((p) => {
             const { migratedFileCount, totalFileCount, isCompleted } =
               ctx.state.getPackageMigrateProgress(
-                p.path // pacakge fullpath is the key of the packageMap in state
+                p.path // package fullpath is the key of the packageMap in state
               );
             const errorCount = ctx.state.getPackageErrorCount(p.path);
             // default text to show per package
@@ -81,7 +81,7 @@ export function analyzeTask(
             let icon = '';
             let isOptionDisabled = false;
             if (totalFileCount !== 0) {
-              // has previous migratoin
+              // has previous migration
               progressText = `${migratedFileCount} of ${totalFileCount} files migrated, ${errorCount} @ts-expect-error(s) need to be fixed`;
               icon = IN_PROGRESS_MARK;
 

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -1,4 +1,4 @@
-import { resolve, extname } from 'node:path';
+import { extname, resolve } from 'node:path';
 import { ESLint } from 'eslint';
 import { outputFileSync } from 'fs-extra/esm';
 import { cosmiconfigSync } from 'cosmiconfig';
@@ -173,7 +173,7 @@ async function writeLintConfig(
 ): Promise<void> {
   outputFileSync(configPath, config);
 
-  //yml and ymal don't need formatting. yamlStringify does the formatting already.
+  //yml and yaml don't need formatting. yamlStringify does the formatting already.
   if (format === FORMAT.JS || format === FORMAT.CJS) {
     const formattedConfig = await lintJSConfig(config, configPath, basePath);
     formattedConfig && outputFileSync(configPath, formattedConfig);

--- a/packages/cli/src/commands/migrate/tasks/convert.ts
+++ b/packages/cli/src/commands/migrate/tasks/convert.ts
@@ -5,8 +5,8 @@ import chalk from 'chalk';
 import { execa } from 'execa';
 import {
   determineProjectName,
-  openInEditor,
   getPathToBinary,
+  openInEditor,
   prettyGitDiff,
 } from '@rehearsal/utils';
 
@@ -24,12 +24,12 @@ export function convertTask(
     title: 'Convert JS files to TS',
     enabled: (): boolean => !options.dryRun,
     task: async (ctx: MigrateCommandContext, task): Promise<void> => {
-      // Because we have to eagerly import all the tasks we need tolazily load these
+      // Because we have to eagerly import all the tasks we need to lazily load these
       // modules because they refer to typescript which may or may not be installed
       const migrate = await import('@rehearsal/migrate').then((m) => m.migrate);
       const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
       const { generateReports, getReportSummary } = await import('../../../helpers/report.js');
-      // If context is provide via external parameter, merge with existed
+      // If context is provided via external parameter, merge with existed
       if (context) {
         ctx = { ...ctx, ...context };
       }

--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -27,7 +27,7 @@ function extractDepName(dep: string): string {
   return matched ? matched[0] : dep;
 }
 
-// check if package.json has all required dependecies
+// check if package.json has all required dependencies
 // from rehearsal default and user config
 export async function shouldRunDepInstallTask(
   options: MigrateCommandOptions,
@@ -97,7 +97,7 @@ export function depInstallTask(
       // for deps
       if (dependencies.length) {
         try {
-          task.output = `Installing dependecies: ${dependencies.join(', ')}`;
+          task.output = `Installing dependencies: ${dependencies.join(', ')}`;
           await addDep(dependencies, false, { cwd: options.basePath });
         } catch (e) {
           errorMessages.push(formatErrorMessage(dependencies, false));

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -12,7 +12,7 @@ export function regenTask(options: MigrateCommandOptions, logger: Logger): Listr
     title: 'Regenerating report for TS errors and Eslint errors',
     enabled: (): boolean => !options.dryRun,
     task: async (_: MigrateCommandContext, task): Promise<void> => {
-      // Because we have to eagerly import all the tasks we need tolazily load these
+      // Because we have to eagerly import all the tasks we need to lazily load these
       // modules because they refer to typescript which may or may not be installed
       const Reporter = await import('@rehearsal/reporter').then((m) => m.Reporter);
       const { generateReports, getRegenSummary } = await import('../../../helpers/report.js');

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -191,7 +191,7 @@ upgradeCommand
                               ctx.skip = true;
                               task.skip('Skipping task because dryRun flag is set');
                             }
-                            // the diff has been added and commited to the branch
+                            // the diff has been added and committed to the branch
                             // do PR work here and push branch upstream
                             task.title = `Pull-Request Link "https://github.com/foo/foo/pull/00000"`;
                             // on success skip the rest of the tasks
@@ -200,7 +200,7 @@ upgradeCommand
                         },
                       ]);
                     } catch (error) {
-                      // catch the tsc build compliation error
+                      // catch the tsc build compilation error
                       // re-run with tsc --clean and try and mitigate the error with ts-migrate plugins
                       throw new Error('Compilation Error');
                     }

--- a/packages/cli/src/helpers/state.ts
+++ b/packages/cli/src/helpers/state.ts
@@ -1,9 +1,9 @@
 import { resolve } from 'node:path';
-import { existsSync, readFileSync, mkdirSync } from 'node:fs';
-import { writeJSONSync, readJSONSync } from 'fs-extra/esm';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 
-// The reaosn to have packageMap is getting all files in a package faster
-// than loop through everyhing in the files
+// The reason to have packageMap is getting all files in a package faster
+// than loop through everything in the files
 export type Store = {
   name: string | null;
   packageMap: PackageMap;
@@ -112,11 +112,11 @@ export class State {
   addFilesToPackage(packageName: string, files: string[]): void {
     const fileMap: FileStateMap = {};
     const relativePackageName = getRelativePath(this.basePath, packageName);
-    const fileListWithRelateivePath = files.map((f) => getRelativePath(this.basePath, f));
+    const fileListWithRelativePath = files.map((f) => getRelativePath(this.basePath, f));
     // save files to package map for easier retrieve
-    this.store.packageMap[relativePackageName] = fileListWithRelateivePath;
+    this.store.packageMap[relativePackageName] = fileListWithRelativePath;
 
-    fileListWithRelateivePath.forEach((f) => {
+    fileListWithRelativePath.forEach((f) => {
       const relativeTsPath = f.replace(/js$/g, 'ts');
       const absoluteTsPath = getAbsolutePath(this.basePath, relativeTsPath);
       const isConverted = existsSync(absoluteTsPath);

--- a/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
@@ -32,27 +32,6 @@ exports[`Task: analyze > add files in tsconfig.json include 1`] = `
 }
 `;
 
-exports[`Task: analyze > disable package selection if completed 1`] = `
-{
-  ".": [],
-  "./module-a": [
-    "./module-a/index.js",
-  ],
-  "./module-b": [],
-}
-`;
-
-exports[`Task: analyze > disable package selection if completed 2`] = `
-{
-  "./module-a/index.js": {
-    "current": "./module-a/index.ts",
-    "errorCount": 0,
-    "origin": "./module-a/index.js",
-    "package": "./module-a",
-  },
-}
-`;
-
 exports[`Task: analyze > get files that will be migrated 1`] = `
 [
   "foo.js",
@@ -119,25 +98,4 @@ exports[`Task: analyze > print files will be attempted to migrate with --dryRun 
 [DATA] index.js
 [SUCCESS] Analyzing Project
 "
-`;
-
-exports[`Task: analyze > show package progress in interactive mode 1`] = `
-{
-  ".": [],
-  "./module-a": [
-    "./module-a/index.js",
-  ],
-  "./module-b": [],
-}
-`;
-
-exports[`Task: analyze > show package progress in interactive mode 2`] = `
-{
-  "./module-a/index.js": {
-    "current": "./module-a/index.ts",
-    "errorCount": 2,
-    "origin": "./module-a/index.js",
-    "package": "./module-a",
-  },
-}
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
@@ -168,7 +168,7 @@ exports[`Task: config-ts ember app > emberAppWithInRepoAddon > update tsconfig i
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig if not existed 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > create tsconfig if not existed 1`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
@@ -198,7 +198,7 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig 
 }
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig if not existed 2`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > create tsconfig if not existed 2`] = `
 "[STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
@@ -206,14 +206,14 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > create tsconfig 
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > do not skip if custom config exists 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > postTsSetup hook from user config 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [DATA] Run postTsSetup from config
@@ -221,14 +221,14 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > postTsSetup hook
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > run custom config command with user config provided 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] Create tsconfig from config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip if tsconfig.json exists with strict on 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > skip if tsconfig.json exists with strict on 1`] = `
 "[STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
 [STARTED] Create tsconfig.json
@@ -236,7 +236,7 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > skip if tsconfig
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > update tsconfig if exists 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > update tsconfig if exists 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
@@ -244,7 +244,7 @@ exports[`Task: config-ts ember app > emberAppwithInRepoEngine > update tsconfig 
 "
 `;
 
-exports[`Task: config-ts ember app > emberAppwithInRepoEngine > update tsconfig if invalid extends exist 1`] = `
+exports[`Task: config-ts ember app > emberAppWithInRepoEngine > update tsconfig if invalid extends exist 1`] = `
 "[STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json

--- a/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
@@ -11,7 +11,7 @@ exports[`Task: dependency-install > do not run postInstall command if empty 1`] 
 exports[`Task: dependency-install > install custom dependencies 1`] = `
 "[STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 "

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
@@ -73,7 +73,7 @@ exports[`migrate init for ember addon variant > ember3-addon > pass user config 
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
@@ -87,7 +87,7 @@ exports[`migrate init for ember app variant > ember4App > pass user config ember
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -209,7 +209,7 @@ exports[`migrate init for ember app variant > emberApp > pass user config emberA
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -331,7 +331,7 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > pass use
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -366,7 +366,7 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > skip dep
 info:    The project is ready for migration. Please run \\"rehearsal migrate\\" to start the migration."
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default run --emberAppwithInRepoEngine 1`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default run --emberAppWithInRepoEngine 1`] = `
 "[STARTED] Validate project
 [SUCCESS] Validate project
 [STARTED] Initialize
@@ -388,14 +388,14 @@ exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default
 info:    The project is ready for migration. Please run \\"rehearsal migrate\\" to start the migration."
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default run --emberAppwithInRepoEngine 2`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default run --emberAppWithInRepoEngine 2`] = `
 "module.exports = {
   extends: [\\"./.rehearsal-eslintrc.js\\"],
 };
 "
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default run --emberAppwithInRepoEngine 3`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default run --emberAppWithInRepoEngine 3`] = `
 "module.exports = {
   \\"parser\\": \\"@typescript-eslint/parser\\",
   \\"parserOptions\\": {
@@ -415,7 +415,7 @@ exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default
 }"
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default run --emberAppwithInRepoEngine 4`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default run --emberAppWithInRepoEngine 4`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
@@ -445,7 +445,7 @@ exports[`migrate init for ember app variant > emberAppwithInRepoEngine > default
 }
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > pass user config emberAppwithInRepoEngine 1`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > pass user config emberAppWithInRepoEngine 1`] = `
 "[STARTED] Validate project
 [SUCCESS] Validate project
 [STARTED] Initialize
@@ -453,7 +453,7 @@ exports[`migrate init for ember app variant > emberAppwithInRepoEngine > pass us
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -468,7 +468,7 @@ exports[`migrate init for ember app variant > emberAppwithInRepoEngine > pass us
 info:    The project is ready for migration. Please run \\"rehearsal migrate\\" to start the migration."
 `;
 
-exports[`migrate init for ember app variant > emberAppwithInRepoEngine > skip dep install, ts config, and lint config if exists 1`] = `
+exports[`migrate init for ember app variant > emberAppWithInRepoEngine > skip dep install, ts config, and lint config if exists 1`] = `
 "[STARTED] Validate project
 [SUCCESS] Validate project
 [STARTED] Initialize

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
@@ -80,7 +80,7 @@ exports[`migrate init > pass user config 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Install dependencies from config
-[DATA] Installing dependecies: fs-extra
+[DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json

--- a/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/initialize.test.ts.snap
@@ -1,12 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Task: initialize > print files will be attempted to migrate with --dryRun 1`] = `
-"[STARTED] Initialize
-[DATA] Setting up config for basic
-[SUCCESS] Initialize
-"
-`;
-
 exports[`Task: initialize > read and store config via --userConfig 1`] = `
 {
   "exclude": [

--- a/packages/cli/test/commands/migrate/__snapshots__/regen.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/regen.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Task: regen > no effect on JS filse before conversion 1`] = `
+exports[`Task: regen > no effect on JS files before conversion 1`] = `
 "[STARTED] Initialize
 [DATA] Setting up config for basic_regen
 [SUCCESS] Initialize

--- a/packages/cli/test/commands/migrate/analyze.test.ts
+++ b/packages/cli/test/commands/migrate/analyze.test.ts
@@ -4,16 +4,16 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { writeJSONSync } from 'fs-extra/esm';
 import { Project } from 'fixturify-project';
 import { readFile, readTSConfig, writeTSConfig } from '@rehearsal/utils';
-import { analyzeTask, addFilesToIncludes } from '../../../src/commands/migrate/tasks/index.js';
+import { addFilesToIncludes, analyzeTask } from '../../../src/commands/migrate/tasks/index.js';
 import {
-  prepareProject,
-  listrTaskRunner,
   createMigrateOptions,
-  KEYS,
-  sendKey,
   createOutputStream,
-  isPackageSelection,
   isActionSelection,
+  isPackageSelection,
+  KEYS,
+  listrTaskRunner,
+  prepareProject,
+  sendKey,
 } from '../../test-helpers/index.js';
 import { TSConfig } from '../../../src/types.js';
 
@@ -108,13 +108,13 @@ describe('Task: analyze', () => {
     expect(output).toContain('[SUCCESS] Analyzing Project');
 
     // check context
-    const expectedRellativePaths = ['foo.js', 'depends-on-foo.js', 'index.js'];
-    const expectedAbsolutePaths = expectedRellativePaths.map((f) => {
+    const expectedRelativePaths = ['foo.js', 'depends-on-foo.js', 'index.js'];
+    const expectedAbsolutePaths = expectedRelativePaths.map((f) => {
       return resolve(project.baseDir, f);
     });
     expect(ctx.input).toBe('basic(no progress found)');
     expect(ctx.targetPackagePath).toBe(project.baseDir);
-    expect(ctx.sourceFilesWithRelativePath).toStrictEqual(expectedRellativePaths);
+    expect(ctx.sourceFilesWithRelativePath).toStrictEqual(expectedRelativePaths);
     expect(ctx.sourceFilesWithAbsolutePath).toStrictEqual(expectedAbsolutePaths);
   });
 
@@ -132,10 +132,10 @@ describe('Task: analyze', () => {
   });
 
   test('throw if --package option is not valid', async () => {
-    const options = createMigrateOptions(project.baseDir, { package: 'no-valid-pacakge' });
+    const options = createMigrateOptions(project.baseDir, { package: 'no-valid-package' });
     const tasks = [analyzeTask(options)];
     await expect(() => listrTaskRunner(tasks)).rejects.toThrowError(
-      `Cannot find package no-valid-pacakge in your project. Please make sure it is a valid package and try again.`
+      `Cannot find package no-valid-package in your project. Please make sure it is a valid package and try again.`
     );
   });
 

--- a/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/config-ts.ember-app.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { readdirSync } from 'node:fs';
-import { afterEach, beforeEach, afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import {
   getEmberAppProject,
@@ -9,15 +9,15 @@ import {
 } from '@rehearsal/test-support';
 import { Project } from 'fixturify-project';
 import { tsConfigTask } from '../../../src/commands/migrate/tasks/index.js';
-import { listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
-import { runTsConfig, createUserConfig } from '../../test-helpers/config-ts-test-utils.js';
+import { createMigrateOptions, listrTaskRunner } from '../../test-helpers/index.js';
+import { createUserConfig, runTsConfig } from '../../test-helpers/config-ts-test-utils.js';
 import { TSConfig } from '../../../src/types.js';
 import { UserConfig } from '../../../src/user-config.js';
 
 const projects = {
   emberApp: getEmberAppProject(),
   emberAppWithInRepoAddon: getEmberAppWithInRepoAddonProject(),
-  emberAppwithInRepoEngine: getEmberAppWithInRepoEngineProject(),
+  emberAppWithInRepoEngine: getEmberAppWithInRepoEngineProject(),
 };
 
 describe('Task: config-ts ember app', () => {

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readFileSync, readdirSync, promises as fs } from 'node:fs';
+import { promises as fs, readdirSync, readFileSync } from 'node:fs';
 import { writeJSONSync } from 'fs-extra/esm';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { getFiles } from '@rehearsal/test-support';
@@ -8,7 +8,7 @@ import { Project } from 'fixturify-project';
 import { readTSConfig } from '@rehearsal/utils';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install.js';
 
-import { runBin, prepareProject, cleanOutput } from '../../test-helpers/index.js';
+import { cleanOutput, prepareProject, runBin } from '../../test-helpers/index.js';
 import { CustomConfig } from '../../../src/types.js';
 import type { PackageJson } from 'type-fest';
 
@@ -80,7 +80,7 @@ describe('migrate - validation', () => {
   });
 
   test('throw if not in project root with pnpm workspaces', async () => {
-    project = new Project('workspaces-with-pnpm-erorr');
+    project = new Project('workspaces-with-pnpm-error');
 
     project.files = {
       'package.json': JSON.stringify({
@@ -107,7 +107,7 @@ describe('migrate - validation', () => {
   });
 
   test('not throw if in project root with unrelated npm/yarn workspaces', async () => {
-    project = new Project('workspaces-with-pnpm-erorr');
+    project = new Project('workspaces-with-pnpm-error');
     project.files = {
       'package.json': JSON.stringify({
         name: 'foo',
@@ -229,11 +229,11 @@ describe('migrate: e2e', () => {
     const lintConfig = readFileSync(resolve(project.baseDir, '.eslintrc.js'), {
       encoding: 'utf-8',
     });
-    const lintConfigDefualt = readFileSync(resolve(project.baseDir, '.rehearsal-eslintrc.js'), {
+    const lintConfigDefault = readFileSync(resolve(project.baseDir, '.rehearsal-eslintrc.js'), {
       encoding: 'utf-8',
     });
     expect(lintConfig).toMatchSnapshot();
-    expect(lintConfigDefualt).toMatchSnapshot();
+    expect(lintConfigDefault).toMatchSnapshot();
 
     // new scripts
     expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');
@@ -264,11 +264,11 @@ describe('migrate: e2e', () => {
     const lintConfig = readFileSync(resolve(project.baseDir, '.eslintrc.js'), {
       encoding: 'utf-8',
     });
-    const lintConfigDefualt = readFileSync(resolve(project.baseDir, '.rehearsal-eslintrc.js'), {
+    const lintConfigDefault = readFileSync(resolve(project.baseDir, '.rehearsal-eslintrc.js'), {
       encoding: 'utf-8',
     });
     expect(lintConfig).toMatchSnapshot();
-    expect(lintConfigDefualt).toMatchSnapshot();
+    expect(lintConfigDefault).toMatchSnapshot();
 
     // new scripts
     expect(packageJson?.scripts?.['lint:tsc']).toBe('tsc --noEmit');

--- a/packages/cli/test/commands/migrate/init-command.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/init-command.ember-app.test.ts
@@ -1,22 +1,22 @@
 import { resolve } from 'node:path';
 import { readdirSync } from 'node:fs';
-import { beforeEach, afterEach, afterAll, describe, test, expect } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { writeJSONSync } from 'fs-extra';
 import { Project } from 'fixturify-project';
 import {
+  getEmber4AppProject,
   getEmberAppProject,
   getEmberAppWithInRepoAddonProject,
   getEmberAppWithInRepoEngineProject,
-  getEmber4AppProject,
 } from '@rehearsal/test-support';
 import { REQUIRED_DEPENDENCIES } from '../../../src/commands/migrate/tasks/dependency-install.js';
 
 import { cleanOutput } from '../../test-helpers/index.js';
 import {
-  runDefault,
-  runWithUserConfig,
-  runTwoTimes,
   CUSTOM_CONFIG,
+  runDefault,
+  runTwoTimes,
+  runWithUserConfig,
 } from '../../test-helpers/init-command-test-utils.js';
 import { CustomConfig } from '../../../src/types.js';
 
@@ -28,7 +28,7 @@ function createUserConfig(basePath: string, config: CustomConfig): void {
 const projects = {
   emberApp: getEmberAppProject(),
   emberAppWithInRepoAddon: getEmberAppWithInRepoAddonProject(),
-  emberAppwithInRepoEngine: getEmberAppWithInRepoEngineProject(),
+  emberAppWithInRepoEngine: getEmberAppWithInRepoEngineProject(),
   ember4App: getEmber4AppProject(),
 };
 

--- a/packages/cli/test/commands/migrate/regen.test.ts
+++ b/packages/cli/test/commands/migrate/regen.test.ts
@@ -4,16 +4,16 @@ import { createLogger, format, transports } from 'winston';
 
 import { Project } from 'fixturify-project';
 import {
-  initTask,
-  depInstallTask,
-  convertTask,
-  tsConfigTask,
-  lintConfigTask,
   analyzeTask,
+  convertTask,
+  depInstallTask,
+  initTask,
+  lintConfigTask,
   regenTask,
+  tsConfigTask,
   validateTask,
 } from '../../../src/commands/migrate/tasks/index.js';
-import { prepareProject, listrTaskRunner, createMigrateOptions } from '../../test-helpers/index.js';
+import { createMigrateOptions, listrTaskRunner, prepareProject } from '../../test-helpers/index.js';
 
 const logger = createLogger({
   transports: [new transports.Console({ format: format.cli() })],
@@ -54,7 +54,7 @@ describe('Task: regen', () => {
     );
   });
 
-  test('no effect on JS filse before conversion', async () => {
+  test('no effect on JS files before conversion', async () => {
     project.files['package.json'] = JSON.stringify({
       name: 'basic_regen',
       version: '1.0.0',

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -1,15 +1,15 @@
-import { join, resolve, dirname } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { Readable } from 'stream';
 import { readFileSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
 import which from 'which';
-import { ListrTask, Listr } from 'listr2';
+import { Listr, ListrTask } from 'listr2';
 import { git, gitIsRepoDirty, readJSON } from '@rehearsal/utils';
 import { Project } from 'fixturify-project';
 
-import { MigrateCommandOptions, Formats, MigrateCommandContext } from '../../src/types.js';
-import type { Options, ExecaChildProcess } from 'execa';
+import { Formats, MigrateCommandContext, MigrateCommandOptions } from '../../src/types.js';
+import type { ExecaChildProcess, Options } from 'execa';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,7 +39,7 @@ export async function gitDeleteLocalBranch(checkoutBranch?: string): Promise<voi
   }
 }
 
-// helper funcion to run a command via the actual bin
+// helper function to run a command via the actual bin
 // stdout of commands available via ExecaChildProcess.stdout
 export function runBin(command: string, args: string[], options: Options = {}): ExecaChildProcess {
   const cliPath = resolve(__dirname, `../../bin/rehearsal.js`);
@@ -134,7 +134,7 @@ export function sendKey(key: KEYS): void {
 
 // clear all special chars for snapshot test
 // especially in interactive mode, the enquirer prompt would produce difference chars in different environment
-// which makes snapshot test improssible
+// which makes snapshot test impossible
 export function removeSpecialChars(input: string): string {
   const specialCharRegex = /[^A-Za-z 0-9 .,?""!@#$%^&*()-_=+;:<>/\\|}{[\]`~\n]*/g;
   const colorCharRegex = /\[\d+m/g;

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -38,6 +38,44 @@ dummy.key;
 "
 `;
 
+exports[`Test transform > addErrorTypeGuard 2`] = `
+"// Case #1: try ... catch
+
+const test = [\\"dummy\\"];
+
+try {
+  console.log(\\"success\\");
+} catch (e) {
+  console.log((e as Error).message);
+  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
+  console.log(e.notErrorMember);
+
+  if ((e as Error).name === \\"Test\\") {
+    console.log((e as Error).name);
+    console.log((e as Error).name);
+    console.log((e as Error).name);
+    console.log((e as Error).name);
+  }
+
+  if (test[1] === undefined && (e as Error).name === \\"Test\\") {
+    console.log((e as Error).name);
+  }
+}
+
+// Case #2: not a try catch
+
+function getObject<T>(): T {
+  const object = [\\"dummy\\"];
+  return object as unknown as T;
+}
+
+const dummy = getObject();
+
+/* @ts-expect-error @rehearsal TODO TS18046: 'dummy' is of type 'unknown'. */
+dummy.key;
+"
+`;
+
 exports[`Test transform > addMissingExport 1`] = `
 "/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
 import React from \\"react\\";
@@ -167,7 +205,321 @@ export default makeToDo(ToDo);
 "
 `;
 
+exports[`Test transform > addMissingExport 5`] = `
+"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
+import React from \\"react\\";
+
+export interface Props {
+  name: string;
+  age: string;
+}
+
+{
+  /* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */
+}
+const Kid = ({ name, age }: Props) => <div>{\`\${name},\${age}\`}</div>;
+
+export default Kid;
+"
+`;
+
+exports[`Test transform > addMissingExport 6`] = `
+"import Kid from \\"./4082-1-import\\";
+
+export default {
+  kid: Kid,
+  title: \\"Kid\\",
+};
+"
+`;
+
+exports[`Test transform > addMissingExport 7`] = `
+"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
+import React from \\"react\\";
+
+interface ToDo {
+  id: string;
+  title: string;
+  content: string;
+}
+
+interface ToDoState {
+  todos: ToDo[];
+}
+
+export interface InjectedProps {
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  todos: ToDo[];
+}
+
+export interface AllProps extends InjectedProps {
+  style: React.CSSProperties;
+}
+
+export default <P extends InjectedProps>(Component: React.ComponentType<P>) =>
+  class extends React.Component<Omit<P, keyof InjectedProps>, ToDoState> {
+    state = { todos: [] };
+
+    onRemove = (id: string) => () => {
+      const filteredToDos = (this.state.todos as ToDo[]).filter(
+        (todo) => (todo as ToDo).id !== id
+      );
+      /* @ts-expect-error @rehearsal TODO TS2339: Property 'setState' does not exist on type '(Anonymous class)'. */
+      this.setState({ todos: filteredToDos });
+    };
+
+    onAdd = () => {
+      const todo = {
+        title: \\"\\",
+        content: \\"\\",
+        id: \`\${Date.now}\`,
+      };
+      /* @ts-expect-error @rehearsal TODO TS2339: Property 'setState' does not exist on type '(Anonymous class)'. */
+      this.setState((prev) => {
+        [...prev.todos, todo];
+      });
+    };
+    props: P | undefined;
+
+    render() {
+      return (
+        /* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations. */
+        <Component
+          {...(this.props as P)}
+          todos={this.state.todos}
+          onAdd={this.onAdd}
+          onRemove={this.onRemove}
+        />
+      );
+    }
+  };
+"
+`;
+
+exports[`Test transform > addMissingExport 8`] = `
+"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
+import React from \\"react\\";
+
+import makeToDo, { AllProps } from \\"./4082-2-import\\";
+
+const ToDo = (props: AllProps) => {
+  return (
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+    <div style={props.style}>
+/* @ts-expect-error @rehearsal TODO TS7006: Parameter 'todo' implicitly has an 'any' type. */
+      {props.todos.map((todo) => (
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+        <div key={todo.id}>
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+          <div>{todo.title}</div>
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+          <div>{todo.content}</div>
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+          <button data-id={todo.id} onClick={() => props.onRemove(todo.id)}>
+/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'Remove'. */
+            Remove
+/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'button'. */
+          </button>
+/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'div'. */
+        </div>
+      ))}
+{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
+      <button onClick={props.onAdd}>Add</button>
+/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'div'. */
+    </div>
+  );
+};
+export default makeToDo(ToDo);
+"
+`;
+
 exports[`Test transform > addMissingTypesBasedOnInheritance 1`] = `
+"// Basics
+
+class Animal {
+  title = \\"\\";
+
+  test(test: string): string {
+    return test;
+  }
+
+  say(message: string): string {
+    return message;
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return false;
+  }
+}
+
+interface Wild {
+  wild(place: string): string;
+}
+
+interface Happy {
+  happy(num: number): void;
+}
+
+class Food {
+  title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}
+
+class Dog extends Animal {
+  say(message: string): string {
+    console.log(message);
+    return \\"bar\\";
+  }
+}
+
+export class WildDog extends Dog implements Wild, Happy {
+  say(message: string): string {
+    console.log(message);
+    return \\"bar\\";
+  }
+
+  override feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return true;
+  }
+
+  wild(place: string): string {
+    return place;
+  }
+
+  happy(num: number): void {
+    console.log(num);
+  }
+}
+
+export class Cat extends Animal {
+  override say(text: string): string {
+    console.log(text);
+    return \\"meo\\";
+  }
+
+  feed(something: Food): boolean {
+    console.log(something);
+    return false;
+  }
+}
+
+// Generics
+
+type Thing = {
+  foo: number;
+};
+
+// Generic Interfaces
+
+interface GenericThingInterface<A = number, B = string> {
+  thing(a: A, b: B): void;
+}
+
+interface ConstrainedThingInterface<C extends Thing> {
+  thing(c: C): void;
+}
+
+export class GenericThingImp1 implements GenericThingInterface {
+  thing(a: number, b: string): void {
+    console.log(a, b);
+  }
+}
+
+export class GenericThingImp2
+  implements GenericThingInterface<boolean, number>
+{
+  thing(a: boolean, b: number): void {
+    console.log(a, b);
+  }
+}
+
+export class GenericThingImp3
+  implements ConstrainedThingInterface<{ foo: number; bar: string }>
+{
+  thing(c: { foo: number; bar: string }): void {
+    console.log(c);
+  }
+}
+
+// Generic Classes
+
+class GenericThingClass<A = number, B = string> {
+  thing(a: A, b: B): void {
+    console.log(a, b);
+  }
+}
+
+class ConstrainedThingClass<C extends Thing> {
+  thing(c: C): void {
+    console.log(c);
+  }
+}
+
+export class GenericThingExt1 extends GenericThingClass {
+  thing(a: number, b: string): void {
+    console.log(a, b);
+  }
+}
+
+export class GenericThingExt2 extends GenericThingClass<boolean, number> {
+  thing(a: boolean, b: number): void {
+    console.log(a, b);
+  }
+}
+
+export class GenericThingExt3 extends ConstrainedThingClass<{
+  foo: number;
+  bar: string;
+}> {
+  thing(c: { foo: number; bar: string }): void {
+    console.log(c);
+  }
+}
+
+// Multiple signatures
+
+interface MultipleInterface {
+  foo(a: number): number;
+  foo(b: string): string;
+  foo(a: number, b: string): boolean;
+
+  moo(a: string): string;
+}
+
+class MultipleClass {
+  boo(a: number): number;
+  boo(b: string): string;
+  boo(a: number, b: string): boolean;
+  boo(ab: number | string, b?: string): number | string | boolean {
+    return !ab || !b;
+  }
+}
+
+export class MultipleImpl extends MultipleClass implements MultipleInterface {
+  /* @ts-expect-error @rehearsal TODO TS2416: Property 'boo' in type 'MultipleImpl' is not assignable to the same property in base type 'MultipleClass'..  Type '(ab: any, b?: any) => boolean' is not assignable to type '{ (a: number): number; (b: string): string; (a: number, b: string): boolean; }'..    Type 'boolean' is not assignable to type 'number'. */
+  boo(ab, b?): boolean {
+    return !ab || !b;
+  }
+
+  /* @ts-expect-error @rehearsal TODO TS2416: Property 'foo' in type 'MultipleImpl' is not assignable to the same property in base type 'MultipleInterface'..  Type '(ab: any, b?: any) => boolean' is not assignable to type '{ (a: number): number; (b: string): string; (a: number, b: string): boolean; }'..    Type 'boolean' is not assignable to type 'number'. */
+  foo(ab, b?): boolean {
+    return !ab || !b;
+  }
+
+  moo(b: string): string {
+    return b;
+  }
+}
+"
+`;
+
+exports[`Test transform > addMissingTypesBasedOnInheritance 2`] = `
 "// Basics
 
 class Animal {
@@ -391,6 +743,45 @@ export class TestClass extends BaseTestClass implements TestInterface {
 "
 `;
 
+exports[`Test transform > addMissingTypesBasedOnInlayHints 2`] = `
+"export function test1(): string {
+  return \\"Test this\\";
+}
+
+export const test2 = () => console.log(\\"Test this\\");
+
+export const test3 = () => \\"Test this\\";
+
+export function test4<Type>(arg: Array<Type>): Type[] {
+  return arg;
+}
+
+export async function test5(): Promise<TestClass> {
+  return new TestClass();
+}
+
+interface TestInterface {
+  test1(): string | undefined;
+}
+
+class BaseTestClass {
+  test2(param: boolean): number | string {
+    return param ? 0 : \\"0\\";
+  }
+}
+
+export class TestClass extends BaseTestClass implements TestInterface {
+  test1(): string | undefined {
+    return undefined;
+  }
+
+  test2(): string | number {
+    return 0;
+  }
+}
+"
+`;
+
 exports[`Test transform > makeMemberOptional 1`] = `
 "export interface Animal {
   species: string;
@@ -440,6 +831,142 @@ exports[`Test transform > makeMemberOptional 4`] = `
 `;
 
 exports[`Test transform > makeMemberOptional 5`] = `
+"import { Animal, Car } from \\"./2790-import-1\\";
+import { Employee } from \\"./2790-import-2\\";
+import * as RabbitStuff from \\"./2790-import-3\\";
+import Human from \\"./2790-import-4\\";
+
+const animal: Animal = {
+  species: \\"dog\\",
+  weight: 90,
+};
+
+delete animal.weight;
+
+const car: Car = {
+  make: \\"Ford\\",
+  model: \\"Focus\\",
+  color: \\"red\\",
+};
+
+delete car.color;
+
+const employee = new Employee({ name: \\"Victor\\", badgeNumber: \\"12345\\" });
+delete employee.badgeNumber;
+
+const human: Human = {
+  weight: 200,
+  height: 180,
+};
+delete human.height;
+
+const rabbit: RabbitStuff.Rabbit = {
+  color: \\"butterscotch\\",
+  species: \\"Holland Lop\\",
+  name: \\"Poca\\",
+};
+delete rabbit.color;
+
+interface Person {
+  name: string;
+  age?: number;
+  address?: string | null;
+}
+
+const person: Person = {
+  name: \\"Jane\\",
+  age: 10,
+  address: \\"123 Happy St\\",
+};
+
+delete person.address;
+
+class Student {
+  name: string;
+  grade: number;
+  gender?: string;
+
+  constructor({
+    name,
+    grade,
+    gender,
+  }: {
+    name: string;
+    grade: number;
+    gender: string;
+  }) {
+    this.name = name;
+    this.grade = grade;
+    this.gender = gender;
+  }
+}
+const student = new Student({ name: \\"\\", grade: 3, gender: \\"male\\" });
+delete student.gender;
+
+type Tree = {
+  species: string;
+  age: number;
+  height?: number;
+};
+
+const oak: Tree = {
+  species: \\"oak\\",
+  age: 150,
+  height: 40,
+};
+delete oak.height;
+"
+`;
+
+exports[`Test transform > makeMemberOptional 6`] = `
+"export interface Animal {
+  species: string;
+  weight?: number;
+}
+
+export interface Car {
+  make: string;
+  model: string;
+  color?: string;
+}
+"
+`;
+
+exports[`Test transform > makeMemberOptional 7`] = `
+"export class Employee {
+  name: string;
+  badgeNumber?: string;
+
+  constructor({ name, badgeNumber }: { name: string; badgeNumber: string }) {
+    this.name = name;
+    this.badgeNumber = badgeNumber;
+  }
+}
+"
+`;
+
+exports[`Test transform > makeMemberOptional 8`] = `
+"export interface Rabbit {
+  color?: string;
+  species: string;
+  name: string;
+}
+
+export function feedRabbit(rabbit: Rabbit): void {
+  console.log(\`Rabbit \${rabbit.name} loves to eat fruit, not hay.\`);
+}
+"
+`;
+
+exports[`Test transform > makeMemberOptional 9`] = `
+"export default interface Human {
+  height?: number;
+  weight: number;
+}
+"
+`;
+
+exports[`Test transform > makeMemberOptional 10`] = `
 "import { Animal, Car } from \\"./2790-import-1\\";
 import { Employee } from \\"./2790-import-2\\";
 import * as RabbitStuff from \\"./2790-import-3\\";

--- a/packages/codefixes/test/ts-codefixes.test.ts
+++ b/packages/codefixes/test/ts-codefixes.test.ts
@@ -3,11 +3,11 @@ import { resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { RehearsalService } from '@rehearsal/service';
 import {
+  ImportsNotUsedAsValues,
+  JsxEmit,
   ModuleKind,
   ModuleResolutionKind,
   ScriptTarget,
-  ImportsNotUsedAsValues,
-  JsxEmit,
 } from 'typescript';
 import { TypescriptCodeFixCollection } from '../src/typescript-codefix-collection.js';
 import { getDiagnosticOrder } from '../src/get-diagnostics.js';
@@ -89,7 +89,7 @@ describe('ts-codefixes', () => {
     expect(service.getFileText(input)).toEqual(await fs.readFile(expectation, 'utf-8'));
   }
 
-  test('addMissingAync', async () => {
+  test('addMissingAsync', async () => {
     await runTest('addMissingAsync/failing/fail-1.ts', 'addMissingAsync/passing/pass-1.ts');
   });
 

--- a/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-package-graph.ts
@@ -57,7 +57,7 @@ export class EmberAppPackageGraph extends PackageGraph {
    *  In this case we are processing that file.
    *
    *  We need to update that Node with the complete ModuleNode data.
-   *  Then we parse that service file for any other service depdendencies.
+   *  Then we parse that service file for any other service dependencies.
    *
    * @param m A `ModuleNode` with the path information
    * @returns Node<ModuleNode> the new or existing Node<ModuleNode>
@@ -91,7 +91,7 @@ export class EmberAppPackageGraph extends PackageGraph {
 
     const services = discoverServiceDependencies(this.baseDir, n.content.path);
 
-    this.debug('>>> SERVICES DISCOVERD', services);
+    this.debug('>>> SERVICES DISCOVERED', services);
 
     services.forEach((s) => {
       // We look this up in our resolution map to short-circuit this process
@@ -101,7 +101,7 @@ export class EmberAppPackageGraph extends PackageGraph {
 
         if (!maybePackage) {
           throw new Error(
-            `Unknown error occured. Invalid resolution for service '${s.serviceName}' in options.resolutions.services`
+            `Unknown error occurred. Invalid resolution for service '${s.serviceName}' in options.resolutions.services`
           );
         }
 
@@ -109,7 +109,7 @@ export class EmberAppPackageGraph extends PackageGraph {
         // If yes then it's truly external and we can ignore it
         if (this.package.dependencies && this.package.dependencies[maybePackage]) {
           this.debug(
-            `Ignore! A resolution was found for serivce '${s.serviceName}' in file '${m.path}'.`
+            `Ignore! A resolution was found for service '${s.serviceName}' in file '${m.path}'.`
           );
           return;
         }
@@ -119,7 +119,7 @@ export class EmberAppPackageGraph extends PackageGraph {
         );
       }
 
-      // If we found an addonName we potentially have a resolution within project to a service implmentation
+      // If we found an addonName we potentially have a resolution within project to a service implementation
       if (s.addonName) {
         this.debug(`Coordinates: s.addonName: ${s.addonName} for ${s.serviceName}`);
         // Lookup the addonName in the package graph
@@ -164,7 +164,7 @@ export class EmberAppPackageGraph extends PackageGraph {
           } else {
             // Create an edge between these packages.
             // We can create edges between packages in the project.
-            // When the actual implmentation is added to the project, it will
+            // When the actual implementation is added to the project, it will
             // get updated.
 
             if (this.parent) {
@@ -189,7 +189,7 @@ export class EmberAppPackageGraph extends PackageGraph {
         const someService = this.graph.getNode(maybeServicePath);
         if (!someService) {
           throw new Error(
-            'EmberAppPackageDependencyGraph: Unknown error occured. Unable to retrieve existing service'
+            'EmberAppPackageDependencyGraph: Unknown error occurred. Unable to retrieve existing service'
           );
         }
         this.graph.addEdge(n, someService);
@@ -228,7 +228,7 @@ export class EmberAppPackageGraph extends PackageGraph {
   }
 
   /**
-   * Creates a list of realitve paths in a ember package for where a service
+   * Creates a list of relative paths in an ember package for where a service
    * implementation may exist.
    *
    * @param serviceName

--- a/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-app-project-graph.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import fastGlob from 'fast-glob';
 import { findUpSync } from 'find-up';
 import debug, { type Debugger } from 'debug';
@@ -245,7 +245,7 @@ export class EmberAppProjectGraph extends ProjectGraph {
     // This allows for all package.json files when read to construct a complete graph of dependencies.
     // Regardless of workspaces or ember-engines.
     //
-    // The downside is that we don't limit the scope of direcotires we crawl. We may need to add more
+    // The downside is that we don't limit the scope of directories we crawl. We may need to add more
     //  exclusions to the fastglob above to constrain packageJson discovery.
     //
     // This is why we can ignore workspace data defined in root package.json during discovery.

--- a/packages/migration-graph-ember/src/utils/discover-ember-service-dependencies.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-service-dependencies.ts
@@ -1,10 +1,9 @@
-import { join, extname } from 'node:path';
+import { extname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { parseSync } from '@swc/core';
 import debug from 'debug';
 
 import { transformGjs } from './transform-gjs.js';
-
 import type {
   CallExpression,
   ClassDeclaration,
@@ -101,10 +100,10 @@ export function discoverServiceDependencies(
   let foundClasses: Array<ClassExpression | ClassDeclaration> = [];
 
   // Find all ClassDeclaration in body of the parsed file
-  const classDeclrations = findClassDeclarations(parsed.body);
+  const classDeclarations = findClassDeclarations(parsed.body);
 
-  if (classDeclrations) {
-    foundClasses = foundClasses.concat(Array.from(classDeclrations));
+  if (classDeclarations) {
+    foundClasses = foundClasses.concat(Array.from(classDeclarations));
   }
 
   // Typical use case will have ExportDefaultDeclaration where the body is a ClassExpression
@@ -205,16 +204,16 @@ function findDecoratorWithName(
   return decorators.find((d) => {
     let identifier: Identifier | undefined;
 
-    // For a given decorate it's expression proeprty can either
+    // For a given decorate its expression property can either
     // be an Identifier or CallExpression
 
     // If it's an identifier it would look like
     // e.g. `@service name;`
-    if (isDecoratorWithExpressionTypeIdenfitier(d)) {
+    if (isDecoratorWithExpressionTypeIdentifier(d)) {
       identifier = d.expression as Identifier;
     }
 
-    // If it's a CallExpression this is the case where we pass meta data
+    // If it's a CallExpression this is the case where we pass metadata
     // into the decorator
     // e.g. `@service('someAddon@serviceName') myVariable;`
     else if (isDecoratorWithExpressionTypeCallExpression(d)) {
@@ -230,7 +229,7 @@ function hasDecoratorWithName(decorators: Decorator[], decoratorName: string): b
   return !!findDecoratorWithName(decorators, decoratorName);
 }
 
-function isDecoratorWithExpressionTypeIdenfitier(d: Decorator): boolean {
+function isDecoratorWithExpressionTypeIdentifier(d: Decorator): boolean {
   return d.expression.type === 'Identifier';
 }
 

--- a/packages/migration-graph-ember/src/utils/ember.ts
+++ b/packages/migration-graph-ember/src/utils/ember.ts
@@ -74,7 +74,7 @@ export function requirePackageMain(
 export function getNameFromMain(pathToPackage: string): string | undefined {
   const addonEntryPoint = requirePackageMain(pathToPackage);
 
-  // presence of this method idicates that the module names in code are different
+  // presence of this method indicates that the module names in code are different
   // than the actual module name in package.json
   if (addonEntryPoint.moduleName) {
     return addonEntryPoint.moduleName();

--- a/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-package-graph.test.ts
@@ -26,7 +26,7 @@ describe('Unit | EmberAddonPackageGraph', () => {
 
   test('should create an edge between files when path references moduleName', async () => {
     // Some addons
-    // Use Case where an addon is reference files from within the addon but using the modulenName in the path
+    // Use Case where an addon is reference files from within the addon but using the moduleName in the path
     // e.g. moduleName of some-module
     // Som
     // `import MyComponent from 'some-module/components/some-component';

--- a/packages/migration-graph-ember/test/entities/ember-addon-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-addon-package.test.ts
@@ -59,7 +59,7 @@ describe('Unit | Entities | EmberAddonPackage', () => {
     excludes.forEach((pattern) => {
       expect(
         pkg.excludePatterns.has(pattern),
-        `expect EmberrAddonPackage to exclude ${pattern}`
+        `expect EmberAddonPackage to exclude ${pattern}`
       ).toBeTruthy();
     });
   });

--- a/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package-graph.test.ts
@@ -8,10 +8,10 @@ import {
 } from '@rehearsal/test-support';
 import merge from 'lodash.merge';
 import {
-  type ModuleNode,
-  type PackageNode,
   type Graph,
   type GraphNode,
+  type ModuleNode,
+  type PackageNode,
 } from '@rehearsal/migration-graph-shared';
 import fixturify from 'fixturify';
 import { Project } from 'fixturify-project';
@@ -152,7 +152,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     const options = {};
     const graph: Graph<ModuleNode> = new EmberAppPackageGraph(p, options).discover();
 
-    // Assert edget between salutation and locale.ts
+    // Assert edged between salutation and locale.ts
 
     const source = graph.getNode('app/services/locale.js');
     const dest = graph.getNode('app/services/request.ts');
@@ -245,7 +245,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     ).toBe(true);
   });
 
-  test('should update sythetic node with actual packageNode once added', async () => {
+  test('should update synthetic node with actual packageNode once added', async () => {
     project = getEmberProject('app-with-in-repo-addon');
 
     project.mergeFiles({
@@ -383,7 +383,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     const options: EmberAppPackageGraphOptions = { parent: appNode, project: m };
     emberAppPackage.getModuleGraph(options);
 
-    // Validate that there is a syntehtic node to firstAddon and that there
+    // Validate that there is a synthetic node to firstAddon and that there
     // is an edge between the app and the addon
 
     let firstAddonNode = m.graph.getNode(firstAddonName);
@@ -528,7 +528,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     // app uses a service `date` from `some-addon`
     // └── some-addon exposes `date`
 
-    // We start creating the proejct graph
+    // We start creating the project graph
 
     // We add walk the app first
     // Then we walk the addon.
@@ -609,7 +609,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     const options: EmberAppPackageGraphOptions = { parent: appNode, project: projectGraph };
     emberAppPackage.getModuleGraph(options);
 
-    // Validate that there is a syntehtic node to firstAddon and that there
+    // Validate that there is a synthetic node to firstAddon and that there
     // is an edge between the app and the addon
 
     expect(appNode.adjacent.has(projectGraph.graph.getNode(someAddonModuleName))).toBe(true);
@@ -630,7 +630,7 @@ describe('Unit | EmberAppPackageGraph', () => {
     expect(someNode.content.synthetic, 'the node on the graph should be replaced').toBeFalsy();
   });
 
-  test('should find service with .ts extenstion within an addon', async () => {
+  test('should find service with .ts extension within an addon', async () => {
     const project = getEmberProject('app-with-in-repo-addon');
 
     project.mergeFiles({

--- a/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-package.test.ts
@@ -1,8 +1,8 @@
 import { resolve } from 'node:path';
-import { describe, test, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import { writeSync } from 'fixturify';
 import { DirResult, dirSync, setGracefulCleanup } from 'tmp';
-import { FIXTURES, FIXTURE_NAMES } from '../fixtures/package-fixtures.js';
+import { FIXTURE_NAMES, FIXTURES } from '../fixtures/package-fixtures.js';
 import { EmberAppPackage } from '../../src/entities/ember-app-package.js';
 import { getEmberExcludePatterns } from '../../src/utils/excludes.js';
 
@@ -46,7 +46,7 @@ describe('Unit | Entities | EmberAppPackage', () => {
     excludes.forEach((pattern) => {
       expect(
         pkg.excludePatterns.has(pattern),
-        `expect EmberrAddonPackage to exclude ${pattern}`
+        `expect EmberAddonPackage to exclude ${pattern}`
       ).toBeTruthy();
     });
   });

--- a/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
@@ -52,7 +52,7 @@ describe('Unit | EmberAppProjectGraph', () => {
   test('options.eager=true should create a synthetic node and then backfill when packageName differs from addonName', async () => {
     // If a parent app is crawled first eagerly, it may create some synthetic nodes.
 
-    // Create an app where the app users a service with ambigous coordinates
+    // Create an app where the app users a service with ambiguous coordinates
 
     // package.name is @some-org/some-addon
 
@@ -63,9 +63,9 @@ describe('Unit | EmberAppProjectGraph', () => {
 
     // We put packages in the graph by their packageName
 
-    // This tests the logic in EmberAppprojectGraph.addPackageToGrpah()
+    // This tests the logic in EmberAppProjectGraph.addPackageToGraph()
 
-    // To add a entry in the registry for this lookup so we can update the synthetic node that is injected when this service is not found.
+    // To add a entry in the registry for this lookup, so we can update the synthetic node that is injected when this service is not found.
 
     project = getEmberProject('app-with-in-repo-addon');
 
@@ -131,7 +131,7 @@ export default class Salutation extends Component {
 
     const projectGraph = new EmberAppProjectGraph(project.baseDir, { eager: true });
 
-    // Manualy add the RootPackage or AppPackage for the project, so it will parse the source files.
+    // Manually add the RootPackage or AppPackage for the project, so it will parse the source files.
     const appPackage = new EmberAppPackage(project.baseDir);
     const rootPackageNode = projectGraph.addPackageToGraph(appPackage);
 
@@ -489,12 +489,12 @@ export default class Salutation extends Component {
 
       expect(
         flatten(filter(orderedPackages[0].content.pkg?.getModuleGraph().topSort() || [])),
-        'expected migraiton order for addon'
+        'expected migration order for addon'
       ).toStrictEqual(['addon/components/greet.js']);
 
       expect(
         flatten(filter(orderedPackages[1].content.pkg?.getModuleGraph().topSort() || [])),
-        'expected migraiton order for app'
+        'expected migration order for app'
       ).toStrictEqual(EXPECTED_APP_FILES);
     });
     test('app-with-in-repo-engine', async () => {
@@ -509,12 +509,12 @@ export default class Salutation extends Component {
       expect(flatten(orderedPackages)).toStrictEqual(['some-engine', 'app-template']);
       expect(
         flatten(filter(orderedPackages[0].content.pkg?.getModuleGraph().topSort() || [])),
-        'expected migraiton order for in-repo-engine'
+        'expected migration order for in-repo-engine'
       ).toStrictEqual(['addon/resolver.js', 'addon/engine.js', 'addon/routes.js']);
 
       expect(
         flatten(filter(orderedPackages[1].content.pkg?.getModuleGraph().topSort() || [])),
-        'expected migraiton order for app'
+        'expected migration order for app'
       ).toStrictEqual([
         'app/app.js',
         'app/services/locale.js',

--- a/packages/migration-graph-ember/test/fixtures/package-fixtures.ts
+++ b/packages/migration-graph-ember/test/fixtures/package-fixtures.ts
@@ -20,13 +20,13 @@ const EMBER_FIXTURE_NAMES = {
   ADDON_WITH_COMPLEX_CUSTOM_PACKAGE_MAIN: 'addon-with-complex-custom-module-name',
   WORKSPACE_CONTAINER: 'workspace-container',
   NON_WORKSPACE_IN_WORKSPACE_CONTAINER: 'non-workspace',
-  SIMPLE_ADDON_IN_WORSKAPCE_CONTAINER: 'simple-workspace-addon',
+  SIMPLE_ADDON_IN_WORKSPACE_CONTAINER: 'simple-workspace-addon',
   MULTIPLE_EXPORTS_FROM_ADDON_MAIN: 'multiple-exports-from-addon-main',
 };
 
 const EMBER_FIXTURES: { [key: string]: any } = {};
 
-// Stub this with a package.json becuase this directory of FIXTURES is use for genearting module mappings.
+// Stub this with a package.json because this directory of FIXTURES is use for generating module mappings.
 EMBER_FIXTURES['package.json'] = json({
   name: 'some-root',
   version: '0.0.0',
@@ -231,11 +231,11 @@ EMBER_FIXTURES[EMBER_FIXTURE_NAMES.WORKSPACE_CONTAINER][
 };
 
 EMBER_FIXTURES[EMBER_FIXTURE_NAMES.WORKSPACE_CONTAINER].packages[
-  EMBER_FIXTURE_NAMES.SIMPLE_ADDON_IN_WORSKAPCE_CONTAINER
+  EMBER_FIXTURE_NAMES.SIMPLE_ADDON_IN_WORKSPACE_CONTAINER
 ] = {
   'index.js': readFileSync(join(__dirname, 'simple-addon', 'index.js'), 'utf-8'),
   'package.json': json({
-    name: EMBER_FIXTURE_NAMES.SIMPLE_ADDON_IN_WORSKAPCE_CONTAINER,
+    name: EMBER_FIXTURE_NAMES.SIMPLE_ADDON_IN_WORKSPACE_CONTAINER,
     version: '1.0.0',
     keywords: ['ember-addon'],
     'ember-addon': {
@@ -243,8 +243,6 @@ EMBER_FIXTURES[EMBER_FIXTURE_NAMES.WORKSPACE_CONTAINER].packages[
     },
   }),
 };
-
-
 
 // export the fixture and names for easier mapping
 export { EMBER_FIXTURES as FIXTURES, EMBER_FIXTURE_NAMES as FIXTURE_NAMES };

--- a/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
+++ b/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
@@ -222,11 +222,11 @@ describe('discoverServiceDependencies', () => {
 
     fixturify.writeSync(tmpDir, files);
 
-    const resultss = discoverServiceDependencies(tmpDir, 'service.js');
+    const results = discoverServiceDependencies(tmpDir, 'service.js');
 
-    expect(resultss).toBeTruthy();
-    expect(resultss.length).toBe(1);
-    expect(resultss[0].serviceName).toBe('request');
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0].serviceName).toBe('request');
   });
 
   test('should handle default export and named exports from @ember/service', () => {

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -11,10 +11,10 @@ import type { ProjectGraph } from './project-graph.js';
 import type {
   ICruiseOptions,
   ICruiseResult,
-  IModule,
   IDependency,
-  IResolveOptions,
+  IModule,
   IReporterOutput,
+  IResolveOptions,
 } from '../../types/dependency-cruiser/index.js';
 
 const EXCLUDE_FILE_EXTS = ['\\.css$', '\\.json$', '\\.graphql$'];
@@ -34,7 +34,7 @@ export type PackageGraphOptions = {
   project?: ProjectGraph;
 };
 export class PackageGraph {
-  protected debug: Debugger = debug(`rehearsal:migration-graph-sahred:${this.constructor.name}`);
+  protected debug: Debugger = debug(`rehearsal:migration-graph-shared:${this.constructor.name}`);
 
   protected baseDir: string;
   protected package: Package;
@@ -83,7 +83,7 @@ export class PackageGraph {
 
     let result: IReporterOutput;
 
-    // TODO get entrypoint  Package (maybePckage) and instantiate with that value if provided from API.
+    // TODO get entrypoint  Package (maybePackage) and instantiate with that value if provided from API.
     const target = entrypoint ? [entrypoint] : [...include];
 
     const resolveOptions = this.resolveOptions;
@@ -111,7 +111,7 @@ export class PackageGraph {
       }
 
       // IModule.source and IDependency.resolved paths from dependency-cruiser can
-      // have awkward paths when using a tmpDir in MacOS resolveing the paths to the
+      // have awkward paths when using a tmpDir in MacOS resolving the paths to the
       // baseDir helps ensure we always get a file path relative to the baseDir.
 
       const sourcePath = resolveRelative(baseDir, m.source);
@@ -120,7 +120,7 @@ export class PackageGraph {
         this.debug(
           `The target file "${sourcePath}" is external to package "${this.package.packageName}" (${baseDir}), omitting target file form package-graph.`
         );
-        // Should resolve path completely relativeto the project and find which package it belongs to.
+        // Should resolve path completely relative to the project and find which package it belongs to.
         // Ask project which package does this belong maybe create an edge?
         return;
       }

--- a/packages/migration-graph-shared/src/entities/project-graph.ts
+++ b/packages/migration-graph-shared/src/entities/project-graph.ts
@@ -84,7 +84,7 @@ export class ProjectGraph {
       this.debug('Package %s appears to been migrated to Typescript.', p.packageName);
     }
 
-    // Find in-project dependnecies/devDepenencies
+    // Find in-project dependencies/devDependencies
     if (crawl) {
       this.discoverEdgesFromDependencies(node);
     }
@@ -144,7 +144,7 @@ export class ProjectGraph {
 
     if (deps) {
       this.debug(
-        'Found explicit depedencies for %s: %s',
+        'Found explicit dependencies for %s: %s',
         pkg.packageName,
         deps.map((p) => p.packageName)
       );

--- a/packages/migration-graph-shared/test/entities/package.test.ts
+++ b/packages/migration-graph-shared/test/entities/package.test.ts
@@ -117,12 +117,12 @@ describe('Unit | Entities | Package', function () {
       const p = new Package(pathToPackage);
       expect(p.isConvertedToTypescript()).toBe(false);
     });
-    test('should be true if tsconfig.json and atleast one .ts file exists', () => {
+    test('should be true if tsconfig.json and at least one .ts file exists', () => {
       pathToPackage = getPathToPackage(FIXTURE_NAMES.PACKAGE_CONTAINS_TYPESCRIPT);
       const p = new Package(pathToPackage);
       expect(p.isConvertedToTypescript()).toBe(true);
     });
-    test('should be true if tsconfig.json and atleast one .ts file exists', () => {
+    test('should be true if tsconfig.json and at least one .ts file exists', () => {
       pathToPackage = getPathToPackage(FIXTURE_NAMES.PACKAGE_CONTAINS_TYPESCRIPT);
       const p = new Package(pathToPackage);
       expect(p.isConvertedToTypescript()).toBe(true);

--- a/packages/migration-graph-shared/test/entities/project-graph.test.ts
+++ b/packages/migration-graph-shared/test/entities/project-graph.test.ts
@@ -1,5 +1,5 @@
 import { getFiles } from '@rehearsal/test-support';
-import { describe, expect, test, afterEach } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { Project } from 'fixturify-project';
 import { ProjectGraph } from '../../src/entities/project-graph.js';
 import { onlyPackage, Package } from '../../src/entities/package.js';
@@ -260,7 +260,7 @@ describe('project-graph', () => {
         '@something/blorp',
         '@something/bar',
         '@something/foo',
-        'some-library-with-workspace', // Root Pacakge is last.
+        'some-library-with-workspace', // Root Package is last.
       ]);
 
       const [package0, package1, package2, package3, package4] = sortedPackages

--- a/packages/migration-graph-shared/test/graph/graph.test.ts
+++ b/packages/migration-graph-shared/test/graph/graph.test.ts
@@ -49,7 +49,7 @@ describe('graph', () => {
 
     // We expect a leaf-to-root output.
     // const expected = ['0', '1', '3', '2', '4', '5'];
-    // This order is determiend by the order for which the node was added to the graph.
+    // This order is determined by the order for which the node was added to the graph.
     // Node f was added first and it's dependencies are in the order of adjacencies.
     const expected = ['1', '3', '2', '0', '5', '4'];
     const nodes = graph.topSort();

--- a/packages/migration-graph/src/migration-strategy.ts
+++ b/packages/migration-graph/src/migration-strategy.ts
@@ -64,7 +64,7 @@ export class MigrationStrategy {
 
   toString(): string {
     const files = this.#files.reduce((f, result) => `${result}\n${f}`, '');
-    return `Suggsted Migration Strategy\n${files}`;
+    return `Suggested Migration Strategy\n${files}`;
   }
 }
 

--- a/packages/service/src/rehearsal-service-host.ts
+++ b/packages/service/src/rehearsal-service-host.ts
@@ -49,10 +49,10 @@ export class RehearsalServiceHost implements LanguageServiceHost {
 
   async installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult> {
     if (this.seenTypingsRequest.has(options.fileName)) {
-      return { successMessage: `Succussfully installed ${options.packageName}` };
+      return { successMessage: `Successfully installed ${options.packageName}` };
     }
 
-    // Save the intall request information so we don't continuously download
+    // Save the install request information, so we don't continuously download
     this.seenTypingsRequest.set(options.fileName, options.packageName);
 
     const nearestPackageJSON = findupSync('package.json', {
@@ -69,7 +69,7 @@ export class RehearsalServiceHost implements LanguageServiceHost {
       // types we just downloaded
       this.typeRootVersion++;
 
-      return { successMessage: `Succussfully installed ${options.packageName}` };
+      return { successMessage: `Successfully installed ${options.packageName}` };
     }
 
     return Promise.reject({ error: `Could not install ${options.packageName}` });

--- a/packages/test-support/src/files.ts
+++ b/packages/test-support/src/files.ts
@@ -159,7 +159,7 @@ export const FILES_EMBER_APP = {
   },
 };
 
-export function getEmberAddonConfigEmberyTryFile(): string {
+export function getEmberAddonConfigEmberTryFile(): string {
   return FILE_EMBER_ADDON_CONFIG_EMBER_TRY;
 }
 export function getEmberAppFiles(): fixturify.DirJSON {
@@ -370,7 +370,7 @@ export function getEmberAppWithInRepoEngine(engineName = 'some-engine'): fixturi
       `,
     },
     lib: {
-      // Add the egine to lib directory
+      // Add the engine to lib directory
       [engineName]: {
         addon: {
           'engine.js': `

--- a/packages/test-support/src/project.ts
+++ b/packages/test-support/src/project.ts
@@ -4,9 +4,9 @@ import findupSync from 'findup-sync';
 import tmp from 'tmp';
 import { Project } from 'fixturify-project';
 import {
+  getEmberAddonFiles,
   getEmberAppFiles,
   getEmberAppWithInRepoAddonFiles,
-  getEmberAddonFiles,
   getEmberAppWithInRepoEngine,
 } from './files.js';
 
@@ -17,7 +17,7 @@ const __dirname = dirname(__filename);
 const maybePackageJson = findupSync('./package.json', { cwd: __dirname });
 
 if (!maybePackageJson) {
-  throw new Error('Unable to dermien rooDir for @rehearsal/test-support');
+  throw new Error('Unable to determine rooDir for @rehearsal/test-support');
 }
 
 const ROOT_DIR = dirname(maybePackageJson);
@@ -94,7 +94,7 @@ function addUtilDirectory(project: Project): Project {
 }
 
 /**
- * Augments the project to have an in-repo addon with an acceptance test to evalute the composition.
+ * Augments the project to have an in-repo addon with an acceptance test to evaluate the composition.
  * @param {Project} project
  * @param {string} [addonName='some-addon']
  */
@@ -232,7 +232,7 @@ export function getEmberProject(variant: EmberProjectFixture): Project {
       project = getEmberAddonProject();
       break;
     default:
-      throw new Error(`Unable to getProjectVaraint for '${variant}'.`);
+      throw new Error(`Unable to getProjectVariant for '${variant}'.`);
   }
 
   return project;

--- a/packages/test-support/src/scenarios.ts
+++ b/packages/test-support/src/scenarios.ts
@@ -1,12 +1,12 @@
 import { join } from 'node:path';
-import { Scenarios, Scenario, PreparedApp } from 'scenario-tester';
+import { PreparedApp, Scenario, Scenarios } from 'scenario-tester';
 import { rimraf } from 'rimraf';
 
 import {
-  getEmberAppProject,
-  emberAppTemplate,
   emberAddonTemplate,
+  emberAppTemplate,
   getEmberAddonProject,
+  getEmberAppProject,
   getEmberAppWithInRepoAddonProject,
   getEmberAppWithInRepoEngineProject,
 } from './project.js';
@@ -72,7 +72,7 @@ async function getPreparedApp(scenario: Scenario, cache = false): Promise<Prepar
     const maybeApp = preparedAppCache.get(scenario);
 
     if (!maybeApp) {
-      throw new Error(`Unable to retrieve parepared app for ${scenario.name}`);
+      throw new Error(`Unable to retrieve prepared app for ${scenario.name}`);
     }
 
     return maybeApp;

--- a/packages/test-support/test/scenarios-app.test.ts
+++ b/packages/test-support/test/scenarios-app.test.ts
@@ -2,7 +2,7 @@ import { PreparedApp, Scenario } from 'scenario-tester';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { appScenarios, clean } from '../src/scenarios.js';
 
-// Enable these tests to validate if our scenarios fixtures build a funciton all
+// Enable these tests to validate if our scenarios fixtures build a function all
 describe('scenarios - app-variants', () => {
   appScenarios.forEachScenario((scenario: Scenario) => {
     describe(scenario.name, () => {

--- a/packages/test-support/test/scenarios-debug.test.ts
+++ b/packages/test-support/test/scenarios-debug.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { clean, getEmberAppScenario } from '../src/scenarios.js';
 
-// Enable these tests to validate if our scenarios fixtures build a funciton all
+// Enable these tests to validate if our scenarios fixtures build a function all
 describe('scenarios - validate scenarios for npm install + test', () => {
   test.skip('debug scenario test', async () => {
     const app = await getEmberAppScenario('app'); // Choose a scenario to debug

--- a/packages/ts-utils/test/tsc-utils/is-subtype-of.test.ts
+++ b/packages/ts-utils/test/tsc-utils/is-subtype-of.test.ts
@@ -49,7 +49,7 @@ describe('Test isSubtypeOf', () => {
     hasSubtype(9, 'Student');
   });
 
-  test('should return false when empty string is passed in as the subttype string', () => {
+  test('should return false when empty string is passed in as the subtype string', () => {
     hasNotSubtype(1, '');
   });
 });

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -1,10 +1,10 @@
-import { join, resolve, normalize, dirname, relative } from 'node:path';
-import { readFileSync, existsSync } from 'node:fs';
-import { writeJSONSync, readJSONSync } from 'fs-extra/esm';
+import { dirname, join, normalize, relative, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { readJSONSync, writeJSONSync } from 'fs-extra/esm';
 import { compare } from 'compare-versions';
 import json5 from 'json5';
 import { valid } from 'semver';
-import { type SimpleGit, type SimpleGitOptions, simpleGit } from 'simple-git';
+import { type SimpleGit, simpleGit, type SimpleGitOptions } from 'simple-git';
 import which from 'which';
 import { InvalidArgumentError } from 'commander';
 import chalk from 'chalk';
@@ -13,8 +13,8 @@ import micromatch from 'micromatch';
 import yaml from 'js-yaml';
 import { execa, execaSync } from 'execa';
 import findupSync from 'findup-sync';
-import type { GitDescribe } from './types.js';
 import type { Options } from 'execa';
+import type { GitDescribe } from './types.js';
 import type { PackageJson } from 'type-fest';
 
 export const VERSION_PATTERN = /_(\d+\.\d+\.\d+)/;
@@ -30,7 +30,7 @@ export async function gitCommit(msg: string, msgType = 'chore(deps-dev)'): Promi
   await git.commit(`${msgType.trim()}: [REHEARSAL-BOT] ${msg.trim()}`, '--no-verify');
 }
 
-// we want a seperate branch & PR for each diagnostic
+// we want a separate branch & PR for each diagnostic
 // eg. await gitCheckoutNewBranch('4.8.0-beta', 'typescript', 'diagnostic-4082')
 export async function gitCheckoutNewLocalBranch(
   depSemVersion: string,


### PR DESCRIPTION
Fix a bunch of typos in comments and output messages.

Imports in affected files are reordered automatically by IDE on save.