### PR TITLE
fix: ignore hbs files

### DIFF
--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -504,45 +504,31 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js
 [DATA] processing file: /app/router.js
-[DATA] processing file: /app/components/ember-component.hbs
 [DATA] processing file: /app/components/ember-component.ts
-[DATA] processing file: /app/components/foo.hbs
 [DATA] processing file: /app/components/foo.ts
-[DATA] processing file: /app/components/js-component.hbs
 [DATA] processing file: /app/components/js-component.js
-[DATA] processing file: /app/components/no-backing-module.hbs
-[DATA] processing file: /app/components/nocheck-me.hbs
 [DATA] processing file: /app/components/qux.ts
-[DATA] processing file: /app/components/template-only-module.hbs
 [DATA] processing file: /app/components/template-only-module.ts
-[DATA] processing file: /app/components/wrapper-component.hbs
 [DATA] processing file: /app/components/wrapper-component.ts
 [DATA] processing file: /app/controllers/classic-route.ts
 [DATA] processing file: /app/helpers/affix.ts
 [DATA] processing file: /app/helpers/repeat.ts
 [DATA] processing file: /app/routes/classic-route.ts
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/classic-route.hbs
-[DATA] processing file: /app/components/bar/index.hbs
 [DATA] processing file: /app/components/bar/index.ts
-[DATA] processing file: /app/templates/components/qux.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
 [DATA] processing file: /app/components/test-cases/subclassing/parent.ts
 [DATA] processing file: /app/components/test-cases/subclassing/child.ts
