### PR TITLE
feat: add support for ember@4 service exported method.

### DIFF
--- a/packages/migration-graph-ember/src/utils/discover-ember-service-dependencies.ts
+++ b/packages/migration-graph-ember/src/utils/discover-ember-service-dependencies.ts
@@ -73,19 +73,33 @@ export function discoverServiceDependencies(
     return EMPTY_RESULT;
   }
 
-  // We need to look through all import declarations to find the one with the export `inject`
-  const importDeclaration = findImportDeclarationWithExportedName(
+  // We need to look through all import declarations to find for exports with either:
+  // `inject` 3.28
+  // `service` 4+
+
+
+  const foundImportDeclarationUsingInject = findImportDeclarationWithExportedName(
     maybeImportDeclarations,
     'inject'
   );
 
+  const foundImportDeclarationUsingService = findImportDeclarationWithExportedName(
+    maybeImportDeclarations,
+    'service'
+  );
+
+  const importDeclaration = foundImportDeclarationUsingInject || foundImportDeclarationUsingService;
+
   if (!importDeclaration) {
-    DEBUG_CALLBACK('No import declaration found with usage of inject');
+    DEBUG_CALLBACK('No import declaration found with exported names: inject or service');
     return EMPTY_RESULT;
   }
 
   // In the case of re-assignment from inject as service, we walk the specifiers
-  const maybeSpecifier = findSpecifierByExportedName(importDeclaration.specifiers, 'inject');
+  const maybeInjectSpecifier = findSpecifierByExportedName(importDeclaration.specifiers, 'inject');
+  const maybeServiceSpecifier = findSpecifierByExportedName(importDeclaration.specifiers, 'service');
+
+  const maybeSpecifier = maybeInjectSpecifier || maybeServiceSpecifier;
 
   if (!maybeSpecifier) {
     return EMPTY_RESULT;

--- a/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
+++ b/packages/migration-graph-ember/test/utils/discover-ember-service-dependencies.test.ts
@@ -117,6 +117,50 @@ describe('discoverServiceDependencies', () => {
     expect(discovered.serviceName).toBe('locale');
   });
 
+  test('should find service usage with service export', () => {
+    const files = {
+      'component.js': `
+        import Component from '@glimmer/component';
+        import { service } from '@ember/service';
+
+        export default class Salutation extends Component {
+          @service locale;
+        }
+      `,
+    };
+
+    fixturify.writeSync(tmpDir, files);
+
+    const results = discoverServiceDependencies(tmpDir, 'component.js');
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    const discovered = results[0];
+    expect(discovered.serviceName).toBe('locale');
+  });
+
+  test('should find service usage with service export', () => {
+    const files = {
+      'component.js': `
+        import Component from '@glimmer/component';
+        import { service as something } from '@ember/service';
+
+        export default class Salutation extends Component {
+          @something locale;
+        }
+      `,
+    };
+
+    fixturify.writeSync(tmpDir, files);
+
+    const results = discoverServiceDependencies(tmpDir, 'component.js');
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    const discovered = results[0];
+    expect(discovered.serviceName).toBe('locale');
+  });
+
   test('should find multiple services', () => {
     const files = {
       'component.js': `


### PR DESCRIPTION
Add support for import specifiers `service` to migraiton-graph-ember. Fixes #998 

# Context
We currently support this API when parsing a file for services usage:
`ember@3.28`
```
import { inject as service } from '@ember/service';
```

For `ember@>=4` we need to support the following.
```
import { service } from '@ember/service';
```

This PR adds checks for the service import specifier and any re-assignment of that exported name.
