### PR TITLE
fix(cli): dep install collision

### DIFF
--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-addon.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -13,7 +13,7 @@ exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > create .eslint
 
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -25,7 +25,7 @@ exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > postLintSetup 
 
 exports[`Task: config-lint -- ember-addon-matrix > ember3-addon > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config

--- a/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/config-lint.ember-app.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -13,7 +13,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > create .eslintrc.j
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -25,7 +25,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > postLintSetup hook
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-app > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -36,7 +36,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-app > run custom config 
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -47,7 +47,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > cre
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -59,7 +59,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > pos
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -70,7 +70,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoAddon > run
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > create .eslintrc.js if not existed 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -81,7 +81,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > cr
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > postLintSetup hook from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config
@@ -93,7 +93,7 @@ exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > po
 
 exports[`Task: config-lint -- ember-app-matrix > ember3-appWithInRepoEngine > run custom config command with user config provided 1`] = `
 "[STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create eslint config

--- a/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Task: dependency-install > do not run postInstall command if empty 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
@@ -11,7 +10,6 @@ exports[`Task: dependency-install > do not run postInstall command if empty 1`] 
 
 exports[`Task: dependency-install > install custom dependencies 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
@@ -29,7 +27,6 @@ exports[`Task: dependency-install > install required dependencies 1`] = `
 
 exports[`Task: dependency-install > multiple postInstall commands from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
@@ -54,7 +51,6 @@ We ran into an error when installing devDependencies, please install the followi
 
 exports[`Task: dependency-install > single postInstall command from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, fs-extra
 [DATA] Setting resolutions: typescript@^5.0.3

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-addon.test.ts.snap
@@ -7,7 +7,7 @@ exports[`migrate init for ember addon variant > ember3-addon > default run --emb
 [DATA] Setting up config for addon-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -73,9 +73,8 @@ exports[`migrate init for ember addon variant > ember3-addon > pass user config 
 [DATA] Setting up config for addon-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.ember-app.test.ts.snap
@@ -7,7 +7,7 @@ exports[`migrate init for ember app variant > ember4App > default run --ember4Ap
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -87,9 +87,8 @@ exports[`migrate init for ember app variant > ember4App > pass user config ember
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -131,7 +130,7 @@ exports[`migrate init for ember app variant > emberApp > default run --emberApp 
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -211,9 +210,8 @@ exports[`migrate init for ember app variant > emberApp > pass user config emberA
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -255,7 +253,7 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > default 
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -335,9 +333,8 @@ exports[`migrate init for ember app variant > emberAppWithInRepoAddon > pass use
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -379,7 +376,7 @@ exports[`migrate init for ember app variant > emberAppWithInRepoEngine > default
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json
@@ -459,9 +456,8 @@ exports[`migrate init for ember app variant > emberAppWithInRepoEngine > pass us
 [DATA] Setting up config for app-template
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
-[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
+[DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3
 [SUCCESS] Install dependencies
 [STARTED] Create tsconfig.json

--- a/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/init-command.test.ts.snap
@@ -80,7 +80,6 @@ exports[`migrate init > pass user config 1`] = `
 [DATA] Setting up config for basic
 [SUCCESS] Initialize
 [STARTED] Install dependencies
-[DATA] Install dependencies from rehearsal config
 [DATA] Installing dependencies: fs-extra
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, tmp
 [DATA] Setting resolutions: typescript@^5.0.3


### PR DESCRIPTION
Fixes #919 

This PR refactors `shouldRunDepInstallTask` to avoid dependency install collision. The issue previously was if a project had a dependency in-which rehearsal was trying to install as a dev-dependency the package manager would logically throw. 

Before we install a dep or devDep we now check against both dep and devDep of the consuming application and only install the delta regardless of where its installed eg.

- rehearsal is trying to install prettier as a devDep
- migrating app has prettier as a dep
- rehearsal will NOT try and install prettier as a devDep