-[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
 [DATA] processing file: /app/pods/components/baz/component.ts
-[DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   31 errors caught by rehearsal
+[TITLE]   22 errors caught by rehearsal
 [TITLE]   2 have been fixed by rehearsal
-[TITLE]   29 errors need to be fixed manually
-[TITLE]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   20 errors need to be fixed manually
+[TITLE]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   31 errors caught by rehearsal
+[SUCCESS]   22 errors caught by rehearsal
 [SUCCESS]   2 have been fixed by rehearsal
-[SUCCESS]   29 errors need to be fixed manually
-[SUCCESS]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   20 errors need to be fixed manually
+[SUCCESS]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 
@@ -557,43 +543,29 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js
 [DATA] processing file: /app/router.js
-[DATA] processing file: /app/components/ember-component.hbs
 [DATA] processing file: /app/components/ember-component.ts
-[DATA] processing file: /app/components/foo.hbs
 [DATA] processing file: /app/components/foo.ts
-[DATA] processing file: /app/components/js-component.hbs
 [DATA] processing file: /app/components/js-component.js
-[DATA] processing file: /app/components/no-backing-module.hbs
-[DATA] processing file: /app/components/nocheck-me.hbs
 [DATA] processing file: /app/components/qux.ts
-[DATA] processing file: /app/components/template-only-module.hbs
 [DATA] processing file: /app/components/template-only-module.ts
-[DATA] processing file: /app/components/wrapper-component.hbs
 [DATA] processing file: /app/components/wrapper-component.ts
 [DATA] processing file: /app/controllers/classic-route.ts
 [DATA] processing file: /app/routes/classic-route.ts
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/classic-route.hbs
-[DATA] processing file: /app/components/bar/index.hbs
 [DATA] processing file: /app/components/bar/index.ts
-[DATA] processing file: /app/templates/components/qux.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
 [DATA] processing file: /app/components/test-cases/subclassing/parent.ts
 [DATA] processing file: /app/components/test-cases/subclassing/child.ts
-[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
 [DATA] processing file: /app/pods/components/baz/component.ts
-[DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   26 errors caught by rehearsal
+[TITLE]   17 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   25 errors need to be fixed manually
-[TITLE]     -- 23 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   16 errors need to be fixed manually
+[TITLE]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   26 errors caught by rehearsal
+[SUCCESS]   17 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   25 errors need to be fixed manually
-[SUCCESS]     -- 23 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   16 errors need to be fixed manually
+[SUCCESS]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 

--- a/packages/migration-graph/src/resolver.ts
+++ b/packages/migration-graph/src/resolver.ts
@@ -50,7 +50,7 @@ export class Resolver {
 
   constructor(options: ResolverOptions) {
     this.ignorePatterns = [
-      '**/*.hbs', // +  // Ignoring HBS until .hbs file until https://github.com/rehearsal-js/rehearsal-js/issues/1119 is resolved
+      '**/*.hbs', // +  // Ignoring .hbs until https://github.com/rehearsal-js/rehearsal-js/issues/1119 is resolved
       ...(options?.ignore ?? []),
     ];
     this.scanForImports = options?.scanForImports;

--- a/packages/migration-graph/src/resolver.ts
+++ b/packages/migration-graph/src/resolver.ts
@@ -49,7 +49,10 @@ export class Resolver {
   ];
 
   constructor(options: ResolverOptions) {
-    this.ignorePatterns = [...(options?.ignore ?? [])];
+    this.ignorePatterns = [
+      '**/*.hbs', // +  // Ignoring HBS until .hbs file until https://github.com/rehearsal-js/rehearsal-js/issues/1119 is resolved
+      ...(options?.ignore ?? []),
+    ];
     this.scanForImports = options?.scanForImports;
     this.includeExternals = options.includeExternals;
     this.fileResolver = enhancedResolve.create.sync({

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -454,58 +454,40 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/router.ts
 [DATA] processing file: /app/adapters/application.ts
 [DATA] processing file: /app/components/hello-world.gts
-[DATA] processing file: /app/components/jumbo.hbs
-[DATA] processing file: /app/components/map.hbs
 [DATA] processing file: /app/components/map.ts
-[DATA] processing file: /app/components/nav-bar.hbs
-[DATA] processing file: /app/components/rental.hbs
-[DATA] processing file: /app/components/rentals.hbs
 [DATA] processing file: /app/components/rentals.ts
-[DATA] processing file: /app/components/share-button.hbs
 [DATA] processing file: /app/components/share-button.ts
 [DATA] processing file: /app/models/rental.ts
 [DATA] processing file: /app/routes/index.ts
 [DATA] processing file: /app/routes/rental.ts
 [DATA] processing file: /app/serializers/application.ts
 [DATA] processing file: /app/services/locale.ts
-[DATA] processing file: /app/templates/about.hbs
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/contact.hbs
-[DATA] processing file: /app/templates/index.hbs
-[DATA] processing file: /app/templates/rental.hbs
-[DATA] processing file: /app/components/rental/detailed.hbs
-[DATA] processing file: /app/components/rental/image.hbs
 [DATA] processing file: /app/components/rental/image.ts
-[DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
-[TITLE]   66 errors caught by rehearsal
+[TITLE]   31 errors caught by rehearsal
 [TITLE]   3 have been fixed by rehearsal
-[TITLE]   63 errors need to be fixed manually
-[TITLE]     -- 63 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   28 errors need to be fixed manually
+[TITLE]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   66 errors caught by rehearsal
+[SUCCESS]   31 errors caught by rehearsal
 [SUCCESS]   3 have been fixed by rehearsal
-[SUCCESS]   63 errors need to be fixed manually
-[SUCCESS]     -- 63 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   28 errors need to be fixed manually
+[SUCCESS]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
 exports[`fix command > ember_js_app_4.11 2`] = `
 "<div class=\\"map\\">
   <img
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'lat' does not exist on type '{}'. }}
     alt=\\"Map image at coordinates {{@lat}},{{@lng}}\\"
-    {{! @glint-expect-error @rehearsal TODO TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Element'. }}
     ...attributes
     src={{this.src}}
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'width' does not exist on type '{}'. }}
-    width={{@width}}
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'height' does not exist on type '{}'. }}
-    height={{@height}}
-  />
-</div>"
+    width={{@width}} height={{@height}}
+  >
+</div>
+"
 `;
 
 exports[`fix command > ember_js_app_4.11 3`] = `


### PR DESCRIPTION
- Ignoring `.hbs` files in graph because the GlintComment plugin cannot accurately inject a `{{! @glint-expect-error }}` comment that doesn't break syntax.
- This can be removed once #1119 is resolved.
