### PR TITLE
fix: use dynamic imports for glint-related modules

### DIFF
--- a/packages/migrate/src/glint-utils.ts
+++ b/packages/migrate/src/glint-utils.ts
@@ -4,6 +4,8 @@ import { readPackageJson } from '@rehearsal/migration-graph-shared';
 import { requirePackageMain } from '@rehearsal/migration-graph-ember';
 import resolvePackagePath from 'resolve-package-path';
 import type { PackageJson, TsConfigJson } from 'type-fest';
+import type { GlintService } from '@rehearsal/service';
+import type { GlintFixPlugin, GlintReportPlugin } from '@rehearsal/plugins';
 
 // The list of extensions that we expect to be handled by Glint{Fix,Check} plugins. Note that
 // in any ember/glimmer project, we'll use the glint *service* for all files. This list is only
@@ -86,4 +88,31 @@ export async function shouldUseGlint(basePath: string): Promise<boolean> {
   return deps.some((pkgName) => {
     return GLINT_PROJECT_FILES.includes(pkgName);
   });
+}
+
+export const DummyPlugin = {
+  run() {
+    return Promise.resolve([]);
+  },
+};
+
+// All of these functions exist to handle the fact that @glint/core won't be present as a peer dep
+// for non-Ember projects, so we need to lazily import and instantiate anything that depends on it
+// or else we get "module not found" errors
+export async function createGlintService(basePath: string): Promise<GlintService> {
+  const GlintService = (await import('@rehearsal/service')).GlintService;
+
+  return new GlintService(basePath);
+}
+
+export async function createGlintFixPlugin(): Promise<GlintFixPlugin> {
+  const GlintFixPlugin = (await import('@rehearsal/plugins')).GlintFixPlugin;
+
+  return new GlintFixPlugin();
+}
+
+export async function createGlintReportPlugin(): Promise<GlintReportPlugin> {
+  const GlintReportPlugin = (await import('@rehearsal/plugins')).GlintReportPlugin;
+
+  return new GlintReportPlugin();
 }

--- a/packages/plugins/src/plugins/glint-fix.plugin.ts
+++ b/packages/plugins/src/plugins/glint-fix.plugin.ts
@@ -1,16 +1,16 @@
 import { applyCodeFix, makeCodeFixStrict } from '@rehearsal/codefixes';
-import {
-  GlintService,
-  Plugin,
-  PluginOptions,
-  PluginsRunnerContext,
-  type PluginResult,
-} from '@rehearsal/service';
 import debug from 'debug';
 
 import { pathUtils } from '@glint/core';
 import { CodeFixAction } from 'typescript';
 import { CodeActionKind, Diagnostic } from 'vscode-languageserver';
+import type {
+  GlintService,
+  Plugin,
+  PluginOptions,
+  PluginResult,
+  PluginsRunnerContext,
+} from '@rehearsal/service';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-fix');
 

--- a/packages/service/src/glint-utils.ts
+++ b/packages/service/src/glint-utils.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { extname, resolve } from 'node:path';
-import { GlintService } from './glint-service.js';
 import { RehearsalService } from './rehearsal-service.js';
+import type { GlintService } from './glint-service.js';
 import type { PackageJson } from 'type-fest';
 
 // The list of extensions that we expect to be handled by Glint{Fix,Check} plugins. Note that

--- a/packages/service/src/rehearsal-service.ts
+++ b/packages/service/src/rehearsal-service.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 
-import { GlintLanguageServer } from '@glint/core';
 import { RehearsalServiceHost } from './rehearsal-service-host.js';
+import type { GlintLanguageServer } from '@glint/core';
 import type {
   CompilerOptions,
   Diagnostic,


### PR DESCRIPTION
Hopfully closes https://github.com/rehearsal-js/rehearsal-js/issues/975 by making all of the glint-related modules dynamic imports so that we don't even attempt to import things like `GlintService` when we're not in an ember project