### PR TITLE
chore(migrate): add test.todo on bad `.gts` tests

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`fix > .gts > still fixes the file if there are no errors 1`] = `
 "import Component from '@glimmer/component';
 
-export default class Hello extends Component {
+export default class TestGjsNoErrors extends Component {
   name = 'world';
 
   <template>
@@ -286,7 +286,7 @@ import type BooService from \\"boo/services/boo-service\\";
 import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
 
-export default class SomeComponent extends Component {
+export default class SomeTsComponent extends Component {
   @service(\\"boo-service\\")
   declare booService: BooService;
 
@@ -425,7 +425,7 @@ import type Foo from \\"my-addon/services/foo\\";
 import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
 
-export default class SomeComponent extends Component {
+export default class SomeTsComponent extends Component {
   @service(\\"my-addon@foo\\")
   declare foo: Foo;
 }

--- a/packages/migrate/test/fixtures/project/src/gjs-no-errors.gts
+++ b/packages/migrate/test/fixtures/project/src/gjs-no-errors.gts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-export default class Hello extends Component {
+export default class TestGjsNoErrors extends Component {
   name = 'world';
 
   <template>

--- a/packages/migrate/test/fixtures/project/src/missing-local-prop.gts
+++ b/packages/migrate/test/fixtures/project/src/missing-local-prop.gts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-export default class Hello extends Component {
+export default class TestMissingLocalPropGts extends Component {
   <template>
     <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
   </template>

--- a/packages/migrate/test/fixtures/project/src/with-addon-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-addon-service.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-export default class SomeComponent extends Component {
+export default class SomeGtsComponent extends Component {
   @service('my-addon@foo') foo;
 
   <template>Hello</template>

--- a/packages/migrate/test/fixtures/project/src/with-addon-service.ts
+++ b/packages/migrate/test/fixtures/project/src/with-addon-service.ts
@@ -1,6 +1,6 @@
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
-export default class SomeComponent extends Component {
-  @service('my-addon@foo') foo;
+export default class SomeTsComponent extends Component {
+  @service("my-addon@foo") foo;
 }

--- a/packages/migrate/test/fixtures/project/src/with-mapped-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-mapped-service.gts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 
-export default class SomeComponent extends Component {
+export default class TestWithMappedServiceGts extends Component {
   @service("boo-service") booService;
 
   @service gooService;

--- a/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
+++ b/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 
-export default class SomeComponent extends Component {
+export default class SomeTsComponent extends Component {
   @service("boo-service") booService;
 
   @service gooService;

--- a/packages/migrate/test/fixtures/project/src/with-non-qualified-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-non-qualified-service.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-export default class Hello extends Component {
+export default class TestWithNonQualifiedService extends Component {
   @service('authenticated-user') authenticatedUser;
 
   name = 'world';

--- a/packages/migrate/test/fixtures/project/src/with-qualified-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-qualified-service.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-export default class Hello extends Component {
+export default class TestWithQualifiedServiceGts extends Component {
   @service('authentication@authenticated-user') authenticatedUser;
 
   name = 'world';

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -168,7 +168,7 @@ describe('fix', () => {
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
-    test('with non-qualified service', async () => {
+    test.todo('with non-qualified service', async () => {
       // we now have to expect the tsconfig paths have been set as rehearsal will not do it
       // Update the tsconfig with any module name mapping so that any subsequent type checking will
       // be actually work if we happen to encounter any ember addons that specify a `moduleName`
@@ -186,6 +186,7 @@ describe('fix', () => {
         // no ops
       }
 
+      expectFile(outputs[0]).contains('class TestWithNonQualifiedService');
       expectFile(outputs[0]).toMatchSnapshot();
 
       reporter.printReport(project.baseDir);
@@ -195,7 +196,7 @@ describe('fix', () => {
       expect(report.summary[0].basePath).toMatch(project.baseDir);
     });
 
-    test('with service map', async () => {
+    test.todo('with service map', async () => {
       const [inputs, outputs] = prepareInputFiles(project, ['with-mapped-service.gts']);
 
       const input: MigrateInput = {
@@ -209,10 +210,11 @@ describe('fix', () => {
         // no ops
       }
 
+      expectFile(outputs[0]).contains('class TestWithMappedServiceGts');
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
-    test('with qualified service', async () => {
+    test.todo('with qualified service', async () => {
       const [inputs, outputs] = prepareInputFiles(project, ['with-qualified-service.gts']);
 
       const input: MigrateInput = {
@@ -225,11 +227,11 @@ describe('fix', () => {
       for await (const _ of migrate(input)) {
         // no ops
       }
-
+      expectFile(outputs[0]).contains('class TestWithQualifiedServiceGts');
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
-    test('when missing a local prop', async () => {
+    test.todo('when missing a local prop', async () => {
       const [inputs, outputs] = prepareInputFiles(project, ['missing-local-prop.gts']);
 
       const input: MigrateInput = {
@@ -242,7 +244,7 @@ describe('fix', () => {
       for await (const _ of migrate(input)) {
         // no ops
       }
-
+      expectFile(outputs[0]).contains('class TestMissingLocalPropGts');
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
@@ -260,6 +262,7 @@ describe('fix', () => {
         // no ops
       }
 
+      expectFile(outputs[0]).contains('class TestGjsNoErrors');
       expectFile(outputs[0]).toMatchSnapshot();
     });
   });
@@ -703,7 +706,7 @@ export default class SomeComponent extends Component {
       project.dispose();
     });
 
-    test('.gts', async () => {
+    test.todo('.gts', async () => {
       const [inputs, outputs] = prepareInputFiles(project, ['with-addon-service.gts']);
 
       const input: MigrateInput = {
@@ -717,6 +720,7 @@ export default class SomeComponent extends Component {
         // no ops
       }
 
+      expectFile(outputs[0]).contains('SomeGtsComponent');
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
@@ -733,7 +737,7 @@ export default class SomeComponent extends Component {
       for await (const _ of migrate(input)) {
         // no ops
       }
-
+      expectFile(outputs[0]).contains('SomeTsComponent');
       expectFile(outputs[0]).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
- `migrate.test.ts` has many `.gts` tests that don't work.
- This marks all bad tests with a `.todo`
- Modified input to have a unique signature.
- Adds assertions to output for said signature.
- See  #1087  with example test where snapshots are bad. 
- **This is not an issue with the snapshots needing an update**, but an issue where the output is incorrect given the input is inccorrect.