### PR TITLE
fix: remove invariant in graph

### DIFF
--- a/packages/migration-graph/src/resolver.ts
+++ b/packages/migration-graph/src/resolver.ts
@@ -87,7 +87,6 @@ export class Resolver {
 
     allImports.forEach((imp) => {
       const resolved = this.resolveModule(filePath, imp);
-
       if (resolved) {
         this.walk(resolved);
 
@@ -150,13 +149,10 @@ export class Resolver {
         resolved = this.resolveRelative(importer, `${importee}/index`);
       }
 
-      assert(
-        resolved,
-        `Invariant: ${importee} is not resolvable. ${importee} was imported from ${importer} but cannot be resolved.`
-      );
-      debug(`resolve: ${importee} to ${resolved}`);
-      // relative path
-      return resolved;
+      if (resolved) {
+        debug(`resolve: ${importee} to ${resolved}`);
+        return resolved;
+      }
     }
 
     const config = this.findTSConfig(importer);
@@ -197,8 +193,6 @@ export class Resolver {
         return matchedPath;
       }
     }
-
-    debug(`resolve: FAILED ${importee}`);
   }
 
   private resolveRelative(importer: string, importee: string): string | undefined {

--- a/packages/migration-graph/test/resolver.test.ts
+++ b/packages/migration-graph/test/resolver.test.ts
@@ -208,6 +208,12 @@ describe('Resolver', () => {
         },
 
         'package-f': {
+          unresolvable: {
+            'index.js': `
+            import config '../literal/never/exists/on-disk';
+            import {index} from "package-e/foo"
+            `,
+          },
           src: {
             'index.mts': `import {index} from "package-e/foo"`,
           },
@@ -318,6 +324,15 @@ describe('Resolver', () => {
     expect(topSortFiles(resolver.graph)).toMatchObject([
       project.baseDir + '/packages/package-e/src/foo/index.ts',
       project.baseDir + '/packages/package-f/src/index.mts',
+    ]);
+  });
+
+  test('can refer to things that dont really exists', () => {
+    resolver.walk(project.baseDir + '/packages/package-f/unresolvable/index.js');
+
+    expect(topSortFiles(resolver.graph)).toMatchObject([
+      project.baseDir + '/packages/package-e/src/foo/index.ts',
+      project.baseDir + '/packages/package-f/unresolvable/index.js',
     ]);
   });
 });


### PR DESCRIPTION
This removes the invariant assert for when an import has a relative path that never exists. This is typically the case with files that conventional exist only at build time.
