### PR TITLE
fix: thread external option

### DIFF
--- a/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
+++ b/packages/cli/src/commands/graph/tasks/graphOrderTask.ts
@@ -72,6 +72,7 @@ export function graphOrderTask(
               output,
               ignore: options.ignore,
               serviceMap,
+              externals,
             }),
           });
 


### PR DESCRIPTION
We forgot to thread `--externals` into the worker. The branching for the worker probably should be rethought so we don't make this mistake in the future.
