### PR TITLE
chore: move to fast-glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "fixturify": "^3.0.0",
     "fixturify-project": "^5.2.0",
-    "glob": "^9.3.4",
+    "fast-glob": "^3.2.12",
     "husky": "^8.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,15 +82,15 @@ importers:
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.38.0)(prettier@2.8.7)
+      fast-glob:
+        specifier: ^3.2.12
+        version: 3.2.12
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
       fixturify-project:
         specifier: ^5.2.0
         version: 5.2.0
-      glob:
-        specifier: ^9.3.4
-        version: 9.3.5
       husky:
         specifier: ^8.0.3
         version: 8.0.3

--- a/scripts/processDiagnosticsAndFixes.mjs
+++ b/scripts/processDiagnosticsAndFixes.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import glob from 'fast-glob';
 
 /** @typedef {{
     category: string;


### PR DESCRIPTION
This removes the last reference to glob in favor of fast-glob. The reason is to get around some licensing issues.
