### PR TITLE
internal: use magic-string for fixing

### DIFF
--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance.ts
@@ -136,6 +136,17 @@ export class AddMissingTypesBasedOnInheritanceCodeFix implements CodeFix {
 
         // Skipping "non-strict types"
         if (!type || type === 'any' || type === 'object') {
+          // If the type was too loose but we have an accesortor of the current class
+          // recurse with the parent
+          const parentClassMethod = findAncestor(
+            ancestorMethodSymbol.declarations?.[0],
+            isMethodDeclaration
+          );
+
+          if (parentClassMethod) {
+            return this.findInheritedType(parentClassMethod, checker, finder);
+          }
+
           continue;
         }
 

--- a/packages/codefixes/src/get-diagnostics.ts
+++ b/packages/codefixes/src/get-diagnostics.ts
@@ -16,6 +16,7 @@ const PRIORITIZED_CODES: number[] = [
   Diagnostics.TS7046.code,
   Diagnostics.TS7050.code,
   Diagnostics.TS2612.code,
+  Diagnostics.TS4073.code,
 ];
 
 /**

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -111,7 +111,8 @@ export default <P extends InjectedProps>(Component: React.ComponentType<P>) =>
         [...prev.todos, todo];
       });
     };
-    props: P | undefined;
+    // @ts-expect-error @rehearsal TODO TS2564: Property 'props' has no initializer and is not definitely assigned in the constructor.
+    props: P;
 
     render() {
       return (

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -373,9 +373,9 @@ export default class Hello extends Component {
 import { inject as service } from "@ember/service";
 
 export default class Salutation extends Component {
-  @service locale: { current: () => string } | undefined;
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'locale' has no initializer and is not definitely assigned in the constructor.
+  @service locale: { current: () => string };
   get name() {
-    // @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'.
     if (this.locale.current() == "en-US") {
       return "Bob";
     }
@@ -395,7 +395,7 @@ export default class Salutation extends Component {
 
       expect(report.summary[0].basePath).toMatch(project.baseDir);
       expect(getStringAtLocation(outputs[1], report.items[0].nodeLocation as Location)).toEqual(
-        'this.locale'
+        'locale'
       );
       expect(report.items).toHaveLength(1);
       expect(report.items[0].analysisTarget).toEqual('src/salutation.ts');

--- a/packages/plugins/src/plugins/glint-fix.plugin.ts
+++ b/packages/plugins/src/plugins/glint-fix.plugin.ts
@@ -1,7 +1,8 @@
-import { applyCodeFix, makeCodeFixStrict } from '@rehearsal/codefixes';
+import { createRequire } from 'node:module';
+import { makeCodeFixStrict } from '@rehearsal/codefixes';
 import debug from 'debug';
 
-import { CodeFixAction } from 'typescript';
+import ts from 'typescript';
 import { CodeActionKind, Diagnostic } from 'vscode-languageserver';
 import type {
   GlintService,
@@ -10,65 +11,103 @@ import type {
   PluginResult,
   PluginsRunnerContext,
 } from '@rehearsal/service';
+import type MS from 'magic-string';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const MagicString = require('magic-string');
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-fix');
 
 export class GlintFixPlugin implements Plugin<PluginOptions> {
+  appliedAtOffset: { [file: string]: number[] } = {};
+  changeTrackers: Map<string, MS.default> = new Map();
+  allFixedFiles: Set<string> = new Set();
+
   async run(fileName: string, context: PluginsRunnerContext): PluginResult {
-    const allFixedFiles: Set<string> = new Set();
+    // Todo: we should just recreate the plugin class for each file
+    this.resetState();
+
+    this.applyFix(fileName, context, ts.DiagnosticCategory.Error);
+    this.applyFix(fileName, context, ts.DiagnosticCategory.Suggestion);
+
+    this.changeTrackers.forEach((tracker, fileName) => {
+      context.service.setFileText(fileName, tracker.toString());
+    });
+
+    return Promise.resolve(Array.from(this.allFixedFiles));
+  }
+
+  applyFix(
+    fileName: string,
+    context: PluginsRunnerContext,
+    diagnosticCategory: ts.DiagnosticCategory
+  ): void {
     const service = context.service as GlintService;
+    const diagnostics = this.getDiagnostics(service, fileName, diagnosticCategory);
 
-    let diagnostics = this.getDiagnostics(service, fileName);
-
-    while (diagnostics.length > 0) {
-      const diagnostic = diagnostics.shift();
-
-      if (diagnostic === undefined) {
-        break;
-      }
-      const fileText = service.getFileText(fileName);
-      const start = service.pathUtils.positionToOffset(fileText, diagnostic.range.start);
-
+    for (const diagnostic of diagnostics) {
       const fix = this.getCodeFix(fileName, diagnostic, service);
 
       if (fix === undefined) {
+        DEBUG_CALLBACK(` - TS${diagnostic.code} at ${diagnostic.range.start}:\t node not found`);
         continue;
       }
 
-      applyCodeFix(fix, {
-        getText(filename: string) {
-          return context.service.getFileText(filename);
-        },
+      for (const fileTextChange of fix.changes) {
+        let changeTracker: MS.default;
+        if (!this.changeTrackers.has(fileTextChange.fileName)) {
+          const originalText = context.service.getFileText(fileTextChange.fileName);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          changeTracker = new MagicString(originalText);
 
-        applyText(newText: string) {
-          DEBUG_CALLBACK(`- TS${diagnostic.code} at ${start}:\t ${newText}`);
-        },
+          this.changeTrackers.set(fileTextChange.fileName, changeTracker);
+        } else {
+          changeTracker = this.changeTrackers.get(fileTextChange.fileName)!;
+        }
 
-        setText(filename: string, text: string) {
-          context.service.setFileText(filename, text);
-          allFixedFiles.add(filename);
-          DEBUG_CALLBACK(`- TS${diagnostic.code} at ${start}:\t codefix applied`);
-        },
-      });
+        for (const change of fileTextChange.textChanges) {
+          if (change.span.length > 0) {
+            changeTracker.remove(change.span.start, change.span.start + change.span.length);
+          }
 
-      context.reporter.incrementRunFixedItemCount();
+          if (!this.appliedAtOffset[fileTextChange.fileName]) {
+            this.appliedAtOffset[fileTextChange.fileName] = [];
+          }
 
-      // Get updated list of diagnostics
-      diagnostics = this.getDiagnostics(service, fileName);
+          if (this.appliedAtOffset[fileTextChange.fileName].includes(change.span.start)) {
+            continue;
+          } else {
+            // this.appliedAtOffset[fileTextChange.fileName].push(change.span.start);
+          }
+
+          DEBUG_CALLBACK(
+            `- TS${diagnostic.code} at ${diagnostic.range.start}:\t ${change.newText}`
+          );
+
+          changeTracker.appendLeft(change.span.start, change.newText);
+          this.allFixedFiles.add(fileTextChange.fileName);
+        }
+      }
     }
-
-    return Promise.resolve(Array.from(allFixedFiles));
   }
 
-  getDiagnostics(service: GlintService, fileName: string): Diagnostic[] {
-    return service.getDiagnostics(fileName).map((d) => service.convertTsDiagnosticToLSP(d));
+  getDiagnostics(
+    service: GlintService,
+    fileName: string,
+    diagnosticCategory: ts.DiagnosticCategory
+  ): Diagnostic[] {
+    return service
+      .getDiagnostics(fileName)
+      .filter((d) => d.category === diagnosticCategory)
+      .map((d) => service.convertTsDiagnosticToLSP(d));
   }
 
   getCodeFix(
     fileName: string,
     diagnostic: Diagnostic,
     service: GlintService
-  ): CodeFixAction | undefined {
+  ): ts.CodeFixAction | undefined {
     const glintService = service.getGlintService();
     const rawActions = glintService.getCodeActions(
       fileName,
@@ -79,7 +118,7 @@ export class GlintFixPlugin implements Plugin<PluginOptions> {
 
     const transformedActions = service
       .transformCodeActionToCodeFixAction(rawActions)
-      .reduce<CodeFixAction[]>((acc, fix) => {
+      .reduce<ts.CodeFixAction[]>((acc, fix) => {
         const strictFix = makeCodeFixStrict(fix);
 
         if (strictFix) {
@@ -90,5 +129,11 @@ export class GlintFixPlugin implements Plugin<PluginOptions> {
       }, []);
 
     return transformedActions[0];
+  }
+
+  private resetState(): void {
+    this.appliedAtOffset = {};
+    this.changeTrackers = new Map();
+    this.allFixedFiles = new Set();
   }
 }

--- a/packages/plugins/src/plugins/index.ts
+++ b/packages/plugins/src/plugins/index.ts
@@ -8,8 +8,10 @@ export {
   DiagnosticReportPluginOptions,
 } from './diagnostic-report.plugin.js';
 export { GlintFixPlugin } from './glint-fix.plugin.js';
+
 export { GlintCommentPlugin } from './glint-comment.plugin.js';
 export { GlintReportPlugin } from './glint-report.plugin.js';
+
 export { LintPlugin, LintPluginOptions } from './lint.plugin.js';
 export { PrettierPlugin, isPrettierUsedForFormatting } from './prettier.plugin.js';
 export { ReRehearsePlugin, ReRehearsePluginOptions } from './re-rehearse.plugin.js';

--- a/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/upgrade.test.ts.snap
@@ -128,8 +128,8 @@ export class Radio extends Component {
    * @return {string}
    */
   @action
-  // @ts-expect-error @rehearsal TODO TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-  async onRadioChange(value: boolean): Promise<string> {
+  // @ts-expect-error @rehearsal TODO TS1064: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
+  async onRadioChange(value: boolean): string {
     this.one = true;
     this.two = false;
 
@@ -247,7 +247,7 @@ export function oneOfParamsHaveSomethingOrAny(a: string, b): void  {
  * @param {String} a - A string
  * @returns {Promise} the promise that resolves when the request has been resumed
  */
-export function returnTypeHasGenericAny(a: string): Promise<string>  {
+export function returnTypeHasGenericAny(a: string) {
   return Promise.resolve(a);
 }
 
@@ -303,7 +303,9 @@ export function collectModel(model, value): void  {
 `;
 
 exports[`Test upgrade > should fix errors or provide hints for errors in the original files 11`] = `
-"
+"// @ts-expect-error @rehearsal TODO TS6133: The declaration 'resolve' is never read or used. Remove the declaration or use it.
+import { resolve } from 'path';
+
 /* Existing comment */
 
 
@@ -334,11 +336,12 @@ export function usesMissingVarWithLongName(): boolean {
 }
 
 
-
+// @ts-expect-error @rehearsal TODO TS2304: Cannot find name '_inSecondsconst'.
+_inSecondsconst _inMinutes
 // The next function call is not properly formatted
 // @ts-expect-error @rehearsal TODO TS2304: Cannot find name 'timestamp'.
 timestamp(   );
-   
+
 // @ts-expect-error @rehearsal TODO TS2306: File './module.ts' is not a module.
 import testModule from './module';
 
@@ -376,7 +379,8 @@ export class Foo {
    * Viewport Width
    * @type {string}
    */
-  @action viewportWidth: string | undefined;
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'viewportWidth' has no initializer and is not definitely assigned in the constructor.
+  @action viewportWidth: number;
 
   /**
    * Foo Method
@@ -392,7 +396,6 @@ export class Foo {
         orderedBreakpointsLongNameConstant.find(([key]) => key === size)
       ) + 1;
     if (nextBreakpointIndex < orderedBreakpointsLongNameConstant.length) {
-      // @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'.
       return this.viewportWidth >= orderedBreakpointsLongNameConstant[nextBreakpointIndex][1];
     }
 
@@ -413,8 +416,7 @@ export class Foo {
    * @param {string} size
    * @returns {boolean}
    */
-  isLess(size: string): boolean {
-    // @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'.
+  isLess(size: string | number): boolean {
     return this.viewportWidth < breakpointMap[size];
   }
 }
@@ -746,12 +748,11 @@ test2(0);
  * @param {number} me
  * @return {string}
  */
-export function test3(me: number): string {
+export function test3(me: string): string {
   return me.toString();
 }
 
 
-// @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'.
 test3('O');
 
 export class A {
@@ -851,7 +852,7 @@ exports[`Test upgrade > should fix errors or provide hints for errors in the ori
 
 exports[`Test upgrade > should output the correct data from upgrade 1`] = `
 {
-  "fixedItemCount": 114,
+  "fixedItemCount": 127,
   "items": [
     {
       "analysisTarget": "2322.ts",
@@ -1234,19 +1235,19 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
     {
       "analysisTarget": "react-xx.ts",
       "category": "Error",
-      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2355",
-      "hint": "A function whose declared type is neither 'void' nor 'any' must return a value.",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts1064",
+      "hint": "The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?",
       "hintAdded": true,
-      "message": "A function whose declared type is neither 'void' nor 'any' must return a value.",
-      "nodeKind": "TypeReference",
+      "message": "The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?",
+      "nodeKind": "StringKeyword",
       "nodeLocation": {
-        "endColumn": 55,
+        "endColumn": 46,
         "endLine": 24,
         "startColumn": 40,
         "startLine": 24,
       },
-      "nodeText": "Promise<string>",
-      "ruleId": "TS2355",
+      "nodeText": "string",
+      "ruleId": "TS1064",
       "type": 0,
     },
     {
@@ -1702,6 +1703,24 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
     {
       "analysisTarget": "ts-errors.ts",
       "category": "Error",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=TS6133",
+      "hint": "The declaration 'resolve' is never read or used. Remove the declaration or use it.",
+      "hintAdded": true,
+      "message": "'resolve' is declared but its value is never read.",
+      "nodeKind": "ImportDeclaration",
+      "nodeLocation": {
+        "endColumn": 32,
+        "endLine": 2,
+        "startColumn": 1,
+        "startLine": 2,
+      },
+      "nodeText": "import { resolve } from 'path';",
+      "ruleId": "TS6133",
+      "type": 0,
+    },
+    {
+      "analysisTarget": "ts-errors.ts",
+      "category": "Error",
       "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2304",
       "hint": "Cannot find name 'whereAmI'.",
       "hintAdded": true,
@@ -1709,9 +1728,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 18,
-        "endLine": 8,
+        "endLine": 10,
         "startColumn": 10,
-        "startLine": 8,
+        "startLine": 10,
       },
       "nodeText": "whereAmI",
       "ruleId": "TS2304",
@@ -1727,9 +1746,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 17,
-        "endLine": 17,
+        "endLine": 19,
         "startColumn": 7,
-        "startLine": 17,
+        "startLine": 19,
       },
       "nodeText": "missingVar",
       "ruleId": "TS2304",
@@ -1745,9 +1764,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 17,
-        "endLine": 26,
+        "endLine": 28,
         "startColumn": 7,
-        "startLine": 26,
+        "startLine": 28,
       },
       "nodeText": "missingVar",
       "ruleId": "TS2304",
@@ -1763,11 +1782,29 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 97,
-        "endLine": 28,
+        "endLine": 30,
         "startColumn": 7,
-        "startLine": 28,
+        "startLine": 30,
       },
       "nodeText": "missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString",
+      "ruleId": "TS2304",
+      "type": 0,
+    },
+    {
+      "analysisTarget": "ts-errors.ts",
+      "category": "Error",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2304",
+      "hint": "Cannot find name '_inSecondsconst'.",
+      "hintAdded": true,
+      "message": "Cannot find name '_inSecondsconst'.",
+      "nodeKind": "ExpressionStatement",
+      "nodeLocation": {
+        "endColumn": 16,
+        "endLine": 35,
+        "startColumn": 1,
+        "startLine": 35,
+      },
+      "nodeText": "_inSecondsconst",
       "ruleId": "TS2304",
       "type": 0,
     },
@@ -1781,9 +1818,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 10,
-        "endLine": 35,
+        "endLine": 38,
         "startColumn": 1,
-        "startLine": 35,
+        "startLine": 38,
       },
       "nodeText": "timestamp",
       "ruleId": "TS2304",
@@ -1799,9 +1836,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "StringLiteral",
       "nodeLocation": {
         "endColumn": 34,
-        "endLine": 38,
+        "endLine": 41,
         "startColumn": 24,
-        "startLine": 38,
+        "startLine": 41,
       },
       "nodeText": "'./module'",
       "ruleId": "TS2306",
@@ -1811,91 +1848,37 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "analysisTarget": "ts-errors.ts",
       "category": "Error",
       "helpUrl": "",
-      "hint": "'whereAmI' is not defined.",
+      "hint": "Parsing error: Unexpected keyword or identifier.",
       "hintAdded": false,
-      "message": "'whereAmI' is not defined.",
-      "nodeKind": "Identifier",
+      "message": "Parsing error: Unexpected keyword or identifier.",
+      "nodeKind": undefined,
       "nodeLocation": {
-        "endColumn": 18,
-        "endLine": 8,
-        "startColumn": 10,
-        "startLine": 8,
-      },
-      "nodeText": "",
-      "ruleId": "no-undef",
-      "type": 1,
-    },
-    {
-      "analysisTarget": "ts-errors.ts",
-      "category": "Error",
-      "helpUrl": "",
-      "hint": "'missingVar' is not defined.",
-      "hintAdded": false,
-      "message": "'missingVar' is not defined.",
-      "nodeKind": "Identifier",
-      "nodeLocation": {
-        "endColumn": 17,
-        "endLine": 17,
-        "startColumn": 7,
-        "startLine": 17,
-      },
-      "nodeText": "",
-      "ruleId": "no-undef",
-      "type": 1,
-    },
-    {
-      "analysisTarget": "ts-errors.ts",
-      "category": "Error",
-      "helpUrl": "",
-      "hint": "'missingVar' is not defined.",
-      "hintAdded": false,
-      "message": "'missingVar' is not defined.",
-      "nodeKind": "Identifier",
-      "nodeLocation": {
-        "endColumn": 17,
-        "endLine": 26,
-        "startColumn": 7,
-        "startLine": 26,
-      },
-      "nodeText": "",
-      "ruleId": "no-undef",
-      "type": 1,
-    },
-    {
-      "analysisTarget": "ts-errors.ts",
-      "category": "Error",
-      "helpUrl": "",
-      "hint": "'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' is not defined.",
-      "hintAdded": false,
-      "message": "'missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' is not defined.",
-      "nodeKind": "Identifier",
-      "nodeLocation": {
-        "endColumn": 97,
-        "endLine": 28,
-        "startColumn": 7,
-        "startLine": 28,
-      },
-      "nodeText": "",
-      "ruleId": "no-undef",
-      "type": 1,
-    },
-    {
-      "analysisTarget": "ts-errors.ts",
-      "category": "Error",
-      "helpUrl": "",
-      "hint": "'timestamp' is not defined.",
-      "hintAdded": false,
-      "message": "'timestamp' is not defined.",
-      "nodeKind": "Identifier",
-      "nodeLocation": {
-        "endColumn": 10,
+        "endColumn": 2,
         "endLine": 35,
         "startColumn": 1,
         "startLine": 35,
       },
       "nodeText": "",
-      "ruleId": "no-undef",
+      "ruleId": "error-generated-by-Eslint-core",
       "type": 1,
+    },
+    {
+      "analysisTarget": "ts-multiline-hint.ts",
+      "category": "Error",
+      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2564",
+      "hint": "Property 'viewportWidth' has no initializer and is not definitely assigned in the constructor.",
+      "hintAdded": true,
+      "message": "Property 'viewportWidth' has no initializer and is not definitely assigned in the constructor.",
+      "nodeKind": "Identifier",
+      "nodeLocation": {
+        "endColumn": 24,
+        "endLine": 31,
+        "startColumn": 11,
+        "startLine": 31,
+      },
+      "nodeText": "viewportWidth",
+      "ruleId": "TS2564",
+      "type": 0,
     },
     {
       "analysisTarget": "ts-multiline-hint.ts",
@@ -1911,9 +1894,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "AsExpression",
       "nodeLocation": {
         "endColumn": 83,
-        "endLine": 41,
+        "endLine": 42,
         "startColumn": 9,
-        "startLine": 41,
+        "startLine": 42,
       },
       "nodeText": "orderedBreakpointsLongNameConstant.find(([key]) => key === size) as string",
       "ruleId": "TS2345",
@@ -1929,48 +1912,12 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Identifier",
       "nodeLocation": {
         "endColumn": 91,
-        "endLine": 42,
+        "endLine": 43,
         "startColumn": 85,
-        "startLine": 42,
+        "startLine": 43,
       },
       "nodeText": "string",
       "ruleId": "TS2693",
-      "type": 0,
-    },
-    {
-      "analysisTarget": "ts-multiline-hint.ts",
-      "category": "Error",
-      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2532",
-      "hint": "Object is possibly 'undefined'.",
-      "hintAdded": true,
-      "message": "Object is possibly 'undefined'.",
-      "nodeKind": "PropertyAccessExpression",
-      "nodeLocation": {
-        "endColumn": 32,
-        "endLine": 47,
-        "startColumn": 14,
-        "startLine": 47,
-      },
-      "nodeText": "this.viewportWidth",
-      "ruleId": "TS2532",
-      "type": 0,
-    },
-    {
-      "analysisTarget": "ts-multiline-hint.ts",
-      "category": "Error",
-      "helpUrl": "https://stackoverflow.com/search?tab=votes&q=ts2532",
-      "hint": "Object is possibly 'undefined'.",
-      "hintAdded": true,
-      "message": "Object is possibly 'undefined'.",
-      "nodeKind": "PropertyAccessExpression",
-      "nodeLocation": {
-        "endColumn": 30,
-        "endLine": 69,
-        "startColumn": 12,
-        "startLine": 69,
-      },
-      "nodeText": "this.viewportWidth",
-      "ruleId": "TS2532",
       "type": 0,
     },
     {
@@ -1983,9 +1930,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": undefined,
       "nodeLocation": {
         "endColumn": 2,
-        "endLine": 41,
+        "endLine": 42,
         "startColumn": 83,
-        "startLine": 41,
+        "startLine": 42,
       },
       "nodeText": "",
       "ruleId": "error-generated-by-Eslint-core",
@@ -2606,24 +2553,6 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
     {
       "analysisTarget": "ts-types.ts",
       "category": "Error",
-      "helpUrl": "https://stackoverflow.com/questions/42421501/error-ts2345-argument-of-type-t-is-not-assignable-to-parameter-of-type-objec",
-      "hint": "Argument of type 'string' is not assignable to parameter of type 'number'. Consider verifying both types, using type assertion: '('O' as string)', or using type guard: 'if ('O' instanceof string) { ... }'.",
-      "hintAdded": true,
-      "message": "Argument of type 'string' is not assignable to parameter of type 'number'.",
-      "nodeKind": "StringLiteral",
-      "nodeLocation": {
-        "endColumn": 10,
-        "endLine": 29,
-        "startColumn": 7,
-        "startLine": 29,
-      },
-      "nodeText": "'O'",
-      "ruleId": "TS2345",
-      "type": 0,
-    },
-    {
-      "analysisTarget": "ts-types.ts",
-      "category": "Error",
       "helpUrl": "https://stackoverflow.com/questions/43064221/typescript-ts7006-parameter-xxx-implicitly-has-an-any-type",
       "hint": "Parameter 'c' implicitly has an 'any' type.",
       "hintAdded": true,
@@ -2631,9 +2560,9 @@ exports[`Test upgrade > should output the correct data from upgrade 1`] = `
       "nodeKind": "Parameter",
       "nodeLocation": {
         "endColumn": 57,
-        "endLine": 75,
+        "endLine": 74,
         "startColumn": 56,
-        "startLine": 75,
+        "startLine": 74,
       },
       "nodeText": "c",
       "ruleId": "TS7006",

--- a/packages/upgrade/test/fixtures/upgrade/ts-errors.ts
+++ b/packages/upgrade/test/fixtures/upgrade/ts-errors.ts
@@ -32,7 +32,7 @@ export function usesMissingVarWithLongName(): boolean {
 }
 
 function notProperlyFormatted(file: string): string {
-    return                  doSomething(file);
+    return                  doSomethingInternal(file);
     }
 
    /**
@@ -48,7 +48,7 @@ function notProperlyFormatted(file: string): string {
 
 // The next function call is not properly formatted
 timestamp(   );
-   
+
 import testModule from './module';
 
 testModule();


### PR DESCRIPTION
This is a follow on to #977 to move code modification to use magic-string for change tracking. Like #977, we are moving to a more conservative model to limit the amount of modifications we do, however instead of keeping track of lines we edit we track offsets relative to the original file. This obviously limits the amount of errors we can fix, however we need to draw a baseline of conservative but reproducible outcomes. We can expand the types we allow through at the same offset in the future.

I noticed that we were relying on re-checking the file of each turn of the loop to resolve parameter types in `addMissingTypesBasedOnInheritance`, however we can [continue walking up](https://github.com/rehearsal-js/rehearsal-js/pull/987/files#diff-17e38cc310e673b5b57aae2003b38325b0bfba76cc2dac216bffc4d8c0a7a629R139) the class hierarchy to find static types.

This PR does the following:

- Moves fix plugins to use magic-string to do change tracking
- Tracks the offsets of where we placed new types
- Fix plugins now do only 2 passes, 1 pass to fix errors and 1 pass to apply any suggestions
- Changes `addMissingTypesBasedOnInheritance` to walk the class hierarchy when we get loose types

# Follow Ups

- #988 is a cleanup of the plugin queue to create a new instance of the plugin on a per-file bases so we can stop doing [state reseting](https://github.com/rehearsal-js/rehearsal-js/pull/987/files#diff-11e3e65b5b4fefbcc62fbc0826e0036b9a8755b79ad29a33ff8149b126a17152R52) in the plugins