### PR TITLE
fix: don't add multiple todo comments for the same line

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`migrate > .hbs > simple class 1`] = `
 "{{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'. }}
-{{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
 <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>"
 `;
 

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -270,7 +270,6 @@ declare authenticatedUser: AuthenticatedUser;
 export default class Hello extends Component {
   <template>
     {{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Hello'. }}
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
     <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
   </template>
 }


### PR DESCRIPTION
Update `glint-report` so that it only adds one todo comment for a given line, rather than stacking them up.

Closes https://github.com/rehearsal-js/rehearsal-js/issues/900