### PR TITLE
fix: remove duplication in dot output

### DIFF
--- a/packages/migration-graph/src/dot.ts
+++ b/packages/migration-graph/src/dot.ts
@@ -10,13 +10,21 @@ export function generateDotLanguage(graph: PackageGraph): string {
   edge [arrowhead="normal" arrowsize="0.6" penwidth="2.0" color="#00000033" fontname="Helvetica" fontsize="9"]
   `;
 
+  const seenPackages = new Set<string>();
+
   // Create subgraphs for each package
   for (const packageNode of graph.packages.values()) {
+    if (seenPackages.has(packageNode.name)) {
+      continue;
+    }
+
     const packageName = replaceAll(packageNode.name.replace(/[@/]/g, ''), '-', '_');
 
     if (packageNode.files.length === 0) {
       continue;
     }
+
+    seenPackages.add(packageNode.name);
 
     if (packageNode.external) {
       dot += `  subgraph cluster_${packageName} {\n`;

--- a/packages/migration-graph/test/__snapshots__/resolver.test.ts.snap
+++ b/packages/migration-graph/test/__snapshots__/resolver.test.ts.snap
@@ -43,26 +43,6 @@ exports[`Resolver > resolver produces a graph that can be emitted as dotlang 1`]
     node [style=filled, fillcolor=white, shape=box];
     \\"<tmp-path>/packages/with-externals-imports/node_modules/my-external-addon-no-types/addon/index.js\\" [label=\\"addon/index.js\\"];
   }
-  subgraph cluster_my_external_addon_no_types {
-    label=\\"my-external-addon-no-types\\";
-    labeljust=l;
-    href=\\"file://<tmp-path>/packages/with-externals-imports/node_modules/my-external-addon-no-types/package.json\\";
-    color=\\"grey\\"
-    style=\\"dashed\\"
-    fontcolor=\\"grey\\"
-    node [style=filled, fillcolor=white, shape=box];
-    \\"<tmp-path>/packages/with-externals-imports/node_modules/my-external-addon-no-types/addon/index.js\\" [label=\\"addon/index.js\\"];
-  }
-  subgraph cluster_my_external_with_types {
-    label=\\"my-external-with-types\\";
-    labeljust=l;
-    href=\\"file://<tmp-path>/packages/with-externals-imports/node_modules/my-external-with-types/package.json\\";
-    color=\\"grey\\"
-    style=\\"dashed\\"
-    fontcolor=\\"grey\\"
-    node [style=filled, fillcolor=white, shape=box];
-    \\"<tmp-path>/packages/with-externals-imports/node_modules/my-external-with-types/addon/index.ts\\" [label=\\"addon/index.ts\\"];
-  }
   subgraph cluster_my_external_with_types {
     label=\\"my-external-with-types\\";
     labeljust=l;


### PR DESCRIPTION
Because we place aliases into the global packages map we need to remove them when we print the dot output. Otherwise we will have duplicates and `dot` will yak if there are too many dups.