### PR TITLE
internal: restructure plugins

### DIFF
--- a/packages/migrate/src/glint-utils.ts
+++ b/packages/migrate/src/glint-utils.ts
@@ -3,9 +3,13 @@ import path from 'node:path';
 import { readPackageJson } from '@rehearsal/migration-graph-shared';
 import { requirePackageMain } from '@rehearsal/migration-graph-ember';
 import resolvePackagePath from 'resolve-package-path';
+import type { GlintFixPlugin, GlintCommentPlugin, GlintReportPlugin } from '@rehearsal/plugins';
 import type { PackageJson, TsConfigJson } from 'type-fest';
 import type { GlintService } from '@rehearsal/service';
-import type { GlintCommentPlugin, GlintFixPlugin, GlintReportPlugin } from '@rehearsal/plugins';
+
+type GlintFixPluginCtor = typeof GlintFixPlugin;
+type GlintReportPluginCtor = typeof GlintReportPlugin;
+type GlintCommentPluginCtor = typeof GlintCommentPlugin;
 
 // The list of extensions that we expect to be handled by Glint{Fix,Check} plugins. Note that
 // in any ember/glimmer project, we'll use the glint *service* for all files. This list is only
@@ -90,12 +94,6 @@ export async function shouldUseGlint(basePath: string): Promise<boolean> {
   });
 }
 
-export const DummyPlugin = {
-  run() {
-    return Promise.resolve([]);
-  },
-};
-
 // All of these functions exist to handle the fact that @glint/core won't be present as a peer dep
 // for non-Ember projects, so we need to lazily import and instantiate anything that depends on it
 // or else we get "module not found" errors
@@ -106,20 +104,20 @@ export async function createGlintService(basePath: string): Promise<GlintService
   return new GlintService(glintCore, basePath);
 }
 
-export async function createGlintFixPlugin(): Promise<GlintFixPlugin> {
+export async function getGlintFixPlugin(): Promise<GlintFixPluginCtor> {
   const GlintFixPlugin = (await import('@rehearsal/plugins')).GlintFixPlugin;
 
-  return new GlintFixPlugin();
+  return GlintFixPlugin;
 }
 
-export async function createGlintReportPlugin(): Promise<GlintReportPlugin> {
+export async function getGlintReportPlugin(): Promise<GlintReportPluginCtor> {
   const GlintReportPlugin = (await import('@rehearsal/plugins')).GlintReportPlugin;
 
-  return new GlintReportPlugin();
+  return GlintReportPlugin;
 }
 
-export async function createGlintCommentPlugin(): Promise<GlintCommentPlugin> {
+export async function getGlintCommentPlugin(): Promise<GlintCommentPluginCtor> {
   const GlintCommentPlugin = (await import('@rehearsal/plugins')).GlintCommentPlugin;
 
-  return new GlintCommentPlugin();
+  return GlintCommentPlugin;
 }

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -397,7 +397,7 @@ export default class Salutation extends Component {
       expect(getStringAtLocation(outputs[1], report.items[0].nodeLocation as Location)).toEqual(
         'locale'
       );
-      expect(report.items).toHaveLength(1);
+      expect(report.items).toHaveLength(2);
       expect(report.items[0].analysisTarget).toEqual('src/salutation.ts');
     });
   });

--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -8,13 +8,7 @@ import {
   isInstallPackageCommand,
   type DiagnosticWithContext,
 } from '@rehearsal/codefixes';
-import {
-  Plugin,
-  PluginOptions,
-  PluginsRunnerContext,
-  Service,
-  type PluginResult,
-} from '@rehearsal/service';
+import { PluginOptions, PluginsRunnerContext, Service, Plugin } from '@rehearsal/service';
 import { findNodeAtPosition } from '@rehearsal/ts-utils';
 import type MS from 'magic-string';
 
