### PR TITLE
chore: better debugging in graph

### DIFF
--- a/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
+++ b/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
@@ -27,7 +27,7 @@ export function graphOrderTask(
       const { output, rootPath } = options;
       let selectedPackageName: string;
 
-      if (process.env['TEST'] === 'true') {
+      if (process.env['TEST'] === 'true' || process.env['WORKER'] === 'false') {
         // Do this on the main thread because there are issues with resolving worker scripts for worker_threads in vitest
         const { intoGraphOutput } = await import('./graphWorker.js').then((m) => m);
         const { getMigrationOrder } = await import('@rehearsal/migration-graph').then((m) => m);

--- a/packages/migration-graph-shared/src/entities/package-graph.ts
+++ b/packages/migration-graph-shared/src/entities/package-graph.ts
@@ -88,6 +88,7 @@ export class PackageGraph {
 
     const resolveOptions = this.resolveOptions;
     this.debug('Executing dependency-cruiser');
+    this.debug('Basedir: %O', this.baseDir);
     this.debug('Target: %O', target);
     // this.debug('cruiseOptions: %O', cruiseOptions);
     // this.debug('resolveOptions: %O', { ...resolveOptions, fileSystem: undefined });


### PR DESCRIPTION
This adds the ability to turn off the worker thread by passing envar `WORKER=false`. This can be used in conjunction with `DEBUG=` and `node --inspect-brk`. This is working around some issues related to debuggability of worker_threads.
