### PR TITLE
refactor: cleanup report summary

### DIFF
--- a/packages/cli/src/commands/fix/tasks/convert-task.ts
+++ b/packages/cli/src/commands/fix/tasks/convert-task.ts
@@ -37,7 +37,6 @@ export function convertTask(
         tsVersion,
         projectName,
         projectRootDir: rootPath,
-        commandName: 'rehearsal fix',
       };
 
       const reporter = new Reporter(reporterOptions);

--- a/packages/cli/src/commands/fix/tasks/convertWorker.ts
+++ b/packages/cli/src/commands/fix/tasks/convertWorker.ts
@@ -10,7 +10,6 @@ if (!isMainThread && (!process.env['TEST'] || process.env['TEST'] === 'false')) 
     projectRootDir,
     packageDir,
     filesToMigrate,
-    reporterOptionsCommandName,
     reporterOptionsProjectName,
     reporterOptionsProjectRootDir,
     reporterOptionsTSVersion,
@@ -23,7 +22,6 @@ if (!isMainThread && (!process.env['TEST'] || process.env['TEST'] === 'false')) 
     tsVersion: reporterOptionsTSVersion,
     projectName: reporterOptionsProjectName,
     projectRootDir: reporterOptionsProjectRootDir,
-    commandName: reporterOptionsCommandName,
   });
 
   const migrateOptions = {

--- a/packages/codefixes/test/base-codefixes.test.ts
+++ b/packages/codefixes/test/base-codefixes.test.ts
@@ -35,7 +35,6 @@ describe('Test base codefixes', function () {
       tsVersion: '',
       projectName: '@rehearsal/test',
       projectRootDir: project.baseDir,
-      commandName: '@rehearsal/migrate',
     });
 
     const input = {

--- a/packages/codefixes/test/suppressed-errors.test.ts
+++ b/packages/codefixes/test/suppressed-errors.test.ts
@@ -35,7 +35,6 @@ describe('Suppressed Errors', function () {
       tsVersion: '',
       projectName: '@rehearsal/test',
       projectRootDir: project.baseDir,
-      commandName: '@rehearsal/migrate',
     });
 
     const input = {

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,4 +1,4 @@
-import { resolve, join } from 'node:path';
+import { join } from 'node:path';
 import { findUpSync } from 'find-up';
 import { readTSConfig, readJSON } from '@rehearsal/utils';
 import {
@@ -199,7 +199,7 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
   });
 
   // Save report after all yields
-  reporter.saveCurrentRunToReport(resolve(projectRootDir, workingDirName));
+  reporter.saveCurrentRunToReport();
 }
 
 async function readServiceMap(

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -417,18 +417,6 @@ exports[`fix > EXPERIMENTAL_MODES, RehearsalService > mode: single-pass 1`] = `
 "
 `;
 
-exports[`fix > with addon service > .gts 1`] = `
-"import type Foo from 'my-addon/services/foo';
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-export default class SomeComponent extends Component {
-  @service(\\"my-addon@foo\\")
-declare foo: Foo;
-}
-"
-`;
-
 exports[`fix > with addon service > .ts 1`] = `
 "// @ts-expect-error @rehearsal TODO TS2307: Cannot find module '@my-org/some-ember-addon/services/locale-service' or its corresponding type declarations.
 import type LocaleService from \\"@my-org/some-ember-addon/services/locale-service\\";

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -108,7 +108,6 @@ describe('fix', () => {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
     });
 
@@ -190,10 +189,6 @@ describe('fix', () => {
       expectFile(outputs[0]).toMatchSnapshot();
 
       reporter.printReport(project.baseDir);
-
-      const jsonReport = resolve(project.baseDir, 'rehearsal-report.json');
-      const report = JSON.parse(readFileSync(jsonReport).toString()) as Report;
-      expect(report.summary[0].reportOutDir).toMatch(project.baseDir);
     });
 
     test.todo('with service map', async () => {
@@ -282,7 +277,6 @@ describe('fix', () => {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
     });
 
@@ -337,7 +331,6 @@ describe('fix', () => {
       );
 
       expect(reportedItems.length).toBeGreaterThan(0);
-      expect(report.summary[0].reportOutDir).toMatch(project.baseDir);
     });
   });
 
@@ -352,7 +345,6 @@ describe('fix', () => {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
     });
 
@@ -565,7 +557,6 @@ describe('fix', () => {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/migrate',
       });
     });
 
@@ -670,7 +661,6 @@ export default class SomeComponent extends Component {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
 
       const testAddon = project.addDependency('test-addon', '0.0.0');
@@ -784,7 +774,6 @@ export default class LocaleService extends Service {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
 
       await project.write();
@@ -844,7 +833,6 @@ export default class LocaleService extends Service {
         tsVersion: '',
         projectName: '@rehearsal/test',
         projectRootDir: project.baseDir,
-        commandName: '@rehearsal/fix',
       });
 
       await project.write();

--- a/packages/plugins/test/utils.ts
+++ b/packages/plugins/test/utils.ts
@@ -29,7 +29,6 @@ export function mockPluginRunnerContext(project: Project): PluginsRunnerContext 
     tsVersion: '',
     projectName: '@rehearsal/test',
     projectRootDir: project.baseDir,
-    commandName: '@rehearsal/migrate',
   });
 
   return { basePath: project.baseDir, service: rehearsal, reporter };

--- a/packages/reporter/src/formatters/md-formatter.ts
+++ b/packages/reporter/src/formatters/md-formatter.ts
@@ -12,7 +12,6 @@ export class MarkdownFormatter implements FormatterBase {
     for (const block of report.summary) {
       text += `Project Name: ${block.projectName}\n`;
       text += `Typescript Version: ${block.tsVersion}\n`;
-      text += `Report path: ${block.reportOutDir}\n`;
       text += `timestamp: ${block.timestamp}\n`;
       text += `\n`;
     }

--- a/packages/reporter/src/formatters/sarif-formatter.ts
+++ b/packages/reporter/src/formatters/sarif-formatter.ts
@@ -171,7 +171,7 @@ export class SarifFormatter implements FormatterBase {
     return {
       tool: {
         driver: {
-          name: `${report.summary[0].commandName}`,
+          name: `rehearsal report`,
           informationUri: 'https://github.com/rehearsal-js/rehearsal-js',
           rules: [],
         },
@@ -182,7 +182,7 @@ export class SarifFormatter implements FormatterBase {
         description: {
           //For sequential runs, the time difference between each run is minimal, and ts version should be the same.
           //So printing out the first timestamp and first ts version.
-          text: `This is the result of ${report.summary[0].commandName} on your product against TypeScript ${report.summary[0].tsVersion} at ${report.summary[0].timestamp}`,
+          text: `This is the result of running Rehearsal on your product against TypeScript ${report.summary[0].tsVersion} at ${report.summary[0].timestamp}`,
         },
       },
     };

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -23,7 +23,6 @@ const { DiagnosticCategory, flattenDiagnosticMessageText, SyntaxKind } = ts;
 type ReporterMeta = {
   projectName: string;
   projectRootDir: string;
-  commandName: string;
   tsVersion: string;
   stemName?: string;
   previousFixedCount?: number;
@@ -42,7 +41,7 @@ export class Reporter {
   private stemName: string;
 
   constructor(meta: ReporterMeta) {
-    const { projectName, projectRootDir, commandName, tsVersion, previousFixedCount } = meta;
+    const { projectName, projectRootDir, tsVersion, previousFixedCount } = meta;
 
     // do not include extension in the stemName
     this.stemName = meta.stemName || 'rehearsal-report';
@@ -61,9 +60,6 @@ export class Reporter {
         projectName,
         tsVersion,
         timestamp: '',
-        reportOutDir: '',
-        entrypoint: '',
-        commandName,
       },
       fixedItemCount: 0,
       items: [],
@@ -142,10 +138,8 @@ export class Reporter {
     this.currentRun.fixedItemCount++;
   }
 
-  saveCurrentRunToReport(reportOutDir: string, runEntrypoint?: string, timestamp?: string): void {
+  saveCurrentRunToReport(timestamp?: string): void {
     this.currentRun.runSummary.timestamp = timestamp || this.getTimestamp();
-    this.currentRun.runSummary.reportOutDir = reportOutDir;
-    this.currentRun.runSummary.entrypoint = runEntrypoint || '';
     this.report.summary = [...this.report.summary, { ...this.currentRun.runSummary }];
     this.report.fixedItemCount += this.currentRun.fixedItemCount;
 
@@ -234,8 +228,6 @@ export class Reporter {
 
   private resetCurrentRun(): void {
     this.currentRun.runSummary.timestamp = '';
-    this.currentRun.runSummary.reportOutDir = '';
-    this.currentRun.runSummary.entrypoint = '';
     this.currentRun.fixedItemCount = 0;
     this.currentRun.items = [];
   }

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -2,11 +2,8 @@ export type Formatters = 'json' | 'sonarqube' | 'md' | 'sarif';
 
 export type ReportSummary = Record<string, unknown> & {
   projectName: string;
-  reportOutDir: string;
-  entrypoint: string;
   tsVersion: string;
   timestamp: string;
-  commandName: string;
 };
 
 export interface Location {

--- a/packages/reporter/test/__snapshots__/json-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/json-formatter.test.ts.snap
@@ -6,10 +6,7 @@ exports[`JSONFormatter > should transform all fields correctly, irregardless of 
     {
       \\"projectName\\": \\"@rehearsal/test\\",
       \\"tsVersion\\": \\"4.7.4\\",
-      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-      \\"basePath\\": \\"/base/path\\",
-      \\"entrypoint\\": \\"\\",
-      \\"commandName\\": \\"@rehearsal/reporter\\"
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\"
     }
   ],
   \\"fixedItemCount\\": 4,

--- a/packages/reporter/test/__snapshots__/markdown-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/markdown-formatter.test.ts.snap
@@ -4,7 +4,6 @@ exports[`MarkdownFormatter > should transform all fields correctly, irregardless
 "### Summary:
 Project Name: @rehearsal/test
 Typescript Version: 4.7.4
-Report path: undefined
 timestamp: 9/16/2022, 13:24:57
 
 ### Results:

--- a/packages/reporter/test/__snapshots__/reporter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/reporter.test.ts.snap
@@ -6,11 +6,7 @@ exports[`Reporter > addLintItemToRun 1`] = `
     {
       \\"projectName\\": \\"@rehearsal/test\\",
       \\"tsVersion\\": \\"4.7.4\\",
-      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-      \\"basePath\\": \\"/base/path\\",
-      \\"entrypoint\\": \\"\\",
-      \\"commandName\\": \\"@rehearsal/reporter\\",
-      \\"reportOutDir\\": \\"/base/path\\"
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\"
     }
   ],
   \\"fixedItemCount\\": 4,
@@ -106,11 +102,7 @@ exports[`Reporter > addTSItemToRun 1`] = `
     {
       \\"projectName\\": \\"@rehearsal/test\\",
       \\"tsVersion\\": \\"4.7.4\\",
-      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-      \\"basePath\\": \\"/base/path\\",
-      \\"entrypoint\\": \\"\\",
-      \\"commandName\\": \\"@rehearsal/reporter\\",
-      \\"reportOutDir\\": \\"/base/path\\"
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\"
     }
   ],
   \\"fixedItemCount\\": 4,
@@ -260,11 +252,7 @@ exports[`Reporter > printReport default formatter 1`] = `
     {
       \\"projectName\\": \\"@rehearsal/test\\",
       \\"tsVersion\\": \\"4.7.4\\",
-      \\"timestamp\\": \\"9/16/2022, 13:24:57\\",
-      \\"basePath\\": \\"/base/path\\",
-      \\"entrypoint\\": \\"\\",
-      \\"commandName\\": \\"@rehearsal/reporter\\",
-      \\"reportOutDir\\": \\"/base/path\\"
+      \\"timestamp\\": \\"9/16/2022, 13:24:57\\"
     }
   ],
   \\"fixedItemCount\\": 4,
