### PR TITLE
fix(util): move find-up to dependency

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "execa": "^7.1.1",
+    "find-up": "^6.3.0",
     "fs-extra": "^11.1.1",
     "json5": "^2.2.3",
     "simple-git": "^3.17.0",
@@ -49,7 +50,6 @@
   "devDependencies": {
     "@types/which": "^3.0.0",
     "@vitest/coverage-c8": "^0.30.1",
-    "find-up": "^6.3.0",
     "fixturify": "^3.0.0",
     "fixturify-project": "^5.2.0",
     "vitest": "^0.30.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,6 +910,9 @@ importers:
       execa:
         specifier: ^7.1.1
         version: 7.1.1
+      find-up:
+        specifier: ^6.3.0
+        version: 6.3.0
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -935,9 +938,6 @@ importers:
       '@vitest/coverage-c8':
         specifier: ^0.30.1
         version: 0.30.1(vitest@0.30.0)
-      find-up:
-        specifier: ^6.3.0
-        version: 6.3.0
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
Internal usage of `3.0.3` has a problem because find-up has the incorrect API for the package.

**Bug**
```bash
$ yarn rehearsal graph -o migration-graph.json                                     
/node_modules/@rehearsal/utils/dist/src/cli.js:3
import { findUpSync } from 'find-up';
         ^^^^^^^^^^
SyntaxError: Named export 'findUpSync' not found. The requested module 'find-up' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'find-up';
const { findUpSync } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:127:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)
```

Looking at `node_modules/@rehearsal/util` for it's installed find-up in node_modules. It didn't exist. Inspected package.json, it was listed as a devDep.