### PR TITLE
chore: workflow beta

### DIFF
--- a/.github/failed_cron_job_issue_template.md
+++ b/.github/failed_cron_job_issue_template.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduled GitHub Action Failed
-labels: bug, ts-nightly
+labels: bug, ts-beta
 ---
 
 Oh no, something went wrong in the rehearsal scheduled workflow for {{ env.WORKFLOW }}/{{ env.JOB }}.

--- a/.github/workflows/ts-beta-test.yml
+++ b/.github/workflows/ts-beta-test.yml
@@ -1,12 +1,12 @@
-name: TypeScript Nightly Test
+name: TypeScript Beta Test
 
 on:
   schedule: # Run every monday at midnight
     - cron: '0 0 * * 1'
 
 jobs:
-  test-ts-nightly:
-    name: TypeScript Nightly - Runs Entire Slow Test Suite with Linting
+  test-ts-beta:
+    name: TypeScript Beta - Runs Entire Test Suite with Linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,12 +43,14 @@ jobs:
             ${{ runner.os }}-npm-store-
       - name: Install dependencies
         run: pnpm install
-      - name: Install TypeScript Nightly
-        run: pnpm add -d -w typescript@next
+      - name: Install TypeScript Beta
+        run: pnpm add -d -w typescript@beta
       - name: Build
         run: pnpm build
       - name: Lint
         run: pnpm lint
+      - name: Test
+        run: pnpm test
       - name: Test Slow
         run: pnpm test:slow
       - uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
The goal of this PR is to get a pulse of the stability of `beta` when running against the `1.*.*` release of Rehearsal (current)

This PR:

- updates the current `nightly` workflow to now run against `beta` version of typescript
- runs against both test and test:slow
