### PR TITLE
fix(codefixes): handles hint for TS7016 removes absolute urls

### DIFF
--- a/packages/codefixes/src/hints.ts
+++ b/packages/codefixes/src/hints.ts
@@ -6,6 +6,9 @@ import { HintsProvider } from './hints-provider.js';
 const { isIdentifier, isFunctionDeclaration, isParameter, isReturnStatement } = ts;
 
 export const hints = new HintsProvider({
+  2307: {
+    hint: `Could not find a declaration file for module '{0}'. Try installing the missing type or add a new declaration (.d.ts) file containing \`declare module '{0}';\`.`,
+  },
   2322: {
     hint: `Type '{0}' is being returned or assigned, but type '{1}' is expected. Please convert type '{0}' to type '{1}', or return or assign a variable of type '{1}'`,
     helpUrl:
@@ -78,5 +81,8 @@ export const hints = new HintsProvider({
     hint: `Parameter '{0}' implicitly has an '{1}' type.`,
     helpUrl:
       'https://stackoverflow.com/questions/43064221/typescript-ts7006-parameter-xxx-implicitly-has-an-any-type',
+  },
+  7016: {
+    hint: `Could not find a declaration file for module '{0}'. Try installing the missing type or add a new declaration (.d.ts) file containing \`declare module '{0}';\`.`,
   },
 });

--- a/packages/codefixes/src/hints.ts
+++ b/packages/codefixes/src/hints.ts
@@ -6,9 +6,6 @@ import { HintsProvider } from './hints-provider.js';
 const { isIdentifier, isFunctionDeclaration, isParameter, isReturnStatement } = ts;
 
 export const hints = new HintsProvider({
-  2307: {
-    hint: `Could not find a declaration file for module '{0}'. Try installing the missing type or add a new declaration (.d.ts) file containing \`declare module '{0}';\`.`,
-  },
   2322: {
     hint: `Type '{0}' is being returned or assigned, but type '{1}' is expected. Please convert type '{0}' to type '{1}', or return or assign a variable of type '{1}'`,
     helpUrl:


### PR DESCRIPTION
Fixes #1085 

This PR:
- Adds a catch for `TS7016` where we return the hint without absolute paths and 'any' type comment, since its not super helpful.
- Removes the direction to leverage `npm` to install a missing type to `Try installing the missing type`.

**PREVIOUS**
// @ts-expect-error @rehearsal TODO TS7016: Could not find a declaration file for module 'ember-asset-loader/addon/services/asset-loader'. '/Users/medwards/Code/muuto/test-packages/voyager-web/node_modules/ember-asset-loader/addon/services/asset-loader.js' implicitly has an 'any' type. Try npm i --save-dev @types/ember-asset-loader if it exists or add a new declaration (.d.ts) file containing declare module 'ember-asset-loader/addon/services/asset-loader';

**CURRENT**
// @ts-expect-error @rehearsal TODO TS7016: Could not find a declaration file for module 'ember-asset-loader/addon/services/asset-loader'. Try installing the missing type or add a new declaration (.d.ts) file containing \`declare module 'ember-asset-loader/addon/services/asset-loader';\`.