### PR TITLE
fix: migrate @glint/core dep

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -39,6 +39,7 @@
     "version": "pnpm version"
   },
   "dependencies": {
+    "@glint/core": "^1.0.2",
     "@rehearsal/migration-graph": "workspace:*",
     "@rehearsal/plugins": "workspace:*",
     "@rehearsal/reporter": "workspace:*",
@@ -59,7 +60,6 @@
     "winston": "^3.8.2"
   },
   "peerDependencies": {
-    "@glint/core": "^1.0.2",
     "typescript": "^5.0"
   },
   "packageManager": "pnpm@8.2.0",

--- a/packages/plugins/src/plugins/glint-comment.plugin.ts
+++ b/packages/plugins/src/plugins/glint-comment.plugin.ts
@@ -1,6 +1,5 @@
 import { extname } from 'node:path';
 import { createRequire } from 'node:module';
-import { type TransformManager } from '@glint/core';
 import { DiagnosticWithContext, hints, getDiagnosticOrder } from '@rehearsal/codefixes';
 import { GlintService, PluginOptions, Service, PathUtils, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
@@ -8,6 +7,7 @@ import ts from 'typescript';
 import debug from 'debug';
 import { getLocation } from '../helpers.js';
 import { getConditionalCommentPos, onMultilineConditionalTokenLine } from './utils.js';
+import type { TransformManager } from '@glint/core';
 import type MS from 'magic-string';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-comment');


### PR DESCRIPTION
Fixes #1114 

This PR:

- moves `@glint/core` from a devDep/peerDep to dep for the rehearsal/migrate package