### PR TITLE
chore: bumps @glint/core from 1.0.0-beta.4 to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.5.1",
     "@commitlint/config-conventional": "^17.4.4",
-    "@glint/core": "1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/utils": "workspace:*",
     "@types/debug": "^4.1.7",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -60,7 +60,7 @@
     "winston": "^3.8.2"
   },
   "peerDependencies": {
-    "@glint/core": "1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "typescript": "^5.0"
   },
   "packageManager": "pnpm@8.2.0",

--- a/packages/migrate/test/fixtures/project/package-lock.json
+++ b/packages/migrate/test/fixtures/project/package-lock.json
@@ -12,7 +12,7 @@
         "@ember/test-helpers": "^2.9.3",
         "@glimmer/component": "^1.1.2",
         "@glimmerx/component": "^0.6.8",
-        "@glint/core": "^1.0.0-beta.4",
+        "@glint/core": "^1.0.2",
         "@glint/environment-ember-loose": "1.0.0-beta.4",
         "@glint/environment-ember-template-imports": "1.0.0-beta.4",
         "@glint/environment-glimmerx": "^1.0.0-beta.4",

--- a/packages/migrate/test/fixtures/project/package.json
+++ b/packages/migrate/test/fixtures/project/package.json
@@ -13,7 +13,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glimmerx/component": "^0.6.8",
-    "@glint/core": "^1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "@glint/environment-ember-loose": "1.0.0-beta.4",
     "@glint/environment-ember-template-imports": "1.0.0-beta.4",
     "@glint/environment-glimmerx": "^1.0.0-beta.4",

--- a/packages/migrate/test/fixtures/project/packages/foo/package.json
+++ b/packages/migrate/test/fixtures/project/packages/foo/package.json
@@ -13,7 +13,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glimmerx/component": "^0.6.8",
-    "@glint/core": "^1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "@glint/environment-ember-loose": "1.0.0-beta.4",
     "@glint/environment-ember-template-imports": "1.0.0-beta.4",
     "@glint/environment-glimmerx": "^1.0.0-beta.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -57,7 +57,7 @@
     "vitest": "^0.30.0"
   },
   "peerDependencies": {
-    "@glint/core": "1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "typescript": "^5.0"
   },
   "packageManager": "pnpm@8.2.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -51,7 +51,7 @@
     "vitest": "^0.30.0"
   },
   "peerDependencies": {
-    "@glint/core": "1.0.0-beta.4",
+    "@glint/core": "^1.0.2",
     "typescript": "^5.0"
   },
   "packageManager": "pnpm@8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^17.4.4
         version: 17.4.4
       '@glint/core':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@5.0.4)
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.0.4)
       '@rehearsal/reporter':
         specifier: workspace:*
         version: link:packages/reporter
@@ -277,8 +277,8 @@ importers:
   packages/migrate:
     dependencies:
       '@glint/core':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@5.0.4)
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.0.4)
       '@rehearsal/migration-graph-ember':
         specifier: workspace:*
         version: link:../migration-graph-ember
@@ -470,8 +470,8 @@ importers:
   packages/plugins:
     dependencies:
       '@glint/core':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@5.0.4)
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.0.4)
       '@rehearsal/codefixes':
         specifier: workspace:*
         version: link:../codefixes
@@ -581,8 +581,8 @@ importers:
   packages/service:
     dependencies:
       '@glint/core':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@5.0.4)
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.0.4)
       '@rehearsal/reporter':
         specifier: workspace:*
         version: link:../reporter
@@ -2789,8 +2789,8 @@ packages:
       - '@babel/core'
     dev: true
 
-  /@glint/core@1.0.0-beta.4(typescript@5.0.4):
-    resolution: {integrity: sha512-46yKM9fQLX7mSheb2nfAGRwnjoxLSd7sYOkBE57A9LC5KQeAGEMk9Q3bGOYZBVl2qMvF6sdGmYc807FGB3J+Hg==}
+  /@glint/core@1.0.2(typescript@5.0.4):
+    resolution: {integrity: sha512-0bVt/lT/NurpD8nBG9RTPKYlcpg51UDGCKgLoBEFOiTXv3aCSxAVKPud1IYaitGBKE0C+s5pl2PHkgptotVS+w==}
     hasBin: true
     peerDependencies:
       typescript: '>=4.8.0'


### PR DESCRIPTION
This chore PR bumps @glint/core dep to latest release and out of beta