### PR TITLE
fix: need to json5

### DIFF
--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, extname, resolve } from 'node:path';
-import { readJSON } from 'fs-extra/esm';
+import { readJSON } from '@rehearsal/utils';
 import {
   GlintService,
   isGlintFile,


### PR DESCRIPTION
We can't just use `readJSON` on tsconfig.json because they will have comments in them.