### PR TITLE
fix: correctly resolve addon paths

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -48,6 +48,7 @@
     "@rehearsal/utils": "workspace:*",
     "execa": "^7.0.0",
     "fs-extra": "^11.1.0",
+    "resolve-package-path": "^4.0.3",
     "winston": "^3.8.2"
   },
   "devDependencies": {

--- a/packages/migrate/test/fixtures/project/packages/foo/package.json
+++ b/packages/migrate/test/fixtures/project/packages/foo/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Chris Freeman",
+  "license": "ISC",
+  "dependencies": {
+    "@ember/test-helpers": "^2.9.3",
+    "@glimmer/component": "^1.1.2",
+    "@glimmerx/component": "^0.6.8",
+    "@glint/core": "^1.0.0-beta.4",
+    "@glint/environment-ember-loose": "1.0.0-beta.4",
+    "@glint/environment-ember-template-imports": "1.0.0-beta.4",
+    "@glint/environment-glimmerx": "^1.0.0-beta.4",
+    "@glint/template": "1.0.0-beta.4",
+    "@types/ember__service": "^4.0.2",
+    "@types/node": "^18.13.0",
+    "@types/qunit": "^2.19.4",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
+    "ember-cli-htmlbars": "^6.2.0",
+    "ember-qunit": "^6.2.0",
+    "ember-template-imports": "^3.4.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.3",
+    "ember-template-lint": "^5.7.2",
+    "ember-template-lint-plugin-prettier": "^4.1.0",
+    "eslint": "^8.0.0",
+    "eslint-plugin-ember": "^11.4.9",
+    "prettier": "^2.8.3",
+    "qunit": "^2.19.4",
+    "qunit-dom": "^2.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/migrate/test/fixtures/project/packages/foo/with-qualified-service.js
+++ b/packages/migrate/test/fixtures/project/packages/foo/with-qualified-service.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class SomeComponent extends Component {
+  @service('authentication@authenticated-user') authenticatedUser;
+
+  @service('foo@foo-service') otherProp;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,7 @@ importers:
       fixturify-project: ^5.2.0
       fs-extra: ^11.1.0
       listr2: ^5.0.7
+      resolve-package-path: ^4.0.3
       type-fest: ^3.6.1
       uuid: ^9.0.0
       vitest: ^0.29.2
@@ -230,6 +231,7 @@ importers:
       '@rehearsal/utils': link:../utils
       execa: 7.0.0
       fs-extra: 11.1.0
+      resolve-package-path: 4.0.3
       winston: 3.8.2
     devDependencies:
       findup-sync: 5.0.0


### PR DESCRIPTION
Closes https://github.com/rehearsal-js/rehearsal-js/issues/964

Uses https://www.npmjs.com/package/resolve-package-path to correctly resolve package paths even in cases where the `basePath` is not the same as `process.cwd` or the root of the project (e.g. when running something like `rehearsal migrate --package ./packages/foo` in a monorepo)