### PR TITLE
fix: removed remnant package from ctx and adds skipPrompt for graph

### DIFF
--- a/packages/cli/src/commands/fix/command.ts
+++ b/packages/cli/src/commands/fix/command.ts
@@ -104,6 +104,7 @@ async function fix(src: string, options: FixCommandOptions): Promise<void> {
           devDeps: options.devDeps,
           deps: options.deps,
           ignore: options.ignore,
+          skipPrompt: true,
         }),
         convertTask(options),
       ]

--- a/packages/cli/src/commands/fix/tasks/initialize-task.ts
+++ b/packages/cli/src/commands/fix/tasks/initialize-task.ts
@@ -53,8 +53,6 @@ export function initTask(
       // expectation is rehearsal move has already been run on the package
       // expect a tsconfig.json file in rootPath
       if (graph) {
-        ctx.package = src;
-
         [ctx.packageAbs, ctx.packageRel] = validatePackagePath(rootPath, src);
         // expect a tsconfig.json file in the root of the child package
         preFlightCheck(rootPath, ctx.projectType);

--- a/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
+++ b/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
@@ -11,7 +11,7 @@ const __dirname = dirname(__filename);
 
 const workerPath = resolve(__dirname, 'graphWorker.js');
 
-const DEBUG_CALLBACK = debug('rehearsal:cli:graphOrderTask');
+const DEBUG_CALLBACK = debug('rehearsal:cli:graph');
 
 export function graphOrderTask(
   srcDir: string,
@@ -75,16 +75,15 @@ export function graphOrderTask(
       // set the order on the context so we can use it in other tasks
       ctx.migrationOrder = order;
 
-      DEBUG_CALLBACK(`order: ${JSON.stringify(order, null, 2)}`);
-      DEBUG_CALLBACK(`ctx: ${JSON.stringify(ctx, null, 2)}`);
-
-      // if explicit package is passed in use that
-      if (ctx?.package) {
+      // skip the output and prompt. for when we just want the order
+      if (options.skipPrompt) {
         ctx.sourceFilesRel = order.packages.flatMap((pkg) => pkg.files);
-        ctx.sourceFilesAbs = ctx.sourceFilesRel.map((file) => resolve(srcDir, file));
-
-        return;
+        ctx.sourceFilesAbs = ctx.sourceFilesRel.map((file) => resolve(rootPath, file));
       }
+
+      DEBUG_CALLBACK('ctx.sourceFilesRel %O:', ctx.sourceFilesRel);
+      DEBUG_CALLBACK('ctx.sourceFilesAbs %O:', ctx.sourceFilesAbs);
+      DEBUG_CALLBACK('order: %O', order);
 
       // dont prompt just write the file
       if (output) {

--- a/packages/cli/src/commands/move/command.ts
+++ b/packages/cli/src/commands/move/command.ts
@@ -5,6 +5,7 @@ import { Listr } from 'listr2';
 import debug from 'debug';
 import { parseCommaSeparatedList, readJSON } from '@rehearsal/utils';
 import { createLogger, format, transports } from 'winston';
+import { getEmberExcludePatterns } from '@rehearsal/migration-graph-ember';
 import type { MoveTasks, GraphTasks, MoveCommandOptions } from '../../types.js';
 import type { PackageJson } from 'type-fest';
 
@@ -88,8 +89,8 @@ async function move(src: string, options: MoveCommandOptions): Promise<void> {
   const typescriptGlobs = ['**/*.ts', '**/*.tsx', '**/*.gts'].map((glob) => {
     return join(`${options.rootPath}`, src, glob);
   });
-  // We never want to move typescript files
-  options.ignore.push(...typescriptGlobs);
+  // We never want to move typescript files or the ember-cli-build.js files
+  options.ignore.push(...typescriptGlobs, ...getEmberExcludePatterns());
 
   // grab the child move tasks
   const { initTask, moveTask } = await loadMoveTasks();
@@ -103,6 +104,7 @@ async function move(src: string, options: MoveCommandOptions): Promise<void> {
           devDeps: options.devDeps,
           deps: options.deps,
           ignore: options.ignore,
+          skipPrompt: true,
         }),
         moveTask(options.rootPath, options),
       ]

--- a/packages/cli/src/commands/move/tasks/initialize.ts
+++ b/packages/cli/src/commands/move/tasks/initialize.ts
@@ -16,7 +16,6 @@ export function initTask(
       const { rootPath, graph } = options;
 
       if (graph) {
-        ctx.package = src;
         [ctx.packageAbs, ctx.packageRel] = validatePackagePath(rootPath, src);
       } else {
         [ctx.sourceFilesAbs, ctx.sourceFilesRel] = validateSourcePath(rootPath, src, 'js');

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -56,7 +56,6 @@ export type CommandContext = {
   migrationOrder?: { packages: PackageEntry[] };
   source?: string;
   packageEntry?: string;
-  package?: string;
 };
 
 /*
@@ -111,6 +110,7 @@ export type GraphTaskOptions = {
   deps: boolean;
   ignore: string[];
   output?: string;
+  skipPrompt?: boolean;
 };
 
 export type GraphTasks = {

--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -284,6 +284,37 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Analyzing project dependency graph
+[DATA] Graph order for .:
+[DATA] app/app.js
+[DATA] app/components/bar/index.ts
+[DATA] app/components/ember-component.ts
+[DATA] app/components/foo.ts
+[DATA] app/components/js-component.js
+[DATA] app/components/qux.ts
+[DATA] app/components/template-only-module.ts
+[DATA] app/components/test-cases/subclassing/child.ts
+[DATA] app/components/test-cases/subclassing/parent.ts
+[DATA] app/components/wrapper-component.ts
+[DATA] app/controllers/classic-route.ts
+[DATA] app/helpers/affix.ts
+[DATA] app/helpers/repeat.ts
+[DATA] app/pods/components/baz/component.ts
+[DATA] app/router.js
+[DATA] app/routes/classic-route.ts
+[DATA] tests/helpers/index.ts
+[DATA] tests/integration/components/bar-test.ts
+[DATA] tests/integration/components/baz-test.ts
+[DATA] tests/integration/components/ember-component-test.ts
+[DATA] tests/integration/components/qux-test.ts
+[DATA] tests/integration/components/render-test.ts
+[DATA] tests/integration/components/template-only-module-test.ts
+[DATA] tests/integration/helpers/repeat-test.ts
+[DATA] tests/integration/types/empty-signature-test.ts
+[DATA] tests/test-helper.js
+[DATA] types/ember-data/types/registries/model.d.ts
+[DATA] types/global.d.ts
+[DATA] types/template-registry.d.ts
+[DATA] types/ts-ember-app/index.d.ts
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js
@@ -337,6 +368,23 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Analyzing project dependency graph
+[DATA] Graph order for .:
+[DATA] app/app.js
+[DATA] app/components/bar/index.ts
+[DATA] app/components/ember-component.ts
+[DATA] app/components/foo.ts
+[DATA] app/components/js-component.js
+[DATA] app/components/qux.ts
+[DATA] app/components/template-only-module.ts
+[DATA] app/components/test-cases/subclassing/child.ts
+[DATA] app/components/test-cases/subclassing/parent.ts
+[DATA] app/components/wrapper-component.ts
+[DATA] app/controllers/classic-route.ts
+[DATA] app/helpers/affix.ts
+[DATA] app/helpers/repeat.ts
+[DATA] app/pods/components/baz/component.ts
+[DATA] app/router.js
+[DATA] app/routes/classic-route.ts
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js

--- a/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
+++ b/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
@@ -35,6 +35,19 @@ exports[`Command: move > move packages with --graph and --deps flag 1`] = `
 [STARTED] Validating source path
 [SUCCESS] Validating source path
 [STARTED] Analyzing project dependency graph
+[DATA] Graph order for .:
+[DATA] index.js
+[DATA] module-a/index.js
+[DATA] module-a/src/baz.js
+[DATA] module-a/src/foo.js
+[DATA] module-b/index.js
+[DATA] module-b/src/tires.js
+[DATA] module-b/src/car.js
+[DATA] src/bizz.ts
+[DATA] src/foo/baz.js
+[DATA] src/foo/biz.js
+[DATA] src/foo/buz/biz.js
+[DATA] src/index.js
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Executing git mv
 [DATA] git mv failed, using mv

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -53,7 +53,6 @@ const { parseJsonConfigFileContent } = ts;
 export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
   const basePath = resolve(input.rootPath);
   // these will always be typescript files
-  const sourceFilesAbs = input.sourceFilesAbs;
   const reporter = input.reporter;
   const ignore = input.ignore || [];
   const configName = 'tsconfig.json';
@@ -64,7 +63,6 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
 
   DEBUG_CALLBACK('migration started');
   DEBUG_CALLBACK(`Base path: ${basePath}`);
-  DEBUG_CALLBACK(`sourceFiles: ${JSON.stringify(sourceFilesAbs)}`);
 
   // read the tsconfig.json
   const configFile = readTSConfig<TSConfig>(resolve(basePath, configName));
@@ -85,18 +83,21 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
     {},
     configName
   );
+  DEBUG_CALLBACK(`someFiles: %O`, someFiles);
+  DEBUG_CALLBACK(`sourceFilesAbs: %O`, input.sourceFilesAbs);
 
   // these should NOT all go into the report
   const fileNames = [...new Set([...someFiles, ...input.sourceFilesAbs])];
   const ignoredPaths = resolveIgnoredPaths(ignore, basePath, getExcludePatterns);
 
-  DEBUG_CALLBACK(`ignoredPaths: ${JSON.stringify(ignoredPaths)}`);
+  DEBUG_CALLBACK(`fileNames: %O`, fileNames);
+  DEBUG_CALLBACK(`ignoredPaths: %O`, ignoredPaths);
 
   // remove ignored paths from the list of files to migrate
   const filesToMigrate = fileNames.filter((filePath) => !ignoredPaths.includes(filePath));
   const servicesMap = await readServiceMap(basePath, '.rehearsal/services-map.json');
 
-  DEBUG_CALLBACK(`fileNames: ${JSON.stringify(filesToMigrate)}`);
+  DEBUG_CALLBACK(`filesToMigrate: %O`, filesToMigrate);
 
   const service = useGlint
     ? await createGlintService(basePath)

--- a/packages/migration-graph-ember/src/index.ts
+++ b/packages/migration-graph-ember/src/index.ts
@@ -9,6 +9,8 @@ export {
   requirePackageMain,
 } from './utils/ember.js';
 
+export { getEmberExcludePatterns } from './utils/excludes.js';
+
 export { discoverEmberPackages } from './utils/discover-ember-packages.js';
 
 export {

--- a/packages/plugins/src/plugins/re-rehearse.plugin.ts
+++ b/packages/plugins/src/plugins/re-rehearse.plugin.ts
@@ -16,6 +16,8 @@ export class ReRehearsePlugin extends Plugin<ReRehearsePluginOptions> {
   async run(): Promise<string[]> {
     const { fileName, context, options } = this;
 
+    DEBUG_CALLBACK(`this: %O`, this);
+
     let text = context.service.getFileText(fileName);
     const sourceFile = context.service.getSourceFile(fileName);
     const tagStarts = [...text.matchAll(new RegExp(options.commentTag, 'g'))].map((m) => m.index!);


### PR DESCRIPTION
This PR:
- adds an option to the cli graph task to skip the prompt. this is needed when consuming this task in other commands (move & fix)
- cleans up remnant code from a previous refactor for ctx.package