### PR TITLE
fix: fix service string resolution to support package with org in transform plugin 

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -1,3 +1,12 @@
 # @rehearsal/migrate
 
 Rehearsal JavaScript to TypeScript Migration Tool
+
+## Testing
+
+Use the following commands to prepare and clean fixtures for this package:
+
+```
+yarn fixtures:prepare
+yarn fixtures:clean
+```

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -430,7 +430,9 @@ declare foo: Foo;
 `;
 
 exports[`fix > with addon service > .ts 1`] = `
-"// @ts-expect-error @rehearsal TODO TS2306: File './node_modules/test-addon/services/foo.ts' is not a module.
+"// @ts-expect-error @rehearsal TODO TS2307: Cannot find module '@my-org/some-ember-addon/services/locale-service' or its corresponding type declarations.
+import type LocaleService from \\"@my-org/some-ember-addon/services/locale-service\\";
+// @ts-expect-error @rehearsal TODO TS2306: File './node_modules/test-addon/services/foo.ts' is not a module.
 import type Foo from \\"my-addon/services/foo\\";
 import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
@@ -438,6 +440,9 @@ import { inject as service } from \\"@ember/service\\";
 export default class SomeTsComponent extends Component {
   @service(\\"my-addon@foo\\")
   declare foo: Foo;
+
+  @service(\\"@my-org/some-ember-addon@LocaleService\\")
+  declare locale: LocaleService;
 }
 "
 `;

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -78,6 +78,8 @@ exports[`fix > .gts > with service map 1`] = `
 "// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'services/moo/moo' or its corresponding type declarations.
 import type MooService from 'services/moo/moo';
 import type GooService from 'services/goo';
+// @ts-expect-error @rehearsal TODO TS2307: Cannot find module '@some-org/some-package/services/from-service-map' or its corresponding type declarations.
+import type Mapped from '@some-org/some-package/services/from-service-map';
 import type BooService from 'boo/services/boo-service';
 import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
@@ -85,6 +87,9 @@ import { inject as service } from \\"@ember/service\\";
 export default class SomeComponent extends Component {
   @service(\\"boo-service\\")
 declare booService: BooService;
+
+  @service(\\"@some-org/some-package@mapped\\")
+declare something: Mapped;
 
   @service
 declare gooService: GooService;
@@ -282,6 +287,8 @@ exports[`fix > .ts > with service map 1`] = `
 "// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'services/moo/moo' or its corresponding type declarations.
 import type MooService from \\"services/moo/moo\\";
 import type GooService from \\"services/goo\\";
+// @ts-expect-error @rehearsal TODO TS2307: Cannot find module '@some-org/some-package/services/from-service-map' or its corresponding type declarations.
+import type Mapped from \\"@some-org/some-package/services/from-service-map\\";
 import type BooService from \\"boo/services/boo-service\\";
 import Component from \\"@glimmer/component\\";
 import { inject as service } from \\"@ember/service\\";
@@ -289,6 +296,9 @@ import { inject as service } from \\"@ember/service\\";
 export default class SomeTsComponent extends Component {
   @service(\\"boo-service\\")
   declare booService: BooService;
+
+  @service(\\"@some-org/some-package@mapped\\")
+  declare something: Mapped;
 
   @service
   declare gooService: GooService;

--- a/packages/migrate/test/fixtures/project/.rehearsal/services-map.json
+++ b/packages/migrate/test/fixtures/project/.rehearsal/services-map.json
@@ -1,5 +1,6 @@
 {
   "boo-service": "boo/services/boo-service",
   "goo-service": "services/goo",
-  "mooService": "services/moo/moo"
+  "mooService": "services/moo/moo",
+  "@some-org/some-package@mapped": "@some-org/some-package/services/from-service-map"
 }

--- a/packages/migrate/test/fixtures/project/src/with-addon-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-addon-service.gts
@@ -4,5 +4,7 @@ import { inject as service } from '@ember/service';
 export default class SomeGtsComponent extends Component {
   @service('my-addon@foo') foo;
 
+  @service("@my-org/some-ember-addon@LocaleService") locale;
+
   <template>Hello</template>
 }

--- a/packages/migrate/test/fixtures/project/src/with-addon-service.ts
+++ b/packages/migrate/test/fixtures/project/src/with-addon-service.ts
@@ -3,4 +3,6 @@ import { inject as service } from "@ember/service";
 
 export default class SomeTsComponent extends Component {
   @service("my-addon@foo") foo;
+
+  @service("@my-org/some-ember-addon@LocaleService") locale;
 }

--- a/packages/migrate/test/fixtures/project/src/with-mapped-service.gts
+++ b/packages/migrate/test/fixtures/project/src/with-mapped-service.gts
@@ -4,9 +4,12 @@ import { inject as service } from "@ember/service";
 export default class TestWithMappedServiceGts extends Component {
   @service("boo-service") booService;
 
+  @service("@some-org/some-package@mapped") something;
+
   @service gooService;
 
   @service mooService;
+
 
   <template>
     <span>Hello, I am human, and I am 10 years old!</span>

--- a/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
+++ b/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
@@ -4,6 +4,8 @@ import { inject as service } from "@ember/service";
 export default class SomeTsComponent extends Component {
   @service("boo-service") booService;
 
+  @service("@some-org/some-package@mapped") something;
+
   @service gooService;
 
   @service mooService;

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -780,7 +780,7 @@ export default class SomeComponent extends Component {
         // no ops
       }
 
-      expectFile(outputs[0]).toMatchSnapshot();;
+      expectFile(outputs[0]).toMatchSnapshot();
     });
 
     test('mode: drain', async () => {

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -699,6 +699,35 @@ export default class SomeComponent extends Component {
         },
       };
 
+      const somePackageFromOrg = project.addDependency('@my-org/some-ember-addon', '0.0.0');
+      somePackageFromOrg.pkg.keywords = ['ember-addon'];
+      somePackageFromOrg.pkg.main = 'index.ts';
+      somePackageFromOrg.pkg.types = 'index.d.ts';
+      somePackageFromOrg.files = {
+        'index.ts': `module.exports = {
+          moduleName() {
+          return 'some-ember-addon'
+          }
+        }`,
+        services: {
+          'locale.ts': `
+import Service from '@ember/service';
+
+export default class LocaleService extends Service {
+  current() {
+    return 'en-US';
+  }
+}
+          `,
+          'locale.d.ts': `interface LocaleService {
+            current(): string;
+          }
+
+          export default LocaleService;
+          `,
+        },
+      };
+
       await project.write();
     });
 


### PR DESCRIPTION
This fixes #1087.

## Summary

- Prioritizes the `.rehearsal/service-map.json` resolution over our derivation logic.
  - This will allow any future service resolution issues to be short circuited with simply adding a entry to `services-map.json`, rather than waiting for parsing to fail. 
- Improves service strings parsing to support a packageName.
  - This is an internal problem used in some 400+ places in voyager-web. 
```
@service('jet') jet; 
@service('some-module-name@foo') foo;
@service('@some-org/some-package@locale') locale; // This support was added./
```