### PR TITLE
chore: disable requireInTs codefix

### DIFF
--- a/Supported-Fixes.md
+++ b/Supported-Fixes.md
@@ -706,27 +706,6 @@ export function foo() {
 ```
 
 
-## Convert Requires In TypeScript
-
-id: _requireInTs_
-
-Converts CJS to ES Modules
-**Input:**
-
-```ts
-const { a } = require('../a');
-export const b = a;
-
-```
-**Output:**
-
-```ts
-  import { a } from '../a';
-export const b = a;
-
-```
-
-
 ## Strict Class Initialization
 
 id: _strictClassInitialization_

--- a/packages/codefixes/src/codefixesMessages.json
+++ b/packages/codefixes/src/codefixesMessages.json
@@ -155,11 +155,6 @@
     "description": "Removes `await` where the function is not async.",
     "diagnostics": [80007]
   },
-  "requireInTs": {
-    "title": "Convert Requires In TypeScript",
-    "description": "Converts CJS to ES Modules",
-    "diagnostics": [80005]
-  },
   "strictClassInitialization": {
     "title": "Strict Class Initialization",
     "description": "Fixes classes so they are initialized correctly.",

--- a/packages/codefixes/test/ts-codefixes.test.ts
+++ b/packages/codefixes/test/ts-codefixes.test.ts
@@ -224,11 +224,13 @@ describe('ts-codefixes', () => {
     );
   });
 
+  /*
   test('requireInTs', async () => {
     await runTest('requireInTs/failing/fail-1.ts', 'requireInTs/passing/pass-1.ts', [
       'requireInTs/a.ts',
     ]);
   });
+   */
 
   test('unusedIdentifier', async () => {
     await runTest('unusedIdentifier/failing/fail-1.ts', 'unusedIdentifier/passing/pass-1.ts');


### PR DESCRIPTION
Temporary disable `requireInTs` codefix. 
Has to be enabled together with `convertToEsModule`