### PR TITLE
chore: clean stdout for move tests

### DIFF
--- a/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
+++ b/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Command: move > move dir and sub-dir with --source flag 1`] = `
-"[32minfo[39m:    @rehearsal/move 2.0.1-beta
+"info:    @rehearsal/move<test-version>
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Executing git mv
@@ -16,24 +16,22 @@ exports[`Command: move > move dir and sub-dir with --source flag 1`] = `
 [DATA] /src/foo/biz.js -> /src/foo/biz.ts
 [DATA] /src/foo/e.gjs -> /src/foo/e.gts
 [DATA] /src/foo/buz/biz.js -> /src/foo/buz/biz.ts
-[DATA] 
 [SUCCESS] Executing git mv"
 `;
 
 exports[`Command: move > move file with --source flag 1`] = `
-"[32minfo[39m:    @rehearsal/move 2.0.1-beta
+"info:    @rehearsal/move<test-version>
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Executing git mv
 [DATA] git mv failed, using mv
 [DATA] renamed: 
 [DATA] /src/foo/baz.js -> /src/foo/baz.ts
-[DATA] 
 [SUCCESS] Executing git mv"
 `;
 
 exports[`Command: move > move package with --childPackage flag 1`] = `
-"[32minfo[39m:    @rehearsal/move 2.0.1-beta
+"info:    @rehearsal/move<test-version>
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Analyzing project dependency graph
@@ -46,6 +44,5 @@ exports[`Command: move > move package with --childPackage flag 1`] = `
 [DATA] /module-a/index.js -> /module-a/index.ts
 [DATA] /module-a/src/baz.js -> /module-a/src/baz.ts
 [DATA] /module-a/src/foo.js -> /module-a/src/foo.ts
-[DATA] 
 [SUCCESS] Executing git mv"
 `;

--- a/packages/cli/test/commands/move/move.test.ts
+++ b/packages/cli/test/commands/move/move.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { Project } from 'fixturify-project';
 import fastGlob from 'fast-glob';
-import { prepareProject, runBin } from '../../test-helpers/index.js';
+import { cleanOutput, prepareProject, runBin } from '../../test-helpers/index.js';
 
 function sanitizeAbsPath(basePath: string, files: string[]): string[] {
   return files.map((file) => file.replace(basePath, ''));
@@ -39,7 +39,7 @@ describe('Command: move', () => {
       cwd: project.baseDir,
     });
 
-    expect(result.stdout).toMatchSnapshot();
+    expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
     expect(jsSourceFiles).length(3);
     expect(tsSourceFiles).length(1);
     expect(sanitizeAbsPath(projectSourceDir, tsSourceFiles)).toMatchObject(['/baz.ts']);
@@ -65,7 +65,7 @@ describe('Command: move', () => {
       cwd: project.baseDir,
     });
 
-    expect(result.stdout).toMatchSnapshot();
+    expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
     expect(jsSourceFiles).length(0);
     expect(tsSourceFiles).length(5);
     expect(sanitizeAbsPath(project.baseDir, tsSourceFiles)).toMatchObject([
@@ -97,7 +97,7 @@ describe('Command: move', () => {
       cwd: project.baseDir,
     });
 
-    expect(result.stdout).toMatchSnapshot();
+    expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
     expect(jsSourceFiles).length(0);
     expect(tsSourceFiles).length(3);
     expect(sanitizeAbsPath(project.baseDir, tsSourceFiles)).toMatchObject([

--- a/packages/cli/test/test-helpers/index.ts
+++ b/packages/cli/test/test-helpers/index.ts
@@ -160,7 +160,7 @@ export function removeSpecialChars(input: string): string {
 // 3. remove tmp paths
 export function cleanOutput(output: string, basePath: string): string {
   const pathRegex = new RegExp(basePath, 'g');
-  const versionRegex = /(@rehearsal\/migrate)(.+)/g;
+  const versionRegex = /(@rehearsal\/(move|migrate|graph|fix))(.+)/g;
   return removeSpecialChars(
     output.replace(pathRegex, '<tmp-path>').replace(versionRegex, '$1<test-version>')
   );


### PR DESCRIPTION
In the 2.0.1-beta release the master went red due to the `move` tests emitting the current version into stdout and then captured by a snapshot. #1019 brought master back to green but did not resolve the problem. This PR resolves the problem by stabilizing stdout before generating the snapshot.