@@ -341,7 +329,6 @@ exports[`Reporter > printReport md formatter 1`] = `
 "### Summary:
 Project Name: @rehearsal/test
 Typescript Version: 4.7.4
-Report path: /base/path
 timestamp: 9/16/2022, 13:24:57
 
 ### Results:
@@ -376,7 +363,7 @@ exports[`Reporter > printReport sarif formatter 1`] = `
     {
       \\"tool\\": {
         \\"driver\\": {
-          \\"name\\": \\"@rehearsal/reporter\\",
+          \\"name\\": \\"rehearsal report\\",
           \\"informationUri\\": \\"https://github.com/rehearsal-js/rehearsal-js\\",
           \\"rules\\": [
             {
@@ -542,7 +529,7 @@ exports[`Reporter > printReport sarif formatter 1`] = `
       ],
       \\"automationDetails\\": {
         \\"description\\": {
-          \\"text\\": \\"This is the result of @rehearsal/reporter on your product against TypeScript 4.7.4 at 9/16/2022, 13:24:57\\"
+          \\"text\\": \\"This is the result of running Rehearsal on your product against TypeScript 4.7.4 at 9/16/2022, 13:24:57\\"
         }
       }
     }
@@ -692,11 +679,7 @@ exports[`Reporter > saveCurrentRunToReport 1`] = `
   ],
   "summary": [
     {
-      "basePath": "/base/path",
-      "commandName": "@rehearsal/reporter",
-      "entrypoint": "",
       "projectName": "@rehearsal/test",
-      "reportOutDir": "/base/path",
       "timestamp": "9/16/2022, 13:24:57",
       "tsVersion": "4.7.4",
     },

--- a/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
+++ b/packages/reporter/test/__snapshots__/sarif-formatter.test.ts.snap
@@ -177,7 +177,7 @@ exports[`SarifFormatter > should set the correct version, $schema, and initial d
     {
       \\"tool\\": {
         \\"driver\\": {
-          \\"name\\": \\"@rehearsal/reporter\\",
+          \\"name\\": \\"rehearsal report\\",
           \\"informationUri\\": \\"https://github.com/rehearsal-js/rehearsal-js\\",
           \\"rules\\": []
         }
@@ -186,7 +186,7 @@ exports[`SarifFormatter > should set the correct version, $schema, and initial d
       \\"results\\": [],
       \\"automationDetails\\": {
         \\"description\\": {
-          \\"text\\": \\"This is the result of @rehearsal/reporter on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
+          \\"text\\": \\"This is the result of running Rehearsal on your product against TypeScript 4.7.4 at 9/16/2022, 20:16:50\\"
         }
       }
     }

--- a/packages/reporter/test/fixtures/rehearsal-report.json
+++ b/packages/reporter/test/fixtures/rehearsal-report.json
@@ -2,10 +2,7 @@
   "summary": [{
     "projectName": "@rehearsal/test",
     "tsVersion": "4.7.4",
-    "timestamp": "9/16/2022, 13:24:57",
-    "basePath": "/base/path",
-    "entrypoint": "",
-    "commandName": "@rehearsal/reporter"
+    "timestamp": "9/16/2022, 13:24:57"
   }],
   "fixedItemCount": 4,
   "items": [

--- a/packages/reporter/test/fixtures/rehearsal-run.json
+++ b/packages/reporter/test/fixtures/rehearsal-run.json
@@ -5,10 +5,7 @@
   "runSummary": {
     "projectName": "@rehearsal/test",
     "tsVersion": "4.7.4",
-    "timestamp": "9/16/2022, 13:24:57",
-    "basePath": "/base/path",
-    "entrypoint": "",
-    "commandName": "@rehearsal/reporter"
+    "timestamp": "9/16/2022, 13:24:57"
   },
   "fixedItemCount": 4,
   "items": [

--- a/packages/reporter/test/fixtures/sarif-formatter/index.ts
+++ b/packages/reporter/test/fixtures/sarif-formatter/index.ts
@@ -4,10 +4,7 @@ export const initialData: Report = {
   summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
-    timestamp: "9/16/2022, 20:16:50",
-    reportOutDir: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter",
-    entrypoint: "",
+    timestamp: "9/16/2022, 20:16:50"
   }],
   items: [],
   fixedItemCount: 0
@@ -17,10 +14,7 @@ export const addRuleData: Report = {
   summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
-    timestamp: "9/16/2022, 13:24:52",
-    reportOutDir: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter",
-    entrypoint: "",
+    timestamp: "9/16/2022, 13:24:52"
   }],
   fixedItemCount: 5,
   items: [
@@ -96,10 +90,7 @@ export const addResultData: Report = {
   summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
-    timestamp: "9/16/2022, 13:24:57",
-    reportOutDir: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter",
-    entrypoint: "",
+    timestamp: "9/16/2022, 13:24:57"
   }],
   fixedItemCount: 3,
   items: [
@@ -175,10 +166,7 @@ export const addArtifactData: Report = {
   summary: [{
     projectName: "@rehearsal/test",
     tsVersion: "4.7.4",
-    timestamp: "9/16/2022, 13:24:55",
-    reportOutDir: "/reporter/test/sarif-formatter",
-    commandName: "@rehearsal/reporter",
-    entrypoint: '',
+    timestamp: "9/16/2022, 13:24:55"
   }],
   fixedItemCount: 5,
   items: [

--- a/packages/reporter/test/reporter.test.ts
+++ b/packages/reporter/test/reporter.test.ts
@@ -12,7 +12,6 @@ describe('Reporter', () => {
   let project: Project;
   let reportDirectory: string;
   const currentRunTimestamp = '9/16/2022, 13:24:57';
-  const currentRunBasePath = '/base/path';
 
   beforeEach(async () => {
     project = prepareProject('rehearsal-report.json');
@@ -23,7 +22,6 @@ describe('Reporter', () => {
       tsVersion: '',
       projectName: 'test',
       projectRootDir: project.baseDir,
-      commandName: '@rehearsal/reporter',
     });
 
     reporter.currentRun = getJSONReport('rehearsal-run.json');
@@ -36,18 +34,17 @@ describe('Reporter', () => {
 
   test('saveCurrentRunToReport', () => {
     // current run is being set in beforeEach
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
 
     const report = reporter.report;
 
     expect(report.summary.length).toBe(1);
-    expect(report.summary[0].reportOutDir).toMatch(/base/);
     expect(report.summary[0].timestamp).toMatch(/\d+/);
     expect(report).toMatchSnapshot();
   });
 
   test('printReport default formatter', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -57,7 +54,7 @@ describe('Reporter', () => {
   });
 
   test('printReport sarif formatter', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory, ['sarif']);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -67,7 +64,7 @@ describe('Reporter', () => {
   });
 
   test('printReport sonarqube formatter', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory, ['sonarqube']);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -77,7 +74,7 @@ describe('Reporter', () => {
   });
 
   test('printReport md formatter', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory, ['md']);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -110,7 +107,7 @@ describe('Reporter', () => {
     const hint = 'This is the hint.';
 
     reporter.addTSItemToRun(mockDiagnostic, mockNode, location, hint);
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -128,7 +125,7 @@ describe('Reporter', () => {
     };
 
     reporter.addLintItemToRun('testFile1.ts', lintError);
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     reporter.printReport(reportDirectory);
 
     expect(existsSync(reportDirectory)).toBe(true);
@@ -138,13 +135,13 @@ describe('Reporter', () => {
   });
 
   test('getFileNames', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
 
     expect(reporter.getFileNames()).toStrictEqual(['/base/path/file1.ts', '/base/path/file2.ts']);
   });
 
   test('getItemsByAnalysisTarget', () => {
-    reporter.saveCurrentRunToReport(currentRunBasePath, '', currentRunTimestamp);
+    reporter.saveCurrentRunToReport(currentRunTimestamp);
     const items = reporter.getItemsByAnalysisTarget('/base/path/file1.ts');
 
     expect(items).toMatchSnapshot();

--- a/packages/service/test/plugin-runner.test.ts
+++ b/packages/service/test/plugin-runner.test.ts
@@ -9,7 +9,6 @@ describe('PluginsRunner', () => {
       tsVersion: '',
       projectName: '@rehearsal/test',
       projectRootDir: '.',
-      commandName: '@rehearsal/migrate',
     });
 
     const service = new RehearsalService({}, []);


### PR DESCRIPTION
This PR:

- Fixes a bug where absolute paths in the report key `basePath` | `reportOutDir` was an absolute path.
- Refactors the @rehearsal/reporter report `summary` and removes legacy keys:

```
commandName
entrypoint
basePath
reportOutDir
```

- `commandName`: a given report can only be generated via `rehearsal fix` as such we dont need to explicitly call out which rehearsal command was used to generate the report (only 1 option)
- `entrypoint`: this is a remnant from previous API
- `basePath` | `reportOutDir`: `basePath` was renamed to `reportOutDir`. However,  the underlying value for this path just doesn't provide value. As this was only specifying the path in the report where the report itself resides.