### PR TITLE
fix: fix the path to load tsconfig.json

### DIFF
--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -72,7 +72,7 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
     throw Error(`Config file '${configName}' not found in '${packageDir}'`);
   }
 
-  const tsConfig = readTSConfig<TSConfig>(resolve(packageDir, configName));
+  const tsConfig = readTSConfig<TSConfig>(configFile);
 
   if (!tsConfig) {
     throw Error(`Could not read '${configFile}'`);

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -199,6 +199,22 @@ module(\\"Integration | Helper | grid-list\\", function (hooks) {
 "
 `;
 
+exports[`fix > .ts > subpackage without tsconfig.json 1`] = `
+"import type FooService from \\"foo/services/foo-service\\";
+import type AuthenticatedUser from \\"authentication/services/authenticated-user\\";
+import Component from \\"@glimmer/component\\";
+import { inject as service } from \\"@ember/service\\";
+
+export default class SomeComponent extends Component {
+  @service(\\"authentication@authenticated-user\\")
+  declare authenticatedUser: AuthenticatedUser;
+
+  @service(\\"foo@foo-service\\")
+  declare otherProp: FooService;
+}
+"
+`;
+
 exports[`fix > .ts > with non-qualified service 1`] = `
 "import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
@@ -327,6 +343,8 @@ exports[`fix > .ts, .gts > resolveIgnoredPaths() 1`] = `
   "<tmp-path>/packages/foo/package.json",
   "<tmp-path>/packages/foo/tsconfig.json",
   "<tmp-path>/packages/foo/with-qualified-service.ts",
+  "<tmp-path>/packages/moo/package.json",
+  "<tmp-path>/packages/moo/with-qualified-service.ts",
   "<tmp-path>/src/with-class.gts",
 ]
 `;

--- a/packages/migrate/test/fixtures/project/packages/moo/package.json
+++ b/packages/migrate/test/fixtures/project/packages/moo/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Chris Freeman",
+  "license": "ISC",
+  "dependencies": {
+    "@ember/test-helpers": "^2.9.3",
+    "@glimmer/component": "^1.1.2",
+    "@glimmerx/component": "^0.6.8",
+    "@glint/core": "^1.0.2",
+    "@glint/environment-ember-loose": "1.0.0-beta.4",
+    "@glint/environment-ember-template-imports": "1.0.0-beta.4",
+    "@glint/environment-glimmerx": "^1.0.0-beta.4",
+    "@glint/template": "1.0.0-beta.4",
+    "@types/ember__service": "^4.0.2",
+    "@types/node": "^18.13.0",
+    "@types/qunit": "^2.19.4",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
+    "ember-cli-htmlbars": "^6.2.0",
+    "ember-qunit": "^6.2.0",
+    "ember-template-imports": "^3.4.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.3",
+    "ember-template-lint": "^5.7.2",
+    "ember-template-lint-plugin-prettier": "^4.1.0",
+    "eslint": "^8.40.0",
+    "eslint-plugin-ember": "^11.4.9",
+    "prettier": "^2.8.3",
+    "qunit": "^2.19.4",
+    "qunit-dom": "^2.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/migrate/test/fixtures/project/packages/moo/with-qualified-service.ts
+++ b/packages/migrate/test/fixtures/project/packages/moo/with-qualified-service.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class SomeComponent extends Component {
+  @service('authentication@authenticated-user') authenticatedUser;
+
+  @service('foo@foo-service') otherProp;
+}

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -526,6 +526,29 @@ describe('fix', () => {
 
       expectFile(outputs[0]).toMatchSnapshot();
     });
+
+    test('subpackage without tsconfig.json', async () => {
+      await project.write();
+
+      const [inputs, outputs] = prepareInputFiles(
+        project,
+        ['with-qualified-service.ts'],
+        'packages/moo'
+      );
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: resolve(project.baseDir, 'packages/moo'),
+        filesToMigrate: inputs,
+        reporter,
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).toMatchSnapshot();
+    });
   });
 
   describe('.ts, .gts', () => {
@@ -559,7 +582,7 @@ describe('fix', () => {
         return cleanOutput(path, project.baseDir);
       });
 
-      expect(ignoredPaths.length).toBe(7);
+      expect(ignoredPaths.length).toBe(9);
       expect(sanitizedPaths).toMatchSnapshot();
     });
 

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/utils": "workspace:*",
-    "find-up": "^6.3.0",
     "vscode-languageserver": "^8.1.0",
     "vscode-uri": "^3.0.7",
     "winston": "^3.8.2"

--- a/packages/service/src/rehearsal-service-host.ts
+++ b/packages/service/src/rehearsal-service-host.ts
@@ -4,8 +4,7 @@ import ts, {
   InstallPackageOptions,
   LanguageServiceHost,
 } from 'typescript';
-import { addDep } from '@rehearsal/utils';
-import { findUpSync } from 'find-up';
+import { addDep, findNearestPackageJson } from '@rehearsal/utils';
 import type { CompilerOptions, IScriptSnapshot, MapLike } from 'typescript';
 
 const { ScriptSnapshot, getDefaultLibFilePath, sys } = ts;
@@ -55,9 +54,7 @@ export class RehearsalServiceHost implements LanguageServiceHost {
     // Save the install request information, so we don't continuously download
     this.seenTypingsRequest.set(options.fileName, options.packageName);
 
-    const nearestPackageJSON = findUpSync('package.json', {
-      cwd: dirname(options.fileName),
-    });
+    const nearestPackageJSON = findNearestPackageJson(dirname(options.fileName));
 
     if (nearestPackageJSON) {
       // Note: the TSServer is going to swallow the success and failures

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,9 +598,6 @@ importers:
       '@rehearsal/utils':
         specifier: workspace:*
         version: link:../utils
-      find-up:
-        specifier: ^6.3.0
-        version: 6.3.0
       typescript:
         specifier: ^5.0
         version: 5.0.4


### PR DESCRIPTION
Fix the case when the target package doesn't have a tsconfig.json file and the parent one is used.