### PR TITLE
fix: don't fix correctly declared services

### DIFF
--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -192,11 +192,13 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
       },
       (fileName: string) => !(isGlintService(service, useGlint) && isGlintFile(service, fileName))
     )
-    .queue(useGlint ? await getGlintReportPlugin() : DummyPlugin, {
-      commentTag,
-      filter: (fileName: string) =>
-        isGlintService(service, useGlint) && isGlintFile(service, fileName),
-    })
+    .queue(
+      useGlint ? await getGlintReportPlugin() : DummyPlugin,
+      {
+        commentTag,
+      },
+      (fileName: string) => isGlintService(service, useGlint) && isGlintFile(service, fileName)
+    )
     // Report linter issues
     .queue(LintPlugin, {
       eslintOptions: { cwd: basePath, useEslintrc: true, fix: false },

--- a/packages/migrate/test/fixtures/project/.prettierrc
+++ b/packages/migrate/test/fixtures/project/.prettierrc
@@ -10,7 +10,7 @@
       }
     },
     {
-      "files": "*.gjs",
+      "files": "*.gjs, *.gts",
       "options": {
         "parser": "glimmer"
       }

--- a/packages/migrate/test/fixtures/project/src/already-migrated-js-to.ts
+++ b/packages/migrate/test/fixtures/project/src/already-migrated-js-to.ts
@@ -1,0 +1,28 @@
+import type FooService from "foo/services/foo-service";
+
+// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'services/moo/moo' or its corresponding type declarations.
+import type MooService from "services/moo/moo";
+import type GooService from "services/goo";
+import type BooService from "boo/services/boo-service";
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class SomeComponent extends Component {
+  @service("foo@foo-service")
+  declare fooService: FooService;
+
+  @service("boo-service")
+  declare booService: BooService;
+
+  @service
+  declare gooService: GooService;
+
+  @service
+  declare mooService: MooService;
+
+  // Has to be fixes, but no additional import statement added
+  @service("boo-service") secondBooService;
+
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'nonQualified' implicitly has an 'any' type.
+  @service('non-qualified') nonQualified;
+}

--- a/packages/migrate/test/fixtures/project/src/already-migrated.gts
+++ b/packages/migrate/test/fixtures/project/src/already-migrated.gts
@@ -1,0 +1,32 @@
+import type FooService from "foo/services/foo-service";
+
+// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'services/moo/moo' or its corresponding type declarations.
+import type MooService from "services/moo/moo";
+import type GooService from "services/goo";
+import type BooService from "boo/services/boo-service";
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class SomeComponent extends Component {
+  @service("foo@foo-service")
+  declare fooService: FooService;
+
+  @service("boo-service")
+  declare booService: BooService;
+
+  @service
+  declare gooService: GooService;
+
+  @service
+  declare mooService: MooService;
+
+  // Has to be fixes, but no additional import statement added
+  @service("boo-service") secondBooService;
+
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'nonQualified' implicitly has an 'any' type.
+  @service('non-qualified') nonQualified;
+
+  <template>
+    <span>Hello, I am human, and I am 10 years old!</span>
+  </template>
+}

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -23,9 +23,9 @@ export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
     DEBUG_CALLBACK(`Plugin 'GlintReport' run on %O:`, fileName);
 
     const lineHasSupression: { [line: number]: boolean } = {};
-    const originalConentWithErrorsSupressed = context.service.getFileText(fileName);
+    const originalContentWithErrorsSuppressed = context.service.getFileText(fileName);
 
-    let contentWithErrors = originalConentWithErrorsSupressed;
+    let contentWithErrors = originalContentWithErrorsSuppressed;
 
     // TODO: Investigate if there is a better way of finding the ranges using the actual
     // ast instead of regexing
@@ -69,7 +69,7 @@ export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
     }
 
     // Set the document back to the content with the errors supressed
-    service.setFileText(fileName, originalConentWithErrorsSupressed);
+    service.setFileText(fileName, originalContentWithErrorsSuppressed);
 
     return Promise.resolve([]);
   }


### PR DESCRIPTION
The service injection transform plugin no detects if the property doesn't have a `declare` and steps in only in this case.
I also didn't duplicate comments if they are there before the property.

There is still issue with gts formatting, but those are related to glint files transformation :(