### PR TITLE
fix: preflight support for latest dep

### DIFF
--- a/packages/cli/test/commands/fix/init-task.test.ts
+++ b/packages/cli/test/commands/fix/init-task.test.ts
@@ -86,6 +86,8 @@ describe('Fix: Init-Task', () => {
     const projectType: ProjectType = 'base-ts';
 
     projectInit(project, projectType);
+    // support "latest" as a version
+    project.addDevDependency('typescript', 'latest')
 
     await project.write();
 

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -714,6 +714,10 @@ export function isDepsPreReq(basePath: string, requiredDeps: Record<string, stri
     if (Object.keys(requiredDeps).includes(dep)) {
       const installedVersion = packageJSONDeps[dep].replace(/[\^~]/g, '');
       const reqVersion = requiredDeps[dep].replace(/[\^~]/g, '');
+      // support for "latest" version in installedVersion
+      if (installedVersion === 'latest') {
+        continue;
+      }
       // if the installed dep is < the required dep, throw an error
       if (compare(installedVersion, reqVersion, '<')) {
         invalidVersion.push(dep);

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -371,8 +371,8 @@ describe('utils', () => {
 
     project = new Project('my-project', '0.0.0');
 
-    project.addDependency('typescript', '^5.0.1');
-    project.addDevDependency('eslint', '^8.40.0');
+    project.addDependency('typescript', 'latest');
+    project.addDevDependency('eslint', 'latest');
     project.addDevDependency('eslint-plugin-glint', '^1.0.0');
     project.addDevDependency('@glint/core', '^1.0.0');
     project.addDevDependency('@typescript-eslint/parser', '^5.59.2');


### PR DESCRIPTION
This PR:

- allows for "latest" in package.json as a viable version in pre-req check