### PR TITLE
chore(cli): remove unused dryRun

### DIFF
--- a/packages/cli/src/commands/fix/command.ts
+++ b/packages/cli/src/commands/fix/command.ts
@@ -56,7 +56,6 @@ fixCommand
     parseCommaSeparatedList,
     ['sarif']
   )
-  .option('-d, --dryRun', `do nothing; only show what would happen`, false)
   .addOption(
     new Option('--rootPath <project base path>', '-- HIDDEN LOCAL DEV TESTING ONLY --')
       .default(process.cwd())

--- a/packages/cli/src/commands/fix/tasks/convert-task.ts
+++ b/packages/cli/src/commands/fix/tasks/convert-task.ts
@@ -11,7 +11,6 @@ const DEBUG_CALLBACK = debug('rehearsal:cli:fix:convert-task');
 export function convertTask(options: FixCommandOptions, _ctx?: CommandContext): ListrTask {
   return {
     title: 'Infer Types',
-    enabled: (): boolean => !options.dryRun,
     task: async (ctx: CommandContext, task): Promise<void> => {
       // Because we have to eagerly import all the tasks we need to lazily load these
       // modules because they refer to typescript which may or may not be installed

--- a/packages/cli/src/commands/fix/tasks/initialize-task.ts
+++ b/packages/cli/src/commands/fix/tasks/initialize-task.ts
@@ -68,9 +68,8 @@ export function initTask(
       DEBUG_CALLBACK('ctx %O:', ctx);
     },
     options: {
-      // options for dryRun, since we need to keep the output to see the list of files
-      bottomBar: options.dryRun ? true : false,
-      persistentOutput: options.dryRun ? true : false,
+      bottomBar: false,
+      persistentOutput: false,
     },
   };
 }

--- a/packages/cli/src/commands/move/command.ts
+++ b/packages/cli/src/commands/move/command.ts
@@ -118,9 +118,7 @@ async function move(src: string, options: MoveCommandOptions): Promise<void> {
       concurrent: false,
     }).run();
   } catch (e) {
-    if (e instanceof Error) {
-      winstonLogger.error(`${e.message + '\n' + (e.stack || '')}`);
-    }
+    // e we dont need to log this because Listr will have already logged it
   }
 }
 

--- a/packages/cli/src/commands/move/tasks/mv.ts
+++ b/packages/cli/src/commands/move/tasks/mv.ts
@@ -24,6 +24,10 @@ export function moveTask(
 
       DEBUG_CALLBACK(`sourceFilesAbs: ${sourceFilesAbs}`);
 
+      if (dryRun) {
+        task.title = 'Executing git mv (dry run)';
+      }
+
       if (sourceFilesAbs) {
         task.output = gitMove(sourceFilesAbs, task, src, dryRun);
       } else {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -86,7 +86,6 @@ export type FixTasks = {
 export type FixCommandOptions = {
   format: Formatters[];
   graph: boolean;
-  dryRun: boolean;
   rootPath: string;
   devDeps: boolean;
   deps: boolean;

--- a/packages/cli/test/commands/fix/init-task.test.ts
+++ b/packages/cli/test/commands/fix/init-task.test.ts
@@ -277,7 +277,6 @@ describe('Fix: Init-Task', () => {
     const src = resolve(project.baseDir, 'src');
     const options: FixCommandOptions = {
       rootPath: project.baseDir,
-      dryRun: true,
       format: ['sarif'],
       graph: false,
       devDeps: false,


### PR DESCRIPTION
This PR:

- removes `dryRun` from CLI command `fix` as its not supported