### PR TITLE
feat(cli): set resolution of ts in migrated app

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/analyze.ts
+++ b/packages/cli/src/commands/migrate/tasks/analyze.ts
@@ -27,7 +27,7 @@ export function analyzeTask(
   options: MigrateCommandOptions
 ): ListrTask<MigrateCommandContext, ListrDefaultRenderer> {
   return {
-    title: 'Analyzing Project',
+    title: 'Analyze project',
     async task(ctx: MigrateCommandContext, task) {
       const projectName = determineProjectName(options.basePath);
       const packages = discoverEmberPackages(options.basePath);
@@ -41,7 +41,7 @@ export function analyzeTask(
           !existsSync(resolve(options.basePath, options.package, 'package.json'))
         ) {
           throw Error(
-            `Cannot find package ${options.package} in your project. Please make sure it is a valid package and try again.`
+            `Cannot find package ${options.package} in your project. Make sure its a valid package and try again.`
           );
         }
         // set targetPackagePath to the absolute path or the package and continue

--- a/packages/cli/src/commands/migrate/tasks/config-lint.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-lint.ts
@@ -79,11 +79,11 @@ export function lintConfigTask(
       }
 
       if (ctx.userConfig?.hasLintSetup) {
-        task.output = `Create .eslintrc.js from config`;
+        task.output = `Create .eslintrc.js from rehearsal config`;
         await ctx.userConfig.lintSetup();
 
         if (ctx.userConfig.hasPostLintSetup) {
-          task.output = `Run postLintSetup from config`;
+          task.output = `Run postLintSetup from rehearsal config`;
           await ctx.userConfig.postLintSetup();
         }
       } else {
@@ -96,7 +96,7 @@ export function lintConfigTask(
         createRehearsalConfig(options.basePath, format);
 
         if (relativeConfigPath) {
-          task.output = `${relativeConfigPath} already exists, extending Rehearsal default eslint-related config`;
+          task.output = `${relativeConfigPath} already exists, extending rehearsal default eslint-related config`;
           task.title = `Update .eslintrc${format === FORMAT.NO_EXTENSION ? '' : '.' + format}`;
 
           const absoluteConfigPath = resolve(relativeConfigPath);
@@ -108,7 +108,7 @@ export function lintConfigTask(
             options.basePath
           );
         } else {
-          task.output = `Create .eslintrc.${FORMAT.JS}, extending Rehearsal default eslint-related config`;
+          task.output = `Create .eslintrc.${FORMAT.JS}, extending rehearsal default eslint-related config`;
           await extendsRehearsalInNewConfig(options.basePath, `.eslintrc.${FORMAT.JS}`);
         }
       }

--- a/packages/cli/src/commands/migrate/tasks/config-ts.ts
+++ b/packages/cli/src/commands/migrate/tasks/config-ts.ts
@@ -57,11 +57,11 @@ export function tsConfigTask(
       const configPath = resolve(options.basePath, 'tsconfig.json');
 
       if (ctx.userConfig?.hasTsSetup) {
-        task.output = `Create tsconfig from config`;
+        task.output = `Create tsconfig from rehearsal config`;
         await ctx.userConfig.tsSetup();
 
         if (ctx.userConfig.hasPostTsSetupHook) {
-          task.output = `Run postTsSetup from config`;
+          task.output = `Run postTsSetup from rehearsal config`;
           await ctx.userConfig.postTsSetup();
         }
       } else {

--- a/packages/cli/src/commands/migrate/tasks/regen.ts
+++ b/packages/cli/src/commands/migrate/tasks/regen.ts
@@ -9,7 +9,7 @@ import type { MigrateCommandContext, MigrateCommandOptions } from '../../../type
 
 export function regenTask(options: MigrateCommandOptions, logger: Logger): ListrTask {
   return {
-    title: 'Regenerating report for TS errors and Eslint errors',
+    title: 'Regenerating report for TS errors and ESLint errors',
     enabled: (): boolean => !options.dryRun,
     task: async (_: MigrateCommandContext, task): Promise<void> => {
       // Because we have to eagerly import all the tasks we need to lazily load these

--- a/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/analyze.test.ts.snap
@@ -16,9 +16,9 @@ exports[`Task: analyze > accept --package option to skip the selection 1`] = `
 `;
 
 exports[`Task: analyze > accept --package option to skip the selection 2`] = `
-"[STARTED] Analyzing Project
+"[STARTED] Analyze project
 [DATA] Running migration on package .
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 "
 `;
 
@@ -41,9 +41,9 @@ exports[`Task: analyze > get files that will be migrated 1`] = `
 `;
 
 exports[`Task: analyze > get files that will be migrated 2`] = `
-"[STARTED] Analyzing Project
+"[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 "
 `;
 
@@ -90,12 +90,12 @@ exports[`Task: analyze > multi-package > show package progress in interactive mo
 `;
 
 exports[`Task: analyze > print files will be attempted to migrate with --dryRun 1`] = `
-"[STARTED] Analyzing Project
+"[STARTED] Analyze project
 [DATA] Running migration on basic
 [DATA] List of files will be attempted to migrate:
 [DATA]  foo.js
 [DATA] depends-on-foo.js
 [DATA] index.js
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-addon.test.ts.snap
@@ -3,9 +3,10 @@
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 "
 `;
@@ -13,10 +14,11 @@ exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > create .eslint
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
+[DATA] Create .eslintrc.js from rehearsal config
+[DATA] Run postLintSetup from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -24,9 +26,10 @@ exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > postLintSetup 
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-app.test.ts.snap
@@ -1,135 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Task: config-lint -- ember-app-matrix > app > create .eslintrc.js if not existed 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > app > postLintSetup hook from user config 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > app > run custom config command with user config provided 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appEmber4 > create .eslintrc.js if not existed 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appEmber4 > postLintSetup hook from user config 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appEmber4 > run custom config command with user config provided 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoAddon > create .eslintrc.js if not existed 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoAddon > postLintSetup hook from user config 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoAddon > run custom config command with user config provided 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoEngine > create .eslintrc.js if not existed 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoEngine > postLintSetup hook from user config 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
-[SUCCESS] Create eslint config
-"
-`;
-
-exports[`Task: config-lint -- ember-app-matrix > appWithInRepoEngine > run custom config command with user config provided 1`] = `
-"[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
-[SUCCESS] Install dependencies
-[STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[SUCCESS] Create eslint config
-"
-`;
-
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 "
 `;
@@ -137,10 +14,11 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > create .eslintrc.j
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
+[DATA] Create .eslintrc.js from rehearsal config
+[DATA] Run postLintSetup from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -148,9 +26,10 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > postLintSetup hook
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -158,9 +37,10 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > run custom config 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 "
 `;
@@ -168,10 +48,11 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > cre
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
+[DATA] Create .eslintrc.js from rehearsal config
+[DATA] Run postLintSetup from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -179,9 +60,10 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > pos
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -189,9 +71,10 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > run
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 "
 `;
@@ -199,10 +82,11 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > cr
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
+[DATA] Create .eslintrc.js from rehearsal config
+[DATA] Run postLintSetup from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -210,9 +94,10 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > po
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.test.ts.snap
@@ -3,9 +3,10 @@
 exports[`Task: config-lint > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 "
 `;
@@ -13,10 +14,11 @@ exports[`Task: config-lint > create .eslintrc.js if not existed 1`] = `
 exports[`Task: config-lint > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
-[DATA] Run postLintSetup from config
+[DATA] Create .eslintrc.js from rehearsal config
+[DATA] Run postLintSetup from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;
@@ -24,9 +26,10 @@ exports[`Task: config-lint > postLintSetup hook from user config 1`] = `
 exports[`Task: config-lint > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-addon.test.ts.snap
@@ -26,22 +26,22 @@ exports[`Task: config-ts ember app > emberAddon > create tsconfig if not existed
 
 exports[`Task: config-ts ember app > emberAddon > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAddon > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
-[DATA] Run postTsSetup from config
+[DATA] Create tsconfig from rehearsal config
+[DATA] Run postTsSetup from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAddon > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.ember-app.test.ts.snap
@@ -40,22 +40,22 @@ exports[`Task: config-ts ember app > emberApp > create tsconfig if not existed 2
 
 exports[`Task: config-ts ember app > emberApp > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberApp > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
-[DATA] Run postTsSetup from config
+[DATA] Create tsconfig from rehearsal config
+[DATA] Run postTsSetup from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberApp > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
@@ -124,22 +124,22 @@ exports[`Task: config-ts ember app > emberAppWithInRepoAddon > create tsconfig i
 
 exports[`Task: config-ts ember app > emberAppWithInRepoAddon > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAppWithInRepoAddon > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
-[DATA] Run postTsSetup from config
+[DATA] Create tsconfig from rehearsal config
+[DATA] Run postTsSetup from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAppWithInRepoAddon > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
@@ -208,22 +208,22 @@ exports[`Task: config-ts ember app > emberAppWithInRepoEngine > create tsconfig 
 
 exports[`Task: config-ts ember app > emberAppWithInRepoEngine > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAppWithInRepoEngine > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
-[DATA] Run postTsSetup from config
+[DATA] Create tsconfig from rehearsal config
+[DATA] Run postTsSetup from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts ember app > emberAppWithInRepoEngine > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-ts.test.ts.snap
@@ -26,22 +26,22 @@ exports[`Task: config-ts > create tsconfig if not existed 2`] = `
 
 exports[`Task: config-ts > do not skip if custom config exists 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts > postTsSetup hook from user config 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
-[DATA] Run postTsSetup from config
+[DATA] Create tsconfig from rehearsal config
+[DATA] Run postTsSetup from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;
 
 exports[`Task: config-ts > run custom config command with user config provided 1`] = `
 "[STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/convert.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/convert.test.ts.snap
@@ -6,18 +6,19 @@ exports[`Task: convert > accept and discard changes with git 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] ? We have found multiple packages in your project, select the one to migrate:  
 [DATA]  basic(no progress found)
 [DATA]  We have found multiple packages in your project, select the one to migrate:  basic(no progress found)
 [DATA] Running migration on <tmp-path>
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -67,18 +68,19 @@ exports[`Task: convert > accept changes without git 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] ? We have found multiple packages in your project, select the one to migrate:  
 [DATA]  basic(no progress found)
 [DATA]  We have found multiple packages in your project, select the one to migrate:  basic(no progress found)
 [DATA] Running migration on <tmp-path>
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -126,18 +128,19 @@ exports[`Task: convert > cancel prompt in interactive mode 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] ? We have found multiple packages in your project, select the one to migrate:  
 [DATA]  basic(no progress found)
 [DATA]  We have found multiple packages in your project, select the one to migrate:  basic(no progress found)
 [DATA] Running migration on <tmp-path>
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -158,15 +161,16 @@ exports[`Task: convert > generate reports 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -213,15 +217,16 @@ exports[`Task: convert > migrate from default all files .js in root 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -268,15 +273,16 @@ exports[`Task: convert > migrate from specific entrypoint 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -321,18 +327,19 @@ exports[`Task: convert > view changes in $EDITOR 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] ? We have found multiple packages in your project, select the one to migrate:  
 [DATA]  basic(no progress found)
 [DATA]  We have found multiple packages in your project, select the one to migrate:  basic(no progress found)
 [DATA] Running migration on <tmp-path>
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts

--- a/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
@@ -2,17 +2,19 @@
 
 exports[`Task: dependency-install > do not run postInstall command if empty 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 "
 `;
 
 exports[`Task: dependency-install > install custom dependencies 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 "
 `;
@@ -20,15 +22,17 @@ exports[`Task: dependency-install > install custom dependencies 1`] = `
 exports[`Task: dependency-install > install required dependencies 1`] = `
 "[STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 "
 `;
 
 exports[`Task: dependency-install > multiple postInstall commands from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 "
 `;
@@ -50,9 +54,10 @@ We ran into an error when installing devDependencies, please install the followi
 
 exports[`Task: dependency-install > single postInstall command from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, fs-extra
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 "
 `;

--- a/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/e2e.test.ts.snap
@@ -9,18 +9,19 @@ exports[`migrate - validation > absolute entrypoint inside project root works 1`
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] processing file: /foo.ts
@@ -49,18 +50,19 @@ exports[`migrate - validation > not throw if in project root with unrelated npm/
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on package-a
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [TITLE] Migration Complete
 [TITLE]   0 JS files converted to TS
@@ -87,18 +89,19 @@ exports[`migrate - validation > not throw if in project root with unrelated npm/
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on package-a
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [TITLE] Migration Complete
 [TITLE]   0 JS files converted to TS
@@ -125,18 +128,19 @@ exports[`migrate - validation > relative entrypoint inside project root works 1`
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] processing file: /foo.ts
@@ -165,18 +169,19 @@ exports[`migrate: e2e > Print debug messages with --verbose 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 debug:   migration started
 debug:   Base path: <tmp-path>
@@ -214,18 +219,19 @@ exports[`migrate: e2e > default migrate command 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -396,9 +402,9 @@ exports[`migrate: e2e > migrate would skip steps after migrate init 4`] = `
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
 [SUCCESS] Add package scripts
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -449,7 +455,7 @@ exports[`migrate: e2e > regen result after the first pass 1`] = `
 "info:    @rehearsal/migrate<test-version>
 [STARTED] Validate project
 [SUCCESS] Validate project
-[STARTED] Regenerating report for TS errors and Eslint errors
+[STARTED] Regenerating report for TS errors and ESLint errors
 [DATA] processing file: /foo.ts
 [DATA] processing file: /depends-on-foo.ts
 [DATA] processing file: /index.ts

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
@@ -8,11 +8,12 @@ exports[`migrate init for ember addon variant > ember3-addon > default run --emb
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -72,15 +73,16 @@ exports[`migrate init for ember addon variant > ember3-addon > pass user config 
 [DATA] Setting up config for addon-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
@@ -8,13 +8,14 @@ exports[`migrate init for ember app variant > ember4App > default run --ember4Ap
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
 [SUCCESS] Update tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -86,15 +87,16 @@ exports[`migrate init for ember app variant > ember4App > pass user config ember
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -130,13 +132,14 @@ exports[`migrate init for ember app variant > emberApp > default run --emberApp 
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
 [SUCCESS] Update tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -208,15 +211,16 @@ exports[`migrate init for ember app variant > emberApp > pass user config emberA
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -252,13 +256,14 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > default 
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
 [SUCCESS] Update tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -330,15 +335,16 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > pass use
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -374,13 +380,14 @@ exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [DATA] <tmp-path>/tsconfig.json already exists, ensuring strict mode is enabled
 [TITLE] Update tsconfig.json
 [SUCCESS] Update tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -452,15 +459,16 @@ exports[`migrate init for ember app variant > emberAppWithInRepoEngine > pass us
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
@@ -8,11 +8,12 @@ exports[`migrate init > default run 1`] = `
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json
@@ -79,15 +80,16 @@ exports[`migrate init > pass user config 1`] = `
 [DATA] Setting up config for basic
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from config
+[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
-[DATA] Create tsconfig from config
+[DATA] Create tsconfig from rehearsal config
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js from config
+[DATA] Create .eslintrc.js from rehearsal config
 [SUCCESS] Create eslint config
 [STARTED] Add package scripts
 [DATA] Adding \\"lint:tsc\\" script in package.json

--- a/packages/cli/test/commands/migrate/__snapshots__/regen.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/regen.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Task: regen > no effect on JS files before conversion 1`] = `
 [SUCCESS] Validate project
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
-[STARTED] Regenerating report for TS errors and Eslint errors
+[STARTED] Regenerating report for TS errors and ESLint errors
 [TITLE] Migration Report Generated
 [TITLE] 
 [TITLE] 
@@ -43,11 +43,11 @@ exports[`Task: regen > update ts and lint errors based on previous conversion 1`
 [STARTED] Create tsconfig.json
 [SKIPPED] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on basic_regen
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Convert JS files to TS
 [DATA] git mv /foo.js to /foo.ts
 [DATA] git mv /depends-on-foo.js to /depends-on-foo.ts
@@ -85,7 +85,7 @@ exports[`Task: regen > update ts and lint errors based on previous conversion 1`
 [SUCCESS] 
 [SUCCESS]     -- 1 eslint errors, with details in the report
 [SUCCESS] 
-[STARTED] Regenerating report for TS errors and Eslint errors
+[STARTED] Regenerating report for TS errors and ESLint errors
 [DATA] processing file: /foo.ts
 [DATA] processing file: /depends-on-foo.ts
 [DATA] processing file: /index.ts

--- a/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/sequential.test.ts.snap
@@ -6,15 +6,16 @@ exports[`Task: sequential > sequential run regen on the existing report, and run
 [SUCCESS] Initialize
 [STARTED] Install dependencies
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
 [SUCCESS] Create tsconfig.json
 [STARTED] Create eslint config
-[DATA] Create .eslintrc.js, extending Rehearsal default eslint-related config
+[DATA] Create .eslintrc.js, extending rehearsal default eslint-related config
 [SUCCESS] Create eslint config
-[STARTED] Analyzing Project
+[STARTED] Analyze project
 [DATA] Running migration on sequential
-[SUCCESS] Analyzing Project
+[SUCCESS] Analyze project
 [STARTED] Regenerating past migrate report(s), generating current migrate report and merging all reports
 [DATA] processing file: /foo.ts
 [DATA] processing file: /index.ts

--- a/packages/cli/test/commands/migrate/analyze.test.ts
+++ b/packages/cli/test/commands/migrate/analyze.test.ts
@@ -105,7 +105,7 @@ describe('Task: analyze', () => {
 
     // migration would continue after sending "enter" key
     expect(output).toContain(`[DATA] Running migration on ${project.baseDir}`);
-    expect(output).toContain('[SUCCESS] Analyzing Project');
+    expect(output).toContain('[SUCCESS] Analyze project');
 
     // check context
     const expectedRelativePaths = ['foo.js', 'depends-on-foo.js', 'index.js'];
@@ -135,7 +135,7 @@ describe('Task: analyze', () => {
     const options = createMigrateOptions(project.baseDir, { package: 'no-valid-package' });
     const tasks = [analyzeTask(options)];
     await expect(() => listrTaskRunner(tasks)).rejects.toThrowError(
-      `Cannot find package no-valid-package in your project. Please make sure it is a valid package and try again.`
+      `Cannot find package no-valid-package in your project. Make sure its a valid package and try again.`
     );
   });
 

--- a/packages/cli/test/commands/migrate/config-lint.ember-addon.test.ts
+++ b/packages/cli/test/commands/migrate/config-lint.ember-addon.test.ts
@@ -55,7 +55,7 @@ describe('Task: config-lint -- ember-addon-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.js');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.js');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         /* eslint-disable-next-line @typescript-eslint/no-var-requires */
         const newConfig = require(resolve(app.dir, '.eslintrc.js')) as { extends: string[] };
@@ -79,7 +79,7 @@ describe('Task: config-lint -- ember-addon-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc'));
@@ -105,7 +105,7 @@ describe('Task: config-lint -- ember-addon-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.json');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.json');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.json'));
@@ -131,7 +131,7 @@ describe('Task: config-lint -- ember-addon-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.yml');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.yml');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.yml'));
@@ -158,7 +158,7 @@ describe('Task: config-lint -- ember-addon-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.yaml');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.yaml');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.yaml'));

--- a/packages/cli/test/commands/migrate/config-lint.ember-app.test.ts
+++ b/packages/cli/test/commands/migrate/config-lint.ember-app.test.ts
@@ -55,7 +55,7 @@ describe('Task: config-lint -- ember-app-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.js');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.js');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         /* eslint-disable-next-line @typescript-eslint/no-var-requires */
         const newConfig = require(resolve(app.dir, '.eslintrc.js')) as { extends: string[] };
@@ -79,7 +79,7 @@ describe('Task: config-lint -- ember-app-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc'));
@@ -105,7 +105,7 @@ describe('Task: config-lint -- ember-app-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.json');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.json');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.json'));
@@ -131,7 +131,7 @@ describe('Task: config-lint -- ember-app-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.yml');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.yml');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.yml'));
@@ -158,7 +158,7 @@ describe('Task: config-lint -- ember-app-matrix', () => {
         expect(readdirSync(app.dir)).toContain('.eslintrc.yaml');
         expect(readdirSync(app.dir)).toContain('.rehearsal-eslintrc.yaml');
         // Do not use snapshot here since there is absolute path in output
-        expect(output).toContain('extending Rehearsal default eslint-related config');
+        expect(output).toContain('extending rehearsal default eslint-related config');
 
         explorerSync = cosmiconfigSync('');
         const loaded = explorerSync.load(resolve(app.dir, '.eslintrc.yaml'));

--- a/packages/cli/test/commands/migrate/config-lint.test.ts
+++ b/packages/cli/test/commands/migrate/config-lint.test.ts
@@ -53,7 +53,7 @@ describe('Task: config-lint', () => {
     expect(readdirSync(project.baseDir)).toContain('.eslintrc.js');
     expect(readdirSync(project.baseDir)).toContain('.rehearsal-eslintrc.js');
     // Do not use snapshot here since there is absolute path in output
-    expect(output).toContain('extending Rehearsal default eslint-related config');
+    expect(output).toContain('extending rehearsal default eslint-related config');
 
     /* eslint-disable-next-line @typescript-eslint/no-var-requires */
     const newConfig = require(resolve(project.baseDir, '.eslintrc.js')) as { extends: string[] };
@@ -77,7 +77,7 @@ describe('Task: config-lint', () => {
     expect(readdirSync(project.baseDir)).toContain('.eslintrc');
     expect(readdirSync(project.baseDir)).toContain('.rehearsal-eslintrc');
     // Do not use snapshot here since there is absolute path in output
-    expect(output).toContain('extending Rehearsal default eslint-related config');
+    expect(output).toContain('extending rehearsal default eslint-related config');
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(project.baseDir, '.eslintrc'));
@@ -103,7 +103,7 @@ describe('Task: config-lint', () => {
     expect(readdirSync(project.baseDir)).toContain('.eslintrc.json');
     expect(readdirSync(project.baseDir)).toContain('.rehearsal-eslintrc.json');
     // Do not use snapshot here since there is absolute path in output
-    expect(output).toContain('extending Rehearsal default eslint-related config');
+    expect(output).toContain('extending rehearsal default eslint-related config');
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(project.baseDir, '.eslintrc.json'));
@@ -129,7 +129,7 @@ describe('Task: config-lint', () => {
     expect(readdirSync(project.baseDir)).toContain('.eslintrc.yml');
     expect(readdirSync(project.baseDir)).toContain('.rehearsal-eslintrc.yml');
     // Do not use snapshot here since there is absolute path in output
-    expect(output).toContain('extending Rehearsal default eslint-related config');
+    expect(output).toContain('extending rehearsal default eslint-related config');
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(project.baseDir, '.eslintrc.yml'));
@@ -156,7 +156,7 @@ describe('Task: config-lint', () => {
     expect(readdirSync(project.baseDir)).toContain('.eslintrc.yaml');
     expect(readdirSync(project.baseDir)).toContain('.rehearsal-eslintrc.yaml');
     // Do not use snapshot here since there is absolute path in output
-    expect(output).toContain('extending Rehearsal default eslint-related config');
+    expect(output).toContain('extending rehearsal default eslint-related config');
 
     explorerSync = cosmiconfigSync('');
     const loaded = explorerSync.load(resolve(project.baseDir, '.eslintrc.yaml'));

--- a/packages/cli/test/commands/migrate/e2e.test.ts
+++ b/packages/cli/test/commands/migrate/e2e.test.ts
@@ -321,9 +321,9 @@ describe('migrate: e2e', () => {
         '[STARTED] Initialize',
         '[DATA] Setting up config for initialization',
         '[SUCCESS] Initialize',
-        '[STARTED] Analyzing Project',
+        '[STARTED] Analyze project',
         '[DATA] Running migration on initialization',
-        '[SUCCESS] Analyzing Project',
+        '[SUCCESS] Analyze project',
         '[STARTED] Convert JS files to TS`;',
       ].join('\n');
       expect(stdout).toContain(expected);
@@ -397,12 +397,12 @@ describe('migrate: e2e', () => {
         '[STARTED] Initialize',
         '[DATA] Setting up config for my-package',
         '[SUCCESS] Initialize',
-        '[STARTED] Analyzing Project',
+        '[STARTED] Analyze project',
         '[DATA] Running migration on my-package',
         '[DATA] List of files will be attempted to migrate:',
         '[DATA]  lib/a.js',
         '[DATA] index.js',
-        '[SUCCESS] Analyzing Project',
+        '[SUCCESS] Analyze project',
       ].join('\n');
 
       expect(result.stdout).contains(expected);
@@ -436,13 +436,13 @@ describe('migrate: e2e', () => {
         '[STARTED] Initialize',
         '[DATA] Setting up config for my-package',
         '[SUCCESS] Initialize',
-        '[STARTED] Analyzing Project',
+        '[STARTED] Analyze project',
         '[DATA] Running migration on my-package',
         '[DATA] List of files will be attempted to migrate:',
         '[DATA]  lib/a.js',
         '[DATA] index.js',
         '[DATA] test/index.js',
-        '[SUCCESS] Analyzing Project',
+        '[SUCCESS] Analyze project',
       ].join('\n');
 
       expect(result.stdout).contains(expected);

--- a/packages/plugins/src/plugins/transform.plugin.ts
+++ b/packages/plugins/src/plugins/transform.plugin.ts
@@ -8,11 +8,17 @@ import {
 } from '@rehearsal/service';
 import { applyTextChanges } from '@rehearsal/ts-utils';
 import ts, { TextChange } from 'typescript';
+import debug from 'debug';
+
+const DEBUG_CALLBACK = debug('rehearsal:plugins:transform');
 
 export class ServiceInjectionsTransformPlugin implements Plugin<PluginOptions> {
   async run(fileName: string, context: PluginsRunnerContext): PluginResult {
     const service = context.service;
     let sourceFile = service.getSourceFile(fileName);
+
+    // debug callback the version of ts
+    DEBUG_CALLBACK('TS API VERSION: %O', ts.version);
 
     if (!sourceFile) {
       return [];


### PR DESCRIPTION
This PR adds a new feature to the CLI where we now set the resolution of the installed version of typescript in the package.json of the consuming app. Additionally it cleans up some minor copy issues, typo's where found and adds a [DEBUG](https://github.com/rehearsal-js/rehearsal-js/blob/67f1792d1e70c78298871c8f6e927588a2e5041a/packages/plugins/src/plugins/transform.plugin.ts#L21) statement in the transforms plugins exposing the ts compiler version directly.

The core features for review of this change are in two places:
- [util package for cli](https://github.com/rehearsal-js/rehearsal-js/blob/67f1792d1e70c78298871c8f6e927588a2e5041a/packages/utils/src/cli.ts#L319-L413)
- [cli package for dependency install](https://github.com/rehearsal-js/rehearsal-js/blob/67f1792d1e70c78298871c8f6e927588a2e5041a/packages/cli/src/commands/migrate/tasks/dependency-install.ts#L122-L133)

Notice we take precedence of leveraging existing npm api for get/set of the resolutions with a fallback to package.json get/set. 

