### PR TITLE
fix: aliases need to look at modulename

### DIFF
--- a/packages/cli/test/commands/graph/__snapshots__/graph.test.ts.snap
+++ b/packages/cli/test/commands/graph/__snapshots__/graph.test.ts.snap
@@ -24,6 +24,7 @@ exports[`Task: graphOrderTask > can print graph order to stdout in an ember app 
 [DATA]   .
 [DATA]  We found the following packages. Select a packages to see the order of files:  lib/some-addon
 [DATA] Graph order for lib/some-addon:
+[DATA] lib/some-addon/addon/utils/thing.js
 [DATA] lib/some-addon/addon/components/greet.js
 [SUCCESS] Analyzing project dependency graph"
 `;

--- a/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
+++ b/packages/migration-graph-ember/src/entities/ember-addon-package-graph.ts
@@ -9,15 +9,18 @@ export type EmberAddonPackageGraphOptions = EmberAppPackageGraphOptions;
 
 export class EmberAddonPackageGraph extends EmberAppPackageGraph {
   override debug: Debugger = debug(`rehearsal:migration-graph-ember:${this.constructor.name}`);
+  override package: EmberAddonPackage;
 
   constructor(p: EmberAddonPackage, options: EmberAddonPackageGraphOptions = {}) {
     super(p, options);
+    this.package = p;
   }
 
   override get resolveOptions(): IResolveOptions {
-    const alias: Record<string, string> = {};
-
-    alias[this.package.packageName] = resolve(this.baseDir, 'addon');
+    const alias: Record<string, string> = {
+      [this.package.packageName]: resolve(this.baseDir, 'addon'),
+      [this.package.moduleName]: resolve(this.baseDir, 'addon'),
+    };
 
     this.debug({
       baseDir: this.baseDir,

--- a/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
+++ b/packages/migration-graph-ember/test/entities/ember-app-project-graph.test.ts
@@ -429,6 +429,7 @@ export default class Salutation extends Component {
       .flat();
 
     expect(allFiles).toStrictEqual([
+      'addon/utils/thing.js',
       'addon/components/greet.js',
       'addon/services/date.js',
       'app/app.js',
@@ -490,7 +491,7 @@ export default class Salutation extends Component {
       expect(
         flatten(filter(orderedPackages[0].content.pkg?.getModuleGraph().getSortedNodes() || [])),
         'expected migration order for addon'
-      ).toStrictEqual(['addon/components/greet.js']);
+      ).toStrictEqual(['addon/utils/thing.js', 'addon/components/greet.js']);
 
       expect(
         flatten(filter(orderedPackages[1].content.pkg?.getModuleGraph().getSortedNodes() || [])),

--- a/packages/migration-graph/test/migration-strategy.test.ts
+++ b/packages/migration-graph/test/migration-strategy.test.ts
@@ -224,6 +224,7 @@ describe('migration-strategy', () => {
       const files: Array<SourceFile> = strategy.getMigrationOrder();
       const actual: Array<string> = files.map((f) => f.relativePath);
       expect(actual).toStrictEqual([
+        'lib/some-addon/addon/utils/thing.js',
         'lib/some-addon/addon/components/greet.js',
         ...EXPECTED_APP_FILES,
         'tests/acceptance/index-test.js',

--- a/packages/test-support/src/files.ts
+++ b/packages/test-support/src/files.ts
@@ -166,8 +166,11 @@ export function getEmberAppFiles(): fixturify.DirJSON {
   return FILES_EMBER_APP;
 }
 
-export function getEmberAppWithInRepoAddonFiles(addonName = 'some-addon'): fixturify.DirJSON {
-  const addon = getEmberAddonWithInRepoAddonFiles(addonName);
+export function getEmberAppWithInRepoAddonFiles(
+  addonName = 'some-addon',
+  varyNames = false
+): fixturify.DirJSON {
+  const addon = getEmberAddonWithInRepoAddonFiles(addonName, varyNames);
 
   const lib: Record<string, fixturify.DirJSON> = {};
 
@@ -242,12 +245,19 @@ export function getEmptyInRepoAddonFiles(addonName = 'some-addon'): fixturify.Di
   };
 }
 
-export function getEmberAddonWithInRepoAddonFiles(addonName = 'some-addon'): fixturify.DirJSON {
+export function getEmberAddonWithInRepoAddonFiles(
+  addonName = 'some-addon',
+  varyNames = false
+): fixturify.DirJSON {
   return {
     addon: {
+      utils: {
+        'thing.js': 'export const thing = "thing";',
+      },
       components: {
         'greet.js': `
           import Component from '@glimmer/component';
+          import { thing } from '${addonName}/utils/thing';
 
           export default class Greet extends Component {
             get name() {
@@ -267,7 +277,7 @@ export function getEmberAddonWithInRepoAddonFiles(addonName = 'some-addon'): fix
       'use strict';
 
       module.exports = {
-        name: require('./package').name,
+        name: ${varyNames ? `"${addonName}"` : `require('./package').name`},
 
         isDevelopingAddon() {
           return true;
@@ -276,7 +286,7 @@ export function getEmberAddonWithInRepoAddonFiles(addonName = 'some-addon'): fix
       `,
     'package.json': `
       {
-        "name": "${addonName}",
+        "name": "${varyNames ? `@company/${addonName}` : `${addonName}`}",
         "keywords": [
           "ember-addon"
         ],

--- a/packages/test-support/src/project.ts
+++ b/packages/test-support/src/project.ts
@@ -98,7 +98,8 @@ function addUtilDirectory(project: Project): Project {
  */
 export function getEmberAppWithInRepoAddonProject(
   project: Project = emberAppTemplate(),
-  addonName = 'some-addon'
+  addonName = 'some-addon',
+  varyNames = false
 ): Project {
   getEmberAppProject(project);
 
@@ -107,7 +108,7 @@ export function getEmberAppWithInRepoAddonProject(
     paths: [`lib/${addonName}`],
   };
 
-  project.mergeFiles(getEmberAppWithInRepoAddonFiles(addonName));
+  project.mergeFiles(getEmberAppWithInRepoAddonFiles(addonName, varyNames));
 
   return project;
 }
@@ -216,7 +217,7 @@ type EmberProjectFixture =
   | 'addon'
   | 'monorepo';
 
-export function getEmberProject(variant: EmberProjectFixture): Project {
+export function getEmberProject(variant: EmberProjectFixture, varyNames = false): Project {
   let project;
 
   switch (variant) {
@@ -227,7 +228,7 @@ export function getEmberProject(variant: EmberProjectFixture): Project {
       project = addUtilDirectory(getEmberAppProject());
       break;
     case 'app-with-in-repo-addon':
-      project = getEmberAppWithInRepoAddonProject();
+      project = getEmberAppWithInRepoAddonProject(undefined, undefined, varyNames);
       break;
     case 'app-with-in-repo-engine':
       project = getEmberAppWithInRepoEngineProject();


### PR DESCRIPTION
This fixes an issue where [the only alias](https://github.com/rehearsal-js/rehearsal-js/pull/1023/files#diff-492c95ee8a02d9b520537e29d9c4e842e6fc84869da42e916061c3f754408e65R20-R23) we were create for addons was for the packageName but in reality these can be the packageName or the moduleName. This has been validated in our internal apps as well.
