### PR TITLE
fix(glint): adding `@glint-expect-error` around multiple line mustache statements

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -139,6 +139,88 @@ export default class Foo extends Component {}
 "
 `;
 
+exports[`fix > .hbs > support adding comments before curlies 1`] = `
+"<div
+  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'someArg1' does not exist on type '{}'. }}
+  class=\\"{{concat
+      @someArg1
+      @someArg2
+      @someArg3
+      @someArg4
+      @someArg5
+      @someArg6
+      @someArg7
+      @someArg8
+      @someArg9
+      @someArg10
+    }}\\"
+>
+  Hello World!
+</div>
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+{{@arg1}}
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+{{concat @arg1}}
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+{{concat @arg1 @arg2}}
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+<div class=\\"{{concat @arg1}}\\">
+  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+  <div class=\\"{{concat @arg1}}\\">
+    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+    <div class=\\"{{concat @arg1}}\\">
+      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+      <div class=\\"{{concat @arg1}}\\">
+        Hello World!
+      </div>
+    </div>
+  </div>
+</div>
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'arg1' does not exist on type '{}'. }}
+{{@arg1}}
+
+{{! @glint-expect-error @rehearsal TODO TS2339: Property 'someArg1' does not exist on type '{}'. }}
+{{concat
+  @someArg1
+  @someArg2
+  @someArg3
+  @someArg4
+  @someArg5
+  @someArg6
+  @someArg7
+  @someArg8
+  @someArg9
+  @someArg10
+}}
+
+<div>
+  <div>
+    <div>
+      <div>
+        {{! @glint-expect-error @rehearsal TODO TS2339: Property 'someArg1' does not exist on type '{}'. }}
+        {{concat
+          @someArg1
+          @someArg2
+          @someArg3
+          @someArg4
+          @someArg5
+          @someArg6
+          @someArg7
+          @someArg8
+          @someArg9
+          @someArg10
+        }}
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
 exports[`fix > .hbs > template only 1`] = `
 "{{! @glint-expect-error @rehearsal TODO TS7006: Parameter '{0}' implicitly has an 'any' type. }}
 Hello!"

--- a/packages/migrate/test/fixtures/project/src/nested-helper-line-length.hbs
+++ b/packages/migrate/test/fixtures/project/src/nested-helper-line-length.hbs
@@ -1,0 +1,18 @@
+<div
+  {{on
+    "click"
+    (fn
+      @someFunc
+      @someArg1
+      @someArg2
+      @someArg3
+      @someArg4
+      @someArg5
+      @someArg6
+      @someArg7
+      @someArg8
+      @someArg9
+      @someArg10
+    )
+  }}
+/>

--- a/packages/migrate/test/fixtures/project/src/nested-helper-line-length.hbs
+++ b/packages/migrate/test/fixtures/project/src/nested-helper-line-length.hbs
@@ -1,8 +1,5 @@
 <div
-  {{on
-    "click"
-    (fn
-      @someFunc
+  class="{{concat
       @someArg1
       @someArg2
       @someArg3
@@ -13,6 +10,59 @@
       @someArg8
       @someArg9
       @someArg10
-    )
-  }}
-/>
+    }}"
+>
+  Hello World!
+</div>
+
+{{@arg1}}
+
+{{concat @arg1}}
+
+{{concat @arg1 @arg2}}
+
+<div class="{{concat @arg1}}">
+  <div class="{{concat @arg1}}">
+    <div class="{{concat @arg1}}">
+      <div class="{{concat @arg1}}">
+        Hello World!
+      </div>
+    </div>
+  </div>
+</div>
+
+{{@arg1}}
+
+{{concat
+  @someArg1
+  @someArg2
+  @someArg3
+  @someArg4
+  @someArg5
+  @someArg6
+  @someArg7
+  @someArg8
+  @someArg9
+  @someArg10
+}}
+
+<div>
+  <div>
+    <div>
+      <div>
+        {{concat
+          @someArg1
+          @someArg2
+          @someArg3
+          @someArg4
+          @someArg5
+          @someArg6
+          @someArg7
+          @someArg8
+          @someArg9
+          @someArg10
+        }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -350,7 +350,7 @@ describe('fix', () => {
       expect(reportedItems.length).toBeGreaterThan(0);
     });
 
-    test.only('lengthy nested args in helper', async () => {
+    test('support adding comments before curlies', async () => {
       const [inputs, outputs] = prepareInputFiles(project, ['nested-helper-line-length.hbs']);
 
       const input: MigrateInput = {
@@ -363,10 +363,8 @@ describe('fix', () => {
       for await (const _ of migrate(input)) {
         // no ops
       }
-      const content = readFileSync(outputs[0], 'utf-8');
-      console.log(content);
-      // expectFile(outputs[0]).matchSnapshot();
-      expect(true).toBe(false);
+
+      expectFile(outputs[0]).matchSnapshot();
     });
   });
 

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -349,6 +349,25 @@ describe('fix', () => {
 
       expect(reportedItems.length).toBeGreaterThan(0);
     });
+
+    test.only('lengthy nested args in helper', async () => {
+      const [inputs, outputs] = prepareInputFiles(project, ['nested-helper-line-length.hbs']);
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: project.baseDir,
+        filesToMigrate: inputs,
+        reporter,
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+      const content = readFileSync(outputs[0], 'utf-8');
+      console.log(content);
+      // expectFile(outputs[0]).matchSnapshot();
+      expect(true).toBe(false);
+    });
   });
 
   describe('.ts', () => {


### PR DESCRIPTION
Authored with @egorio. We paired on this solution.

### Problem
- Glint Plugin would incorrectly insert comments within an mustache statement nearest the site of the glint error.
- The diagnostic would point to the actual start of the bad argument.

```hbs
{{concat
  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'someArg1' does not exist on type '{}'. }}
  @someArg2
  @someArg3
  @someArg4
  @someArg5
  @someArg6
  @someArg7
  @someArg8
  @someArg9
  @someArg10
}}
```

This fixes #1119 and another issue where a multiline handlebars statement within an html tag would produce invalidate handlebars syntax after running migrate.

```hbs
<div
  class="{{concat
       {{! @glint-expect-error @rehearsal TODO TS2339: Property 'someArg1' does not exist on type '{}'. }}
      @someArg1
      @someArg2
      @someArg3
      @someArg4
      @someArg5
      @someArg6
      @someArg7
      @someArg8
      @someArg9
      @someArg10
    }}"
>
  Hello World!
</div>
```
### Why is this important?

When rehearsal runs against our internal products it breaks `.hbs` files.

### Changes
- When given a diagnostic in an .hbs context, it will find up to the opening curlies, and inject there.
- DRYs up usage of change magicString changeTracker.appendRight method.


### TODO
- [ ] Need to write a smoke-test for this using a angle bracket component invocation with a glint error.
```
<MyComponent
  @badArg
  @someArg2
  @someArg3
  @someArg4
  @someArg5
  @someArg6
  @someArg7
  @someArg8
  @someArg9
  @someArg10
}}
/>
```

