### PR TITLE
fix: dynamic import all glint things

### DIFF
--- a/packages/migrate/src/glint-utils.ts
+++ b/packages/migrate/src/glint-utils.ts
@@ -100,9 +100,10 @@ export const DummyPlugin = {
 // for non-Ember projects, so we need to lazily import and instantiate anything that depends on it
 // or else we get "module not found" errors
 export async function createGlintService(basePath: string): Promise<GlintService> {
+  const glintCore = await import('@glint/core');
   const GlintService = (await import('@rehearsal/service')).GlintService;
 
-  return new GlintService(basePath);
+  return new GlintService(glintCore, basePath);
 }
 
 export async function createGlintFixPlugin(): Promise<GlintFixPlugin> {

--- a/packages/plugins/src/plugins/glint-fix.plugin.ts
+++ b/packages/plugins/src/plugins/glint-fix.plugin.ts
@@ -1,7 +1,6 @@
 import { applyCodeFix, makeCodeFixStrict } from '@rehearsal/codefixes';
 import debug from 'debug';
 
-import { pathUtils } from '@glint/core';
 import { CodeFixAction } from 'typescript';
 import { CodeActionKind, Diagnostic } from 'vscode-languageserver';
 import type {
@@ -28,7 +27,7 @@ export class GlintFixPlugin implements Plugin<PluginOptions> {
         break;
       }
       const fileText = service.getFileText(fileName);
-      const start = pathUtils.positionToOffset(fileText, diagnostic.range.start);
+      const start = service.pathUtils.positionToOffset(fileText, diagnostic.range.start);
 
       const fix = this.getCodeFix(fileName, diagnostic, service);
 

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,7 +1,7 @@
 export { Plugin, PluginOptions, PluginsRunnerContext, PluginsRunner } from './plugin.js';
 export { RehearsalService, type Service } from './rehearsal-service.js';
 export { RehearsalServiceHost } from './rehearsal-service-host.js';
-export { GlintService, type Range } from './glint-service.js';
+export { GlintService, type Range, type PathUtils } from './glint-service.js';
 export * from './glint-utils.js';
 
 export type { PluginResult } from './plugin.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8917,7 +8917,7 @@ packages:
       '@colors/colors': 1.5.0
       '@types/triple-beam': 1.3.2
       fecha: 4.2.3
-      ms: 2.1.2
+      ms: 2.1.3
       safe-stable-stringify: 2.4.3
       triple-beam: 1.3.0
     dev: false
@@ -9305,7 +9305,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}


### PR DESCRIPTION
Follow up to https://github.com/rehearsal-js/rehearsal-js/pull/983

We now just dynamically import all glint-related modules (including `@glint/core`) so that Node should never try to resolve a glint-related import unless one of the factory functions is called.