### PR TITLE
fix: run post-install hooks after install

### DIFF
--- a/packages/cli/src/commands/migrate/tasks/dependency-install.ts
+++ b/packages/cli/src/commands/migrate/tasks/dependency-install.ts
@@ -100,14 +100,6 @@ export function depInstallTask(
 
       const { dependencies, devDependencies } = await shouldRunDepInstallTask(options, ctx);
 
-      // install userConfig postInstall hook
-      if (ctx.userConfig?.hasDependencies) {
-        if (ctx.userConfig?.hasPostInstallHook) {
-          task.output = `Run postInstall hook from config`;
-          await ctx.userConfig.postInstall();
-        }
-      }
-
       const errorMessages: string[] = [];
 
       // for deps
@@ -131,6 +123,14 @@ export function depInstallTask(
 
         if (errorMessages.length) {
           throw new Error(errorMessages.join('\n'));
+        }
+      }
+
+      // install userConfig postInstall hook
+      if (ctx.userConfig?.hasDependencies) {
+        if (ctx.userConfig?.hasPostInstallHook) {
+          task.output = `Run postInstall hook from config`;
+          await ctx.userConfig.postInstall();
         }
       }
 

--- a/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
+++ b/packages/cli/test/commands/migrate/__snapshots__/dependency-install.test.ts.snap
@@ -27,8 +27,8 @@ exports[`Task: dependency-install > install required dependencies 1`] = `
 
 exports[`Task: dependency-install > multiple postInstall commands from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript
+[DATA] Run postInstall hook from config
 [DATA] Setting resolutions: typescript@^5.0.4
 [SUCCESS] Install dependencies
 "
@@ -51,8 +51,8 @@ We ran into an error when installing devDependencies, please install the followi
 
 exports[`Task: dependency-install > single postInstall command from user config 1`] = `
 "[STARTED] Install dependencies
-[DATA] Run postInstall hook from config
 [DATA] Installing devDependencies: @types/node, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint, eslint-config-prettier, eslint-plugin-prettier, prettier, typescript, fs-extra
+[DATA] Run postInstall hook from config
 [DATA] Setting resolutions: typescript@^5.0.4
 [SUCCESS] Install dependencies
 "


### PR DESCRIPTION
Need to actually run `postInstall` hook post-install or else things get weird fast.