@@ -32,24 +26,16 @@ export interface DiagnosticFixPluginOptions extends PluginOptions {
 /**
  * Diagnose issues in the file and applied transforms to fix them
  */
-export class DiagnosticFixPlugin implements Plugin<DiagnosticFixPluginOptions> {
+export class DiagnosticFixPlugin extends Plugin<DiagnosticFixPluginOptions> {
   attemptedToFix: string[] = [];
   appliedAtOffset: { [file: string]: number[] } = {};
   changeTrackers: Map<string, MS.default> = new Map();
   allFixedFiles: Set<string> = new Set();
 
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: DiagnosticFixPluginOptions
-  ): PluginResult {
-    options.safeFixes ??= true;
-    options.strictTyping ??= true;
+  async run(): Promise<string[]> {
+    const { fileName, context, options } = this;
 
     DEBUG_CALLBACK(`Plugin 'DiagnosticFix' run on %O:`, fileName);
-
-    /// Todo: we should just recreate the plugin class for each file
-    this.resetState();
 
     // First attempt to fix all the errors
     await this.applyFixes(context, fileName, ts.DiagnosticCategory.Error, options);
@@ -200,13 +186,6 @@ export class DiagnosticFixPlugin implements Plugin<DiagnosticFixPluginOptions> {
     }
 
     return fix;
-  }
-
-  private resetState(): void {
-    this.appliedAtOffset = {};
-    this.changeTrackers = new Map();
-    this.allFixedFiles = new Set();
-    this.attemptedToFix = [];
   }
 
   private wasAttemptedToFix(diagnostic: DiagnosticWithContext, fix: ts.CodeFixAction): boolean {

--- a/packages/plugins/src/plugins/diagnostic-report.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-report.plugin.ts
@@ -1,11 +1,5 @@
 import { DiagnosticWithContext, hints } from '@rehearsal/codefixes';
-import {
-  Plugin,
-  PluginOptions,
-  type PluginResult,
-  PluginsRunnerContext,
-  Service,
-} from '@rehearsal/service';
+import { PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { findNodeAtPosition } from '@rehearsal/ts-utils';
 import debug from 'debug';
 import ts from 'typescript';
@@ -20,14 +14,9 @@ export interface DiagnosticReportPluginOptions extends PluginOptions {
   commentTag?: string;
 }
 
-export class DiagnosticReportPlugin implements Plugin<DiagnosticReportPluginOptions> {
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: DiagnosticReportPluginOptions
-  ): PluginResult {
-    options.addHints ??= true;
-    options.commentTag ??= `@rehearsal`;
+export class DiagnosticReportPlugin extends Plugin<DiagnosticReportPluginOptions> {
+  async run(): Promise<string[]> {
+    const { fileName, context, options } = this;
 
     DEBUG_CALLBACK(`Plugin 'DiagnosticReport' run on %O:`, fileName);
 
@@ -36,7 +25,7 @@ export class DiagnosticReportPlugin implements Plugin<DiagnosticReportPluginOpti
     const lineHasSupression: { [line: number]: boolean } = {};
     let contentWithErrors = originalConentWithErrorsSupressed;
     const sourceFile = context.service.getSourceFile(fileName);
-    const tagStarts = [...contentWithErrors.matchAll(new RegExp(options.commentTag, 'g'))].map(
+    const tagStarts = [...contentWithErrors.matchAll(new RegExp(options.commentTag!, 'g'))].map(
       (m) => m.index!
     );
 

--- a/packages/plugins/src/plugins/glint-comment.plugin.ts
+++ b/packages/plugins/src/plugins/glint-comment.plugin.ts
@@ -2,15 +2,7 @@ import { extname } from 'node:path';
 import { createRequire } from 'node:module';
 import { type TransformManager } from '@glint/core';
 import { DiagnosticWithContext, hints, getDiagnosticOrder } from '@rehearsal/codefixes';
-import {
-  GlintService,
-  Plugin,
-  PluginOptions,
-  PluginsRunnerContext,
-  Service,
-  type PluginResult,
-  PathUtils,
-} from '@rehearsal/service';
+import { GlintService, PluginOptions, Service, PathUtils, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
 import ts from 'typescript';
 import debug from 'debug';
@@ -36,16 +28,12 @@ export interface DiagnosticWithLocation extends DiagnosticWithContext {
   location: Location;
 }
 
-export class GlintCommentPlugin implements Plugin<PluginOptions> {
+export class GlintCommentPlugin extends Plugin<GlintCommentPluginOptions> {
   changeTrackers: Map<string, MS.default> = new Map();
   ignoreLines: { [line: number]: boolean } = {};
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: GlintCommentPluginOptions
-  ): PluginResult {
-    this.changeTrackers = new Map();
-    this.ignoreLines = {};
+
+  async run(): Promise<string[]> {
+    const { fileName, context, options } = this;
     const service = context.service as GlintService;
     const diagnostics = this.getDiagnostics(service, fileName);
 

--- a/packages/plugins/src/plugins/glint-fix.plugin.ts
+++ b/packages/plugins/src/plugins/glint-fix.plugin.ts
@@ -4,13 +4,7 @@ import debug from 'debug';
 
 import ts from 'typescript';
 import { CodeActionKind, Diagnostic } from 'vscode-languageserver';
-import type {
-  GlintService,
-  Plugin,
-  PluginOptions,
-  PluginResult,
-  PluginsRunnerContext,
-} from '@rehearsal/service';
+import { Plugin, GlintService, PluginsRunnerContext } from '@rehearsal/service';
 import type MS from 'magic-string';
 
 const require = createRequire(import.meta.url);
@@ -19,15 +13,13 @@ const MagicString = require('magic-string');
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-fix');
 
-export class GlintFixPlugin implements Plugin<PluginOptions> {
+export class GlintFixPlugin extends Plugin {
   appliedAtOffset: { [file: string]: number[] } = {};
   changeTrackers: Map<string, MS.default> = new Map();
   allFixedFiles: Set<string> = new Set();
 
-  async run(fileName: string, context: PluginsRunnerContext): PluginResult {
-    // Todo: we should just recreate the plugin class for each file
-    this.resetState();
-
+  async run(): Promise<string[]> {
+    const { fileName, context } = this;
     this.applyFix(fileName, context, ts.DiagnosticCategory.Error);
     this.applyFix(fileName, context, ts.DiagnosticCategory.Suggestion);
 
@@ -129,11 +121,5 @@ export class GlintFixPlugin implements Plugin<PluginOptions> {
       }, []);
 
     return transformedActions[0];
-  }
-
-  private resetState(): void {
-    this.appliedAtOffset = {};
-    this.changeTrackers = new Map();
-    this.allFixedFiles = new Set();
   }
 }

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -1,12 +1,5 @@
 import { DiagnosticWithContext, hints, getDiagnosticOrder } from '@rehearsal/codefixes';
-import {
-  GlintService,
-  Plugin,
-  PluginOptions,
-  PluginsRunnerContext,
-  Service,
-  type PluginResult,
-} from '@rehearsal/service';
+import { GlintService, PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
 import debug from 'debug';
 import ts from 'typescript';
@@ -22,12 +15,9 @@ export interface DiagnosticWithLocation extends DiagnosticWithContext {
   location: Location;
 }
 
-export class GlintReportPlugin implements Plugin<PluginOptions> {
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: GlintReportPluginOptions
-  ): PluginResult {
+export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
+  async run(): Promise<string[]> {
+    const { fileName, context, options } = this;
     const service = context.service as GlintService;
 
     DEBUG_CALLBACK(`Plugin 'GlintReport' run on %O:`, fileName);

--- a/packages/plugins/src/plugins/index.ts
+++ b/packages/plugins/src/plugins/index.ts
@@ -9,8 +9,8 @@ export {
 } from './diagnostic-report.plugin.js';
 export { GlintFixPlugin } from './glint-fix.plugin.js';
 
-export { GlintCommentPlugin } from './glint-comment.plugin.js';
-export { GlintReportPlugin } from './glint-report.plugin.js';
+export { GlintCommentPlugin, GlintCommentPluginOptions } from './glint-comment.plugin.js';
+export { GlintReportPlugin, GlintReportPluginOptions } from './glint-report.plugin.js';
 
 export { LintPlugin, LintPluginOptions } from './lint.plugin.js';
 export { PrettierPlugin, isPrettierUsedForFormatting } from './prettier.plugin.js';

--- a/packages/plugins/src/plugins/lint.plugin.ts
+++ b/packages/plugins/src/plugins/lint.plugin.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { Plugin, PluginOptions, type PluginResult, PluginsRunnerContext } from '@rehearsal/service';
+import { PluginOptions, type PluginResult, Plugin, PluginsRunnerContext } from '@rehearsal/service';
 import { ESLint } from 'eslint';
 import debug from 'debug';
 
@@ -7,20 +7,22 @@ const DEBUG_CALLBACK = debug('rehearsal:plugins:formatting');
 
 export interface LintPluginOptions extends PluginOptions {
   eslintOptions?: ESLint.Options;
-  reportErrors?: boolean;
+  reportErrors: boolean;
 }
 
 /**
  * Source code formatting
  */
-export class LintPlugin implements Plugin<LintPluginOptions> {
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: LintPluginOptions
-  ): PluginResult {
-    options.eslintOptions ??= {};
-    options.reportErrors ??= false;
+export class LintPlugin extends Plugin<LintPluginOptions> {
+  constructor(fileName: string, context: PluginsRunnerContext, options: LintPluginOptions) {
+    super(fileName, context, options);
+    this.options = {
+      eslintOptions: {},
+      ...options,
+    };
+  }
+  async run(): PluginResult {
+    const { fileName, context, options } = this;
 
     if (path.extname(fileName) === '.hbs') {
       return [];

--- a/packages/plugins/src/plugins/prettier.plugin.ts
+++ b/packages/plugins/src/plugins/prettier.plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginOptions, type PluginResult, PluginsRunnerContext } from '@rehearsal/service';
+import { Plugin } from '@rehearsal/service';
 import prettier from 'prettier';
 
 import debug from 'debug';
@@ -8,8 +8,10 @@ const DEBUG_CALLBACK = debug('rehearsal:plugins:prettier');
 /**
  * Source code formatting
  */
-export class PrettierPlugin implements Plugin<PluginOptions> {
-  async run(fileName: string, context: PluginsRunnerContext): PluginResult {
+export class PrettierPlugin extends Plugin {
+  async run(): Promise<string[]> {
+    const { fileName, context } = this;
+
     const text = context.service.getFileText(fileName);
 
     try {

--- a/packages/plugins/src/plugins/re-rehearse.plugin.ts
+++ b/packages/plugins/src/plugins/re-rehearse.plugin.ts
@@ -1,24 +1,20 @@
 import ts from 'typescript';
-import { Plugin, PluginOptions, type PluginResult, PluginsRunnerContext } from '@rehearsal/service';
+import { PluginOptions, Plugin } from '@rehearsal/service';
 import debug from 'debug';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:rerehearse');
 const { isLineBreak } = ts;
 
 export interface ReRehearsePluginOptions extends PluginOptions {
-  commentTag?: string;
+  commentTag: string;
 }
 
 /**
  * Removes all comments with `@rehearsal` tag inside
  */
-export class ReRehearsePlugin implements Plugin<ReRehearsePluginOptions> {
-  async run(
-    fileName: string,
-    context: PluginsRunnerContext,
-    options: ReRehearsePluginOptions
-  ): PluginResult {
-    options.commentTag ??= '@rehearsal';
+export class ReRehearsePlugin extends Plugin<ReRehearsePluginOptions> {
+  async run(): Promise<string[]> {
+    const { fileName, context, options } = this;
 
     let text = context.service.getFileText(fileName);
     const sourceFile = context.service.getSourceFile(fileName);

--- a/packages/plugins/src/plugins/transform.plugin.ts
+++ b/packages/plugins/src/plugins/transform.plugin.ts
@@ -1,19 +1,14 @@
 import { extname } from 'node:path';
-import {
-  GlintService,
-  Plugin,
-  PluginOptions,
-  PluginsRunnerContext,
-  type PluginResult,
-} from '@rehearsal/service';
+import { GlintService, Plugin } from '@rehearsal/service';
 import { applyTextChanges } from '@rehearsal/ts-utils';
 import ts, { TextChange } from 'typescript';
 import debug from 'debug';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:transform');
 
-export class ServiceInjectionsTransformPlugin implements Plugin<PluginOptions> {
-  async run(fileName: string, context: PluginsRunnerContext): PluginResult {
+export class ServiceInjectionsTransformPlugin extends Plugin {
+  async run(): Promise<string[]> {
+    const { fileName, context } = this;
     const service = context.service;
     let sourceFile = service.getSourceFile(fileName);
 

--- a/packages/plugins/test/lint.plugin.test.ts
+++ b/packages/plugins/test/lint.plugin.test.ts
@@ -11,12 +11,10 @@ describe('Test LintPlugin', () => {
 
     const context = mockPluginRunnerContext(project);
 
-    const plugin = new LintPlugin();
-
     for (const file in project.files) {
       const fileName = resolve(project.baseDir, file);
 
-      const result = await plugin.run(fileName, context, {
+      const plugin = new LintPlugin(fileName, context, {
         reportErrors: true,
         eslintOptions: {
           useEslintrc: false,
@@ -26,6 +24,8 @@ describe('Test LintPlugin', () => {
           },
         },
       });
+
+      const result = await plugin.run();
 
       const resultText = context.service.getFileText(fileName).trim();
 

--- a/packages/plugins/test/prettier.plugin.test.ts
+++ b/packages/plugins/test/prettier.plugin.test.ts
@@ -11,12 +11,11 @@ describe('Test PrettierPlugin', () => {
 
     const context = mockPluginRunnerContext(project);
 
-    const plugin = new PrettierPlugin();
-
     for (const file in project.files) {
       const fileName = resolve(project.baseDir, file);
+      const plugin = new PrettierPlugin(fileName, context, {});
 
-      const result = await plugin.run(fileName, context);
+      const result = await plugin.run();
       const resultText = context.service.getFileText(fileName).trim();
 
       expect(result).toHaveLength(1);
@@ -34,12 +33,10 @@ describe('Test PrettierPlugin', () => {
 
     const context = mockPluginRunnerContext(project);
 
-    const plugin = new PrettierPlugin();
-
     for (const file in project.files) {
       const fileName = resolve(project.baseDir, file);
-
-      const result = await plugin.run(fileName, context);
+      const plugin = new PrettierPlugin(fileName, context, {});
+      const result = await plugin.run();
       const resultText = context.service.getFileText(fileName).trim();
 
       expect(result).toHaveLength(1);

--- a/packages/plugins/test/re-rehearse.plugin.test.ts
+++ b/packages/plugins/test/re-rehearse.plugin.test.ts
@@ -11,12 +11,11 @@ describe('Test ReRehearsalPlugin', () => {
 
     const context = mockPluginRunnerContext(project);
 
-    const plugin = new ReRehearsePlugin();
-
     for (const file in project.files) {
       const fileName = resolve(project.baseDir, file);
+      const plugin = new ReRehearsePlugin(fileName, context, { commentTag: '@rehearsal' });
 
-      const result = await plugin.run(fileName, context, { commentTag: '@rehearsal' });
+      const result = await plugin.run();
       const resultText = context.service.getFileText(fileName).trim();
 
       expect(result).toHaveLength(1);

--- a/packages/regen/src/regen.ts
+++ b/packages/regen/src/regen.ts
@@ -82,27 +82,29 @@ export async function regen(input: RegenInput): Promise<RegenOutput> {
 
   const runner = new PluginsRunner({ basePath, service, reporter, logger })
     // Reset
-    .queue(new ReRehearsePlugin(), {
+    .queue(ReRehearsePlugin, {
       commentTag,
     })
     // Add ts-expect-error comments
-    .queue(new DiagnosticCommentPlugin(), {
+    .queue(DiagnosticCommentPlugin, {
+      addHints: true,
       commentTag,
     })
     // Format previously added comments
-    .queue(new PrettierPlugin(), {
-      filter: (fileName: string) => isPrettierUsedForFormatting(fileName),
-    })
-    .queue(new LintPlugin(), {
-      eslintOptions: { cwd: basePath, useEslintrc: true, fix: true },
-      reportErrors: false,
-      filter: (fileName: string) => !isPrettierUsedForFormatting(fileName),
-    })
-    .queue(new DiagnosticReportPlugin(), {
+    .queue(PrettierPlugin, (fileName: string) => isPrettierUsedForFormatting(fileName))
+    .queue(
+      LintPlugin,
+      {
+        eslintOptions: { cwd: basePath, useEslintrc: true, fix: true },
+        reportErrors: false,
+      },
+      (fileName: string) => !isPrettierUsedForFormatting(fileName)
+    )
+    .queue(DiagnosticReportPlugin, {
       commentTag,
     })
     // Report linter issues
-    .queue(new LintPlugin(), {
+    .queue(LintPlugin, {
       eslintOptions: { cwd: basePath, useEslintrc: true, fix: false, ...input.eslintOptions },
       reportErrors: true,
     });

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,4 +1,11 @@
-export { Plugin, PluginOptions, PluginsRunnerContext, PluginsRunner } from './plugin.js';
+export {
+  DummyPlugin,
+  Plugin,
+  PluginFactory,
+  PluginOptions,
+  PluginsRunnerContext,
+  PluginsRunner,
+} from './plugin.js';
 export { RehearsalService, type Service } from './rehearsal-service.js';
 export { RehearsalServiceHost } from './rehearsal-service-host.js';
 export { GlintService, type Range, type PathUtils } from './glint-service.js';


### PR DESCRIPTION
This PR restructures the plugin execution loop and provides an abstract base class that plugins can inherit from. Prior to these changes we had to [reset the class state](https://github.com/rehearsal-js/rehearsal-js/pull/988/files#diff-11e3e65b5b4fefbcc62fbc0826e0036b9a8755b79ad29a33ff8149b126a17152L205) on a per file basis. Instead of registering instances into the queue we can register the constructors and let the queue executor be responsible for constructing them with the correct options. 

This PR does not change any user facing behavior and only cleans up how we author, execute and register plugins.
