### PR TITLE
feat: improved annotateWithTypeFromJSDoc codefix

### DIFF
--- a/Supported-Fixes.md
+++ b/Supported-Fixes.md
@@ -273,37 +273,6 @@ export const p1 = new Promise<void>((resolve) => resolve());
 ```
 
 
-## Annotate From JSDoc
-
-id: _annotateWithTypeFromJSDoc_
-
-Annotates code with the types from the declared JSDoc comments.
-**Input:**
-
-```ts
-/**
- * @param {number} x
- * @returns {number}
- */
-export function f(x) {
-  return x;
-}
-
-```
-**Output:**
-
-```ts
-/**
- * @param {number} x
- * @returns {number}
- */
-export function f(x: number): number {
-  return x;
-}
-
-```
-
-
 ## Add Super To Constructor
 
 id: _constructorForDerivedNeedSuperCall_
@@ -786,6 +755,14 @@ Exports members that are required and used by other exports.
 id: _inferReturnType_
 
 Adds the return type to methods and functions.
+
+
+
+## Annotate Strict Types From JSDoc
+
+id: _annotateWithStrictTypeFromJSDoc_
+
+Annotates code with the only strict types from the declared JSDoc comments.
 
 
 

--- a/packages/codefixes/src/codefixes.ts
+++ b/packages/codefixes/src/codefixes.ts
@@ -8,6 +8,7 @@ import { AddMissingExportCodeFix } from './fixes/addMissingExport.js';
 import { MakeMemberOptionalCodeFix } from './fixes/makeMemberOptional.js';
 import { AddMissingTypesBasedOnInheritanceCodeFix } from './fixes/addMissingTypesBasedOnInheritance.js';
 import { AddMissingTypesBasedOnInlayHintsCodeFix } from './fixes/addMissingTypesBasedOnInlayHints.js';
+import { AnnotateWithStrictTypeFromJSDoc } from './fixes/annotateWithStrictTypeFromJSDoc.js';
 import type { CodeFixAction } from 'typescript';
 
 export const codefixes = new CodeFixesProvider([
@@ -16,6 +17,7 @@ export const codefixes = new CodeFixesProvider([
     new AddMissingExportCodeFix(),
     new AddMissingTypesBasedOnInheritanceCodeFix(),
     new AddMissingTypesBasedOnInlayHintsCodeFix(),
+    new AnnotateWithStrictTypeFromJSDoc(),
     new MakeMemberOptionalCodeFix(),
   ]),
   new TypescriptCodeFixCollection(),

--- a/packages/codefixes/src/codefixesMessages.json
+++ b/packages/codefixes/src/codefixesMessages.json
@@ -52,11 +52,6 @@
     "description": "Adds the `void` as the type parameter of `Promise` where appropriate.",
     "diagnostics": [2810, 2794]
   },
-  "annotateWithTypeFromJSDoc": {
-    "title": "Annotate From JSDoc",
-    "description": "Annotates code with the types from the declared JSDoc comments.",
-    "diagnostics": [80004]
-  },
   "constructorForDerivedNeedSuperCall": {
     "title": "Add Super To Constructor",
     "description": "Adds a call the super class within the constructor.",
@@ -173,35 +168,38 @@
 
   "addErrorTypeGuard": {
     "title": "Add Error Cast",
-    "builtIn": true,
     "description": "Adds a cast to Error objects in catch clauses",
-    "diagnostics": [18046, 2571]
+    "diagnostics": [18046, 2571],
+    "builtIn": true
   },
   "addMissingTypesBasedOnInheritance": {
     "title": "Add Missing Types From Inheritance Chain",
-    "builtIn": true,
     "description": "Adds types to sub-class by looking at the types from the heritage.",
-    "diagnostics": [7050, 7006]
+    "diagnostics": [7050, 7006],
+    "builtIn": true
   },
-
   "makeMemberOptional": {
     "title": "Make Member Optional",
-    "builtIn": true,
     "description": "Safely makes the access to properties optional.",
-    "diagnostics": [2790]
+    "diagnostics": [2790],
+    "builtIn": true
   },
-
   "addMissingExport": {
     "title": "Add Missing Export",
-    "builtIn": true,
     "description": "Exports members that are required and used by other exports.",
-    "diagnostics": [4082]
+    "diagnostics": [4082],
+    "builtIn": true
   },
-
   "inferReturnType": {
     "title": "Add Missing Return Type",
-    "builtIn": true,
     "description": "Adds the return type to methods and functions.",
-    "diagnostics": [7050]
+    "diagnostics": [7050],
+    "builtIn": true
+  },
+  "annotateWithStrictTypeFromJSDoc": {
+    "title": "Annotate Strict Types From JSDoc",
+    "description": "Annotates code with the only strict types from the declared JSDoc comments.",
+    "diagnostics": [80004],
+    "builtIn": true
   }
 }

--- a/packages/codefixes/src/fixes/annotateWithStrictTypeFromJSDoc.ts
+++ b/packages/codefixes/src/fixes/annotateWithStrictTypeFromJSDoc.ts
@@ -1,0 +1,77 @@
+import { canTypeBeResolved, findNodeEndsAtPosition } from '@rehearsal/ts-utils';
+import ts from 'typescript';
+import { Diagnostics } from '../diagnosticInformationMap.generated.js';
+import { TypescriptCodeFixCollection } from '../typescript-codefix-collection.js';
+import type { FileTextChanges, TextChange, CodeFixAction } from 'typescript';
+import type { CodeFix, DiagnosticWithContext } from '../types.js';
+
+const {
+  isFunctionDeclaration,
+  isMethodDeclaration,
+  isPropertyDeclaration,
+  isVariableDeclaration,
+  getJSDocType,
+} = ts;
+
+export class AnnotateWithStrictTypeFromJSDoc implements CodeFix {
+  getErrorCodes = (): number[] => [Diagnostics.TS80004.code];
+
+  getCodeAction(diagnostic: DiagnosticWithContext): CodeFixAction | undefined {
+    const tsCollection = new TypescriptCodeFixCollection();
+
+    const fix = tsCollection
+      .getFixesForDiagnostic(diagnostic, {
+        safeFixes: false,
+        strictTyping: true,
+      })
+      .find((fix) => fix.fixName === 'annotateWithTypeFromJSDoc');
+
+    if (!fix || !diagnostic.node) {
+      return undefined;
+    }
+
+    if (
+      isFunctionDeclaration(diagnostic.node.parent) ||
+      isMethodDeclaration(diagnostic.node.parent) ||
+      isPropertyDeclaration(diagnostic.node.parent) ||
+      isVariableDeclaration(diagnostic.node.parent)
+    ) {
+      return this.filterFunctionParams(fix, diagnostic);
+    }
+
+    return fix;
+  }
+
+  filterFunctionParams(
+    fix: CodeFixAction,
+    diagnostic: DiagnosticWithContext
+  ): CodeFixAction | undefined {
+    const safeChanges: FileTextChanges[] = [];
+    for (const changes of fix.changes) {
+      const safeTextChanges: TextChange[] = [];
+      for (const textChanges of changes.textChanges) {
+        const node = findNodeEndsAtPosition(diagnostic.file, textChanges.span.start);
+
+        if (node) {
+          const typeNode = getJSDocType(node) || getJSDocType(node.parent);
+
+          if (typeNode && !canTypeBeResolved(diagnostic.checker, typeNode)) {
+            continue;
+          }
+        }
+
+        safeTextChanges.push(textChanges);
+      }
+
+      if (safeTextChanges.length) {
+        safeChanges.push({ ...changes, textChanges: safeTextChanges });
+      }
+    }
+
+    if (safeChanges.length) {
+      return { ...fix, changes: safeChanges };
+    }
+
+    return undefined;
+  }
+}

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Test transform > addErrorTypeGuard 1`] = `
+exports[`Test base codefixes > addErrorTypeGuard 1`] = `
 "// Case #1: try ... catch
 
 const test = [\\"dummy\\"];
@@ -38,45 +38,7 @@ dummy.key;
 "
 `;
 
-exports[`Test transform > addErrorTypeGuard 2`] = `
-"// Case #1: try ... catch
-
-const test = [\\"dummy\\"];
-
-try {
-  console.log(\\"success\\");
-} catch (e) {
-  console.log((e as Error).message);
-  /* @ts-expect-error @rehearsal TODO TS18046: 'e' is of type 'unknown'. */
-  console.log(e.notErrorMember);
-
-  if ((e as Error).name === \\"Test\\") {
-    console.log((e as Error).name);
-    console.log((e as Error).name);
-    console.log((e as Error).name);
-    console.log((e as Error).name);
-  }
-
-  if (test[1] === undefined && (e as Error).name === \\"Test\\") {
-    console.log((e as Error).name);
-  }
-}
-
-// Case #2: not a try catch
-
-function getObject<T>(): T {
-  const object = [\\"dummy\\"];
-  return object as unknown as T;
-}
-
-const dummy = getObject();
-
-/* @ts-expect-error @rehearsal TODO TS18046: 'dummy' is of type 'unknown'. */
-dummy.key;
-"
-`;
-
-exports[`Test transform > addMissingExport 1`] = `
+exports[`Test base codefixes > addMissingExport 1`] = `
 "/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
 import React from \\"react\\";
 
@@ -94,7 +56,7 @@ export default Kid;
 "
 `;
 
-exports[`Test transform > addMissingExport 2`] = `
+exports[`Test base codefixes > addMissingExport 2`] = `
 "import Kid from \\"./4082-1-import\\";
 
 export default {
@@ -104,7 +66,7 @@ export default {
 "
 `;
 
-exports[`Test transform > addMissingExport 3`] = `
+exports[`Test base codefixes > addMissingExport 3`] = `
 "/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
 import React from \\"react\\";
 
@@ -168,7 +130,7 @@ export default <P extends InjectedProps>(Component: React.ComponentType<P>) =>
 "
 `;
 
-exports[`Test transform > addMissingExport 4`] = `
+exports[`Test base codefixes > addMissingExport 4`] = `
 "/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
 import React from \\"react\\";
 
@@ -205,136 +167,7 @@ export default makeToDo(ToDo);
 "
 `;
 
-exports[`Test transform > addMissingExport 5`] = `
-"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
-import React from \\"react\\";
-
-export interface Props {
-  name: string;
-  age: string;
-}
-
-{
-  /* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */
-}
-const Kid = ({ name, age }: Props) => <div>{\`\${name},\${age}\`}</div>;
-
-export default Kid;
-"
-`;
-
-exports[`Test transform > addMissingExport 6`] = `
-"import Kid from \\"./4082-1-import\\";
-
-export default {
-  kid: Kid,
-  title: \\"Kid\\",
-};
-"
-`;
-
-exports[`Test transform > addMissingExport 7`] = `
-"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
-import React from \\"react\\";
-
-interface ToDo {
-  id: string;
-  title: string;
-  content: string;
-}
-
-interface ToDoState {
-  todos: ToDo[];
-}
-
-export interface InjectedProps {
-  onAdd: () => void;
-  onRemove: (id: string) => void;
-  todos: ToDo[];
-}
-
-export interface AllProps extends InjectedProps {
-  style: React.CSSProperties;
-}
-
-export default <P extends InjectedProps>(Component: React.ComponentType<P>) =>
-  class extends React.Component<Omit<P, keyof InjectedProps>, ToDoState> {
-    state = { todos: [] };
-
-    onRemove = (id: string) => () => {
-      const filteredToDos = (this.state.todos as ToDo[]).filter(
-        (todo) => (todo as ToDo).id !== id
-      );
-      /* @ts-expect-error @rehearsal TODO TS2339: Property 'setState' does not exist on type '(Anonymous class)'. */
-      this.setState({ todos: filteredToDos });
-    };
-
-    onAdd = () => {
-      const todo = {
-        title: \\"\\",
-        content: \\"\\",
-        id: \`\${Date.now}\`,
-      };
-      /* @ts-expect-error @rehearsal TODO TS2339: Property 'setState' does not exist on type '(Anonymous class)'. */
-      this.setState((prev) => {
-        [...prev.todos, todo];
-      });
-    };
-    props: P | undefined;
-
-    render() {
-      return (
-        /* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations. */
-        <Component
-          {...(this.props as P)}
-          todos={this.state.todos}
-          onAdd={this.onAdd}
-          onRemove={this.onRemove}
-        />
-      );
-    }
-  };
-"
-`;
-
-exports[`Test transform > addMissingExport 8`] = `
-"/* @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations. */
-import React from \\"react\\";
-
-import makeToDo, { AllProps } from \\"./4082-2-import\\";
-
-const ToDo = (props: AllProps) => {
-  return (
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-    <div style={props.style}>
-/* @ts-expect-error @rehearsal TODO TS7006: Parameter 'todo' implicitly has an 'any' type. */
-      {props.todos.map((todo) => (
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-        <div key={todo.id}>
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-          <div>{todo.title}</div>
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-          <div>{todo.content}</div>
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-          <button data-id={todo.id} onClick={() => props.onRemove(todo.id)}>
-/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'Remove'. */
-            Remove
-/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'button'. */
-          </button>
-/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'div'. */
-        </div>
-      ))}
-{/* @ts-expect-error @rehearsal TODO TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists. */}
-      <button onClick={props.onAdd}>Add</button>
-/* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'div'. */
-    </div>
-  );
-};
-export default makeToDo(ToDo);
-"
-`;
-
-exports[`Test transform > addMissingTypesBasedOnInheritance 1`] = `
+exports[`Test base codefixes > addMissingTypesBasedOnInheritance 1`] = `
 "// Basics
 
 class Animal {
@@ -519,192 +352,7 @@ export class MultipleImpl extends MultipleClass implements MultipleInterface {
 "
 `;
 
-exports[`Test transform > addMissingTypesBasedOnInheritance 2`] = `
-"// Basics
-
-class Animal {
-  title = \\"\\";
-
-  test(test: string): string {
-    return test;
-  }
-
-  say(message: string): string {
-    return message;
-  }
-
-  feed(food: Food, quantity: number): boolean {
-    console.log(food, quantity);
-    return false;
-  }
-}
-
-interface Wild {
-  wild(place: string): string;
-}
-
-interface Happy {
-  happy(num: number): void;
-}
-
-class Food {
-  title: string;
-
-  constructor(title: string) {
-    this.title = title;
-  }
-}
-
-class Dog extends Animal {
-  say(message: string): string {
-    console.log(message);
-    return \\"bar\\";
-  }
-}
-
-export class WildDog extends Dog implements Wild, Happy {
-  say(message: string): string {
-    console.log(message);
-    return \\"bar\\";
-  }
-
-  override feed(food: Food, quantity: number): boolean {
-    console.log(food, quantity);
-    return true;
-  }
-
-  wild(place: string): string {
-    return place;
-  }
-
-  happy(num: number): void {
-    console.log(num);
-  }
-}
-
-export class Cat extends Animal {
-  override say(text: string): string {
-    console.log(text);
-    return \\"meo\\";
-  }
-
-  feed(something: Food): boolean {
-    console.log(something);
-    return false;
-  }
-}
-
-// Generics
-
-type Thing = {
-  foo: number;
-};
-
-// Generic Interfaces
-
-interface GenericThingInterface<A = number, B = string> {
-  thing(a: A, b: B): void;
-}
-
-interface ConstrainedThingInterface<C extends Thing> {
-  thing(c: C): void;
-}
-
-export class GenericThingImp1 implements GenericThingInterface {
-  thing(a: number, b: string): void {
-    console.log(a, b);
-  }
-}
-
-export class GenericThingImp2
-  implements GenericThingInterface<boolean, number>
-{
-  thing(a: boolean, b: number): void {
-    console.log(a, b);
-  }
-}
-
-export class GenericThingImp3
-  implements ConstrainedThingInterface<{ foo: number; bar: string }>
-{
-  thing(c: { foo: number; bar: string }): void {
-    console.log(c);
-  }
-}
-
-// Generic Classes
-
-class GenericThingClass<A = number, B = string> {
-  thing(a: A, b: B): void {
-    console.log(a, b);
-  }
-}
-
-class ConstrainedThingClass<C extends Thing> {
-  thing(c: C): void {
-    console.log(c);
-  }
-}
-
-export class GenericThingExt1 extends GenericThingClass {
-  thing(a: number, b: string): void {
-    console.log(a, b);
-  }
-}
-
-export class GenericThingExt2 extends GenericThingClass<boolean, number> {
-  thing(a: boolean, b: number): void {
-    console.log(a, b);
-  }
-}
-
-export class GenericThingExt3 extends ConstrainedThingClass<{
-  foo: number;
-  bar: string;
-}> {
-  thing(c: { foo: number; bar: string }): void {
-    console.log(c);
-  }
-}
-
-// Multiple signatures
-
-interface MultipleInterface {
-  foo(a: number): number;
-  foo(b: string): string;
-  foo(a: number, b: string): boolean;
-
-  moo(a: string): string;
-}
-
-class MultipleClass {
-  boo(a: number): number;
-  boo(b: string): string;
-  boo(a: number, b: string): boolean;
-  boo(ab: number | string, b?: string): number | string | boolean {
-    return !ab || !b;
-  }
-}
-
-export class MultipleImpl extends MultipleClass implements MultipleInterface {
-  /* @ts-expect-error @rehearsal TODO TS2416: Property 'boo' in type 'MultipleImpl' is not assignable to the same property in base type 'MultipleClass'..  Type '(ab: any, b?: any) => boolean' is not assignable to type '{ (a: number): number; (b: string): string; (a: number, b: string): boolean; }'..    Type 'boolean' is not assignable to type 'number'. */
-  boo(ab, b?): boolean {
-    return !ab || !b;
-  }
-
-  /* @ts-expect-error @rehearsal TODO TS2416: Property 'foo' in type 'MultipleImpl' is not assignable to the same property in base type 'MultipleInterface'..  Type '(ab: any, b?: any) => boolean' is not assignable to type '{ (a: number): number; (b: string): string; (a: number, b: string): boolean; }'..    Type 'boolean' is not assignable to type 'number'. */
-  foo(ab, b?): boolean {
-    return !ab || !b;
-  }
-
-  moo(b: string): string {
-    return b;
-  }
-}
-"
-`;
-
-exports[`Test transform > addMissingTypesBasedOnInlayHints 1`] = `
+exports[`Test base codefixes > addMissingTypesBasedOnInlayHints 1`] = `
 "export function test1(): string {
   return \\"Test this\\";
 }
@@ -743,46 +391,165 @@ export class TestClass extends BaseTestClass implements TestInterface {
 "
 `;
 
-exports[`Test transform > addMissingTypesBasedOnInlayHints 2`] = `
-"export function test1(): string {
-  return \\"Test this\\";
+exports[`Test base codefixes > annotateWithStrictTypeFromJSDoc 1`] = `
+"export class Foo {
+  value = 0;
 }
 
-export const test2 = () => console.log(\\"Test this\\");
-
-export const test3 = () => \\"Test this\\";
-
-export function test4<Type>(arg: Array<Type>): Type[] {
-  return arg;
-}
-
-export async function test5(): Promise<TestClass> {
-  return new TestClass();
-}
-
-interface TestInterface {
-  test1(): string | undefined;
-}
-
-class BaseTestClass {
-  test2(param: boolean): number | string {
-    return param ? 0 : \\"0\\";
+export class GenericClass<something = number, somethingElse = number> {
+  thing(a: something, b: somethingElse): void {
+    console.log(a, b);
   }
 }
 
-export class TestClass extends BaseTestClass implements TestInterface {
-  test1(): string | undefined {
-    return undefined;
-  }
+/** @type {number | string} */
+export const a: number | string = 0;
 
-  test2(): string | number {
-    return 0;
+/** @type {number | string | UnavailableType} */
+export const b = 0;
+
+/** @type {GenericClass<string, string, string>} */
+export const c = 0;
+
+export class ThinkClass {
+  /** @type {number | null} */
+  a: number | null = 0;
+
+  /** @type {number | UnavailableType} */
+  b = 0;
+
+  /**
+   * JSDoc
+   *
+   * @param {number} a                                //
+   * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+   * @param {Foo} c                                   // TypeReference
+   * @param {number|UnavailableType} d                // UnionType
+   * @param {() => boolean} e                         // FunctionType
+   * @param {GenericClass<string, string>} f          // TypeReference
+
+   * @param {<callbackFunction>} g                    // FunctionType
+
+   * @param {UnavailableType} h                       // TypeReference
+   * @param {Foo|UnavailableType} i                   // UnionType
+   * @param {() => UnavailableType} j                 // FunctionType
+   * @param {GenericClass<string, UnavailableType>} k // TypeReference
+   * @param {number|() => UnavailableType} l          // UnionType
+   * @param {(a: UnavailableType) => void} m          // FunctionType
+   * @param {(a, b: string) => void} n                // FunctionType
+
+   * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+   * @param {{ a: string, b: Date }} p
+   * @param {{ a: string, b: UnavailableType }} q
+   * @param {function(this:{ a: string}, string, number): boolean} r
+
+   * @return {void}
+   */
+  more(
+    a: number,
+    b: string | number,
+    c: Foo,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'd' implicitly has an 'any' type. */
+    d,
+    e: () => boolean,
+    f: GenericClass<string, string>,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'g' implicitly has an 'any' type. */
+    g,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'h' implicitly has an 'any' type. */
+    h,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'i' implicitly has an 'any' type. */
+    i,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'j' implicitly has an 'any' type. */
+    j,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'k' implicitly has an 'any' type. */
+    k,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'l' implicitly has an 'any' type. */
+    l,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'm' implicitly has an 'any' type. */
+    m,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'a' implicitly has an 'any' type. */
+    n: (a, b: string) => void,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'o' implicitly has an 'any' type. */
+    o,
+    p: { a: string; b: Date },
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'q' implicitly has an 'any' type. */
+    q,
+    r: (this: { a: string }, arg1: string, arg2: number) => boolean,
+    /* @ts-expect-error @rehearsal TODO TS7006: Parameter 's' implicitly has an 'any' type. */
+    s
+  ): void {
+    return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
   }
+}
+
+/**
+ * JSDoc
+ *
+ * @param {number} a                                //
+ * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+ * @param {Foo} c                                   // TypeReference
+ * @param {number|UnavailableType} d                // UnionType
+ * @param {() => boolean} e                         // FunctionType
+ * @param {GenericClass<string, string>} f          // TypeReference
+
+ * @param {<callbackFunction>} g                    // FunctionType
+
+ * @param {UnavailableType} h                       // TypeReference
+ * @param {Foo|UnavailableType} i                   // UnionType
+ * @param {() => UnavailableType} j                 // FunctionType
+ * @param {GenericClass<string, UnavailableType>} k // TypeReference
+ * @param {number|() => UnavailableType} l          // UnionType
+ * @param {(a: UnavailableType) => void} m          // FunctionType
+ * @param {(a, b: string) => void} n                // FunctionType
+
+ * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+ * @param {{ a: string, b: Date }} p                //
+ * @param {{ a: string, b: UnavailableType }} q     //
+ * @param {function(this:{ a: string}, string, number): boolean} r
+
+ * @return {void}
+ */
+export function think(
+  a: number,
+  b: string | number,
+  c: Foo,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'd' implicitly has an 'any' type. */
+  d,
+  e: () => boolean,
+  f: GenericClass<string, string>,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'g' implicitly has an 'any' type. */
+  g,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'h' implicitly has an 'any' type. */
+  h,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'i' implicitly has an 'any' type. */
+  i,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'j' implicitly has an 'any' type. */
+  j,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'k' implicitly has an 'any' type. */
+  k,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'l' implicitly has an 'any' type. */
+  l,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'm' implicitly has an 'any' type. */
+  m,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'a' implicitly has an 'any' type. */
+  n: (a, b: string) => void,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'o' implicitly has an 'any' type. */
+  o,
+  p: { a: string; b: Date },
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'q' implicitly has an 'any' type. */
+  q,
+  r: (this: { a: string }, arg1: string, arg2: number) => boolean,
+  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 's' implicitly has an 'any' type. */
+  s
+): void {
+  return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
 }
 "
 `;
 
-exports[`Test transform > makeMemberOptional 1`] = `
+exports[`Test base codefixes > makeMemberOptional 1`] = `
 "export interface Animal {
   species: string;
   weight?: number;
@@ -796,7 +563,7 @@ export interface Car {
 "
 `;
 
-exports[`Test transform > makeMemberOptional 2`] = `
+exports[`Test base codefixes > makeMemberOptional 2`] = `
 "export class Employee {
   name: string;
   badgeNumber?: string;
@@ -809,7 +576,7 @@ exports[`Test transform > makeMemberOptional 2`] = `
 "
 `;
 
-exports[`Test transform > makeMemberOptional 3`] = `
+exports[`Test base codefixes > makeMemberOptional 3`] = `
 "export interface Rabbit {
   color?: string;
   species: string;
@@ -822,7 +589,7 @@ export function feedRabbit(rabbit: Rabbit): void {
 "
 `;
 
-exports[`Test transform > makeMemberOptional 4`] = `
+exports[`Test base codefixes > makeMemberOptional 4`] = `
 "export default interface Human {
   height?: number;
   weight: number;
@@ -830,143 +597,7 @@ exports[`Test transform > makeMemberOptional 4`] = `
 "
 `;
 
-exports[`Test transform > makeMemberOptional 5`] = `
-"import { Animal, Car } from \\"./2790-import-1\\";
-import { Employee } from \\"./2790-import-2\\";
-import * as RabbitStuff from \\"./2790-import-3\\";
-import Human from \\"./2790-import-4\\";
-
-const animal: Animal = {
-  species: \\"dog\\",
-  weight: 90,
-};
-
-delete animal.weight;
-
-const car: Car = {
-  make: \\"Ford\\",
-  model: \\"Focus\\",
-  color: \\"red\\",
-};
-
-delete car.color;
-
-const employee = new Employee({ name: \\"Victor\\", badgeNumber: \\"12345\\" });
-delete employee.badgeNumber;
-
-const human: Human = {
-  weight: 200,
-  height: 180,
-};
-delete human.height;
-
-const rabbit: RabbitStuff.Rabbit = {
-  color: \\"butterscotch\\",
-  species: \\"Holland Lop\\",
-  name: \\"Poca\\",
-};
-delete rabbit.color;
-
-interface Person {
-  name: string;
-  age?: number;
-  address?: string | null;
-}
-
-const person: Person = {
-  name: \\"Jane\\",
-  age: 10,
-  address: \\"123 Happy St\\",
-};
-
-delete person.address;
-
-class Student {
-  name: string;
-  grade: number;
-  gender?: string;
-
-  constructor({
-    name,
-    grade,
-    gender,
-  }: {
-    name: string;
-    grade: number;
-    gender: string;
-  }) {
-    this.name = name;
-    this.grade = grade;
-    this.gender = gender;
-  }
-}
-const student = new Student({ name: \\"\\", grade: 3, gender: \\"male\\" });
-delete student.gender;
-
-type Tree = {
-  species: string;
-  age: number;
-  height?: number;
-};
-
-const oak: Tree = {
-  species: \\"oak\\",
-  age: 150,
-  height: 40,
-};
-delete oak.height;
-"
-`;
-
-exports[`Test transform > makeMemberOptional 6`] = `
-"export interface Animal {
-  species: string;
-  weight?: number;
-}
-
-export interface Car {
-  make: string;
-  model: string;
-  color?: string;
-}
-"
-`;
-
-exports[`Test transform > makeMemberOptional 7`] = `
-"export class Employee {
-  name: string;
-  badgeNumber?: string;
-
-  constructor({ name, badgeNumber }: { name: string; badgeNumber: string }) {
-    this.name = name;
-    this.badgeNumber = badgeNumber;
-  }
-}
-"
-`;
-
-exports[`Test transform > makeMemberOptional 8`] = `
-"export interface Rabbit {
-  color?: string;
-  species: string;
-  name: string;
-}
-
-export function feedRabbit(rabbit: Rabbit): void {
-  console.log(\`Rabbit \${rabbit.name} loves to eat fruit, not hay.\`);
-}
-"
-`;
-
-exports[`Test transform > makeMemberOptional 9`] = `
-"export default interface Human {
-  height?: number;
-  weight: number;
-}
-"
-`;
-
-exports[`Test transform > makeMemberOptional 10`] = `
+exports[`Test base codefixes > makeMemberOptional 5`] = `
 "import { Animal, Car } from \\"./2790-import-1\\";
 import { Employee } from \\"./2790-import-2\\";
 import * as RabbitStuff from \\"./2790-import-3\\";

--- a/packages/codefixes/test/base-codefixes.test.ts
+++ b/packages/codefixes/test/base-codefixes.test.ts
@@ -10,7 +10,7 @@ import type fixturify from 'fixturify';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('Test transform', function () {
+describe('Test base codefixes', function () {
   const fixturesDir = resolve(__dirname, 'fixtures');
   const codefixesDir = resolve(__dirname, '../src/fixes');
   let project: Project;
@@ -44,6 +44,7 @@ describe('Test transform', function () {
   }
 
   test.each(transforms)('%s', async (transform) => {
+    console.log(transform);
     const upgradeProjectDir = resolve(project.baseDir, transform);
 
     await runUpgrade(upgradeProjectDir);

--- a/packages/codefixes/test/fixtures/annotateWithStrictTypeFromJSDoc/index.ts
+++ b/packages/codefixes/test/fixtures/annotateWithStrictTypeFromJSDoc/index.ts
@@ -1,0 +1,90 @@
+export class Foo {
+  value = 0;
+}
+
+export class GenericClass<something = number, somethingElse = number> {
+  thing(a: something, b: somethingElse) {
+    console.log(a, b);
+  }
+}
+
+/** @type {number | string} */
+export const a = 0;
+
+/** @type {number | string | UnavailableType} */
+export const b = 0;
+
+/** @type {GenericClass<string, string, string>} */
+export const c = 0;
+
+export class ThinkClass {
+  /** @type {number | null} */
+  a = 0;
+
+  /** @type {number | UnavailableType} */
+  b = 0;
+
+  /**
+   * JSDoc
+   *
+   * @param {number} a                                //
+   * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+   * @param {Foo} c                                   // TypeReference
+   * @param {number|UnavailableType} d                // UnionType
+   * @param {() => boolean} e                         // FunctionType
+   * @param {GenericClass<string, string>} f          // TypeReference
+
+   * @param {<callbackFunction>} g                    // FunctionType
+
+   * @param {UnavailableType} h                       // TypeReference
+   * @param {Foo|UnavailableType} i                   // UnionType
+   * @param {() => UnavailableType} j                 // FunctionType
+   * @param {GenericClass<string, UnavailableType>} k // TypeReference
+   * @param {number|() => UnavailableType} l          // UnionType
+   * @param {(a: UnavailableType) => void} m          // FunctionType
+   * @param {(a, b: string) => void} n                // FunctionType
+
+   * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+   * @param {{ a: string, b: Date }} p
+   * @param {{ a: string, b: UnavailableType }} q
+   * @param {function(this:{ a: string}, string, number): boolean} r
+
+   * @return {void}
+   */
+  more(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
+    return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+  }
+}
+
+/**
+ * JSDoc
+ *
+ * @param {number} a                                //
+ * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+ * @param {Foo} c                                   // TypeReference
+ * @param {number|UnavailableType} d                // UnionType
+ * @param {() => boolean} e                         // FunctionType
+ * @param {GenericClass<string, string>} f          // TypeReference
+
+ * @param {<callbackFunction>} g                    // FunctionType
+
+ * @param {UnavailableType} h                       // TypeReference
+ * @param {Foo|UnavailableType} i                   // UnionType
+ * @param {() => UnavailableType} j                 // FunctionType
+ * @param {GenericClass<string, UnavailableType>} k // TypeReference
+ * @param {number|() => UnavailableType} l          // UnionType
+ * @param {(a: UnavailableType) => void} m          // FunctionType
+ * @param {(a, b: string) => void} n                // FunctionType
+
+ * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+ * @param {{ a: string, b: Date }} p                //
+ * @param {{ a: string, b: UnavailableType }} q     //
+ * @param {function(this:{ a: string}, string, number): boolean} r
+
+ * @return {void}
+ */
+export function think(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
+  return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+}

--- a/packages/codefixes/test/ts-codefixes.test.ts
+++ b/packages/codefixes/test/ts-codefixes.test.ts
@@ -133,12 +133,14 @@ describe('ts-codefixes', () => {
     await runTest('addVoidToPromise/failing/fail-1.ts', 'addVoidToPromise/passing/pass-1.ts');
   });
 
+  /*
   test('annotateWithTypeFromJSDoc', async () => {
     await runTest(
       'annotateWithTypeFromJSDoc/failing/fail-1.ts',
       'annotateWithTypeFromJSDoc/passing/pass-1.ts'
     );
   });
+  */
 
   test('constructorForDerivedNeedSuperCall', async () => {
     await runTest(

--- a/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
@@ -750,14 +750,8 @@ export class Foo {
  *
  * @return {void}
  */
-export function think(
-  a: number,
-  b: string | number,
-  /* @ts-expect-error @rehearsal TODO TS7006: Parameter 'c' implicitly has an 'any' type. */
-  c,
-  /* @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'UnavailableType'. */
-  d: UnavailableType
-): void {
+/* @ts-expect-error @rehearsal TODO TS7006: Parameter 'c' implicitly has an 'any' type. */
+export function think(a: number, b: string | number, c, d): void {
   return console.log(a, b, c, d);
 }
 "
@@ -812,7 +806,7 @@ exports[`Test upgrade > should fix errors or provide hints for errors in the ori
 
 exports[`Test upgrade > should output the correct data from upgrade 1`] = `
 {
-  "fixedItemCount": 106,
+  "fixedItemCount": 107,
   "items": [
     {
       "analysisTarget": "2322.ts",
@@ -2229,50 +2223,14 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "message": "Parameter 'c' implicitly has an 'any' type.",
       "nodeKind": "Parameter",
       "nodeLocation": {
-        "endColumn": 4,
-        "endLine": 77,
-        "startColumn": 3,
-        "startLine": 77,
+        "endColumn": 55,
+        "endLine": 74,
+        "startColumn": 54,
+        "startLine": 74,
       },
       "nodeText": "c",
       "ruleId": "TS7006",
       "type": 0,
-    },
-    {
-      "analysisTarget": "ts-types.ts",
-      "category": "Error",
-      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2304",
-      "hint": "Cannot find name 'UnavailableType'.",
-      "hintAdded": true,
-      "message": "Cannot find name 'UnavailableType'.",
-      "nodeKind": "TypeReference",
-      "nodeLocation": {
-        "endColumn": 21,
-        "endLine": 79,
-        "startColumn": 6,
-        "startLine": 79,
-      },
-      "nodeText": "UnavailableType",
-      "ruleId": "TS2304",
-      "type": 0,
-    },
-    {
-      "analysisTarget": "ts-types.ts",
-      "category": "Error",
-      "helpUrl": "",
-      "hint": "'UnavailableType' is not defined.",
-      "hintAdded": false,
-      "message": "'UnavailableType' is not defined.",
-      "nodeKind": "Identifier",
-      "nodeLocation": {
-        "endColumn": 21,
-        "endLine": 79,
-        "startColumn": 6,
-        "startLine": 79,
-      },
-      "nodeText": "",
-      "ruleId": "no-undef",
-      "type": 1,
     },
   ],
   "summary": [


### PR DESCRIPTION
Filtering all types come from JSDocs that can't be resolved.

The feature is implemented as a wrapper over `annotateWithTypeFromJSDoc` codefix and only available for non-glimmer projects.

The next PR will have a JSDoc clean-up part (https://github.com/rehearsal-js/rehearsal-js/issues/590). 

Closes https://github.com/rehearsal-js/rehearsal-js/issues/790