### PR TITLE
fix(migration-graph): add support for resolving service from package within org

### DIFF
--- a/packages/migration-graph/src/discover-services.ts
+++ b/packages/migration-graph/src/discover-services.ts
@@ -179,8 +179,10 @@ function findClassDeclarations(items: ModuleItem[]): Array<ClassDeclaration> | u
 
 function parseServiceMetaFromString(str: string): string {
   if (str.includes('@')) {
-    const [addonName, serviceName] = str.split('@');
-    return `${addonName}/services/${intoFileName(serviceName)}`;
+    const idx = str.lastIndexOf('@');
+    const packageNameOrModuleName = str.substring(0, idx);
+    const serviceName = str.substring(idx + 1);
+    return `${packageNameOrModuleName}/services/${intoFileName(serviceName)}`;
   }
   return intoFileName(str);
 }

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -123,38 +123,24 @@ describe('discoverServiceDependencies', () => {
     expect(results[0]).toBe('shopping-cart');
   });
 
-  test('should find fully qualified serviceName from addon', () => {
+  test('should parse out packagName from service meta', () => {
     const content = `
       import Component from '@glimmer/component';
       import { inject as service } from '@ember/service';
 
       export default class Salutation extends Component {
         @service('authentication@authenticated-user') authenticatedUser;
+        @service('@some-org/some-package@locale') myLocale;
+
       }
     `;
 
     const results = discoverServiceDependencies({})('ecmascript', content);
 
     expect(results).toBeTruthy();
-    expect(results.length).toBe(1);
+    expect(results.length).toBe(2);
     expect(results[0]).toBe('authentication/services/authenticated-user');
-  });
-
-  test.todo('should find fully qualified serviceName package with org', () => {
-    const content = `
-      import Component from '@glimmer/component';
-      import { inject as service } from '@ember/service';
-
-      export default class Salutation extends Component {
-        @service('@some-org/authentication@authenticated-user') authenticatedUser;
-      }
-    `;
-
-    const results = discoverServiceDependencies({})('ecmascript', content);
-
-    expect(results).toBeTruthy();
-    expect(results.length).toBe(1);
-    expect(results[0]).toBe('@some-org/authentication/services/authenticated-user');
+    expect(results[1]).toBe('@some-org/some-package/services/locale');
   });
 
   test('should find without class on export', () => {

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -214,6 +214,43 @@ describe('discoverServiceDependencies', () => {
     expect(results[0]).toBe('locale');
   });
 
+  describe('typescript', () => {
+    test('noop', () => {
+      const content = `
+        import Component from '@glimmer/component';
+        import { service } from '@glmmerx/service';
+
+        export function foo(): string {
+          return "hello";
+        }
+      `;
+      const results = discoverServiceDependencies({})('typescript', content);
+
+      expect(results).toStrictEqual([]);
+    });
+
+    test('should find service', () => {
+      const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service locale;
+
+        get locale(): string {
+          return this.locale.current();
+        }
+      }
+    `;
+
+      const results = discoverServiceDependencies({})('typescript', content);
+
+      expect(results).toBeTruthy();
+      expect(results?.length).toBe(1);
+      expect(results[0]).toBe('locale');
+    });
+  });
+
   describe('ember@3.28', () => {
     test('should find service usage with inject export', () => {
       const content = `

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -164,13 +164,13 @@ describe('discoverServiceDependencies', () => {
 
   test('should handle multiple imports of @ember/service', () => {
     const content = `
-        import Service from '@ember/service';
-        import { service } from '@ember/service';
+      import Service from '@ember/service';
+      import { service } from '@ember/service';
 
-        export default class Locale extends Service {
-          @service request;
-        }
-      `;
+      export default class Locale extends Service {
+        @service request;
+      }
+    `;
 
     const results = discoverServiceDependencies({})('ecmascript', content);
 
@@ -193,6 +193,28 @@ describe('discoverServiceDependencies', () => {
     expect(results).toBeTruthy();
     expect(results.length).toBe(1);
     expect(results[0]).toBe('request');
+  });
+
+  test('should resolve from service-map over parsing meta', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service('authentication@authenticated-user') authenticatedUser;
+        @service('@some-org/some-package@locale') myLocale;
+
+      }
+    `;
+
+    const results = discoverServiceDependencies({
+      '@some-org/some-package@locale': 'foo/service/bar',
+    })('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(2);
+    expect(results[0]).toBe('authentication/services/authenticated-user');
+    expect(results[1]).toBe('foo/service/bar');
   });
 
   test('should ignore @classic decorator', () => {

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -88,7 +88,7 @@ describe('discoverServiceDependencies', () => {
   test('should find multiple services', () => {
     const content = `
       import Component from '@glimmer/component';
-      import { inject as service } from '@ember/service';
+      import { service } from '@ember/service';
 
       export default class Salutation extends Component {
         @service locale;
@@ -109,7 +109,7 @@ describe('discoverServiceDependencies', () => {
   test('should discover serviceName if renamed', () => {
     const content = `
       import Component from '@glimmer/component';
-      import { inject as service } from '@ember/service';
+      import { service } from '@ember/service';
 
       export default class Salutation extends Component {
         @service('shopping-cart') cart;
@@ -126,7 +126,7 @@ describe('discoverServiceDependencies', () => {
   test('should parse out packagName from service meta', () => {
     const content = `
       import Component from '@glimmer/component';
-      import { inject as service } from '@ember/service';
+      import { service } from '@ember/service';
 
       export default class Salutation extends Component {
         @service('authentication@authenticated-user') authenticatedUser;

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from 'vitest';
+
+import { discoverServiceDependencies } from '../src/discover-services.js';
+
+describe('discoverServiceDependencies', () => {
+  test('noop', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      export default class Salutation extends Component {}
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toStrictEqual([]);
+  });
+
+  test('should return empty array if a file cannot be parsed', () => {
+    const content = `
+      import Component form '@glimmer/component';
+      export default klass Salutation extends Component {}
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toStrictEqual([]);
+  });
+
+  test('should return empty array when no services decorators are used', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@ember/service';
+
+      export function foo() {
+        return "hello";
+      }
+    `;
+    const results = discoverServiceDependencies({})('ecmascript', content);
+    expect(results).toEqual([]);
+  });
+
+  test('should return empty array when @glimmerx/service is used', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@glmmerx/service';
+
+      export function foo() {
+        return "hello";
+      }
+    `;
+    const results = discoverServiceDependencies({})('ecmascript', content);
+    expect(results).toEqual([]);
+  });
+
+  test('should find service', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service locale;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    expect(results[0]).toBe('locale');
+  });
+
+  test('should find service when decorator method is renamed', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service as something } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @something locale;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    expect(results[0]).toBe('locale');
+  });
+
+  test('should find multiple services', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service locale;
+        @service tracking;
+        @service request;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(3);
+    expect(results[0]).toBe('locale');
+    expect(results[1]).toBe('tracking');
+    expect(results[2]).toBe('request');
+  });
+
+  test('should discover serviceName if renamed', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service('shopping-cart') cart;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('shopping-cart');
+  });
+
+  test('should find fully qualified serviceName from addon', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service('authentication@authenticated-user') authenticatedUser;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('authentication/services/authenticated-user');
+  });
+
+  test.todo('should find fully qualified serviceName package with org', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service('@some-org/authentication@authenticated-user') authenticatedUser;
+      }
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('@some-org/authentication/services/authenticated-user');
+  });
+
+  test('should find without class on export', () => {
+    const content = `
+      import Component from '@glimmer/component';
+      import { service } from '@ember/service';
+
+      class Salutation extends Component {
+        @service locale;
+      }
+
+      export default Salutation;
+    `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('locale');
+  });
+
+  test('should handle multiple imports of @ember/service', () => {
+    const content = `
+        import Service from '@ember/service';
+        import { service } from '@ember/service';
+
+        export default class Locale extends Service {
+          @service request;
+        }
+      `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('request');
+  });
+
+  test('should handle default export and named exports from @ember/service', () => {
+    const content = `
+        import Service, { service } from '@ember/service';
+
+        export default class Locale extends Service {
+          @service request;
+        }
+      `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results.length).toBe(1);
+    expect(results[0]).toBe('request');
+  });
+
+  test('should ignore @classic decorator', () => {
+    const content = `
+        import classic from 'ember-classic-decorator';
+        import Component from '@glimmer/component';
+        import { inject } from '@ember/service';
+
+        @classic
+        export default class Salutation extends Component {
+          @inject locale;
+        }
+      `;
+
+    const results = discoverServiceDependencies({})('ecmascript', content);
+
+    expect(results).toBeTruthy();
+    expect(results?.length).toBe(1);
+    expect(results[0]).toBe('locale');
+  });
+
+  describe('ember@3.28', () => {
+    test('should find service usage with inject export', () => {
+      const content = `
+      import Component from '@glimmer/component';
+      import { inject as service } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @service locale;
+      }
+    `;
+
+      const results = discoverServiceDependencies({})('ecmascript', content);
+
+      expect(results).toBeTruthy();
+      expect(results?.length).toBe(1);
+      expect(results[0]).toBe('locale');
+    });
+
+    test('should find service when decorator method is renamed', () => {
+      const content = `
+      import Component from '@glimmer/component';
+      import { inject as something } from '@ember/service';
+
+      export default class Salutation extends Component {
+        @something locale;
+      }
+    `;
+
+      const results = discoverServiceDependencies({})('ecmascript', content);
+
+      expect(results).toBeTruthy();
+      expect(results?.length).toBe(1);
+      expect(results[0]).toBe('locale');
+    });
+  });
+});


### PR DESCRIPTION
When parsing service meta we need to ensure we can get a packageName that contains an org.

- Adds test for discover-services.
  - Restored from previous implementation.
  - Updated test cases to work with new API. 
- Fixes bug where a service decorator is using a service from a package within an organziation.
  - `@service('@my-org/some-package@some-service') myService;`

## ToDo
- [x] TypeScript tests.
- [x] Needs test for service-map resolution.