### PR TITLE
feat: add glint errors in output; drop comment insertion in hbs

### DIFF
--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -504,31 +504,47 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js
 [DATA] processing file: /app/router.js
+[DATA] processing file: /app/components/ember-component.hbs
 [DATA] processing file: /app/components/ember-component.ts
+[DATA] processing file: /app/components/foo.hbs
 [DATA] processing file: /app/components/foo.ts
+[DATA] processing file: /app/components/js-component.hbs
 [DATA] processing file: /app/components/js-component.js
+[DATA] processing file: /app/components/no-backing-module.hbs
+[DATA] processing file: /app/components/nocheck-me.hbs
 [DATA] processing file: /app/components/qux.ts
+[DATA] processing file: /app/components/template-only-module.hbs
 [DATA] processing file: /app/components/template-only-module.ts
+[DATA] processing file: /app/components/wrapper-component.hbs
 [DATA] processing file: /app/components/wrapper-component.ts
 [DATA] processing file: /app/controllers/classic-route.ts
 [DATA] processing file: /app/helpers/affix.ts
 [DATA] processing file: /app/helpers/repeat.ts
 [DATA] processing file: /app/routes/classic-route.ts
+[DATA] processing file: /app/templates/application.hbs
+[DATA] processing file: /app/templates/classic-route.hbs
+[DATA] processing file: /app/components/bar/index.hbs
 [DATA] processing file: /app/components/bar/index.ts
+[DATA] processing file: /app/templates/components/qux.hbs
+[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
 [DATA] processing file: /app/components/test-cases/subclassing/parent.ts
 [DATA] processing file: /app/components/test-cases/subclassing/child.ts
+[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
 [DATA] processing file: /app/pods/components/baz/component.ts
+[DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   22 errors caught by rehearsal
+[TITLE]   13 errors caught by rehearsal
 [TITLE]   2 have been fixed by rehearsal
-[TITLE]   20 errors need to be fixed manually
-[TITLE]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   11 errors need to be fixed manually
+[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 9 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   22 errors caught by rehearsal
+[SUCCESS]   13 errors caught by rehearsal
 [SUCCESS]   2 have been fixed by rehearsal
-[SUCCESS]   20 errors need to be fixed manually
-[SUCCESS]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   11 errors need to be fixed manually
+[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 9 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 
@@ -543,29 +559,45 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [STARTED] Infer Types
 [DATA] processing file: /app/app.js
 [DATA] processing file: /app/router.js
+[DATA] processing file: /app/components/ember-component.hbs
 [DATA] processing file: /app/components/ember-component.ts
+[DATA] processing file: /app/components/foo.hbs
 [DATA] processing file: /app/components/foo.ts
+[DATA] processing file: /app/components/js-component.hbs
 [DATA] processing file: /app/components/js-component.js
+[DATA] processing file: /app/components/no-backing-module.hbs
+[DATA] processing file: /app/components/nocheck-me.hbs
 [DATA] processing file: /app/components/qux.ts
+[DATA] processing file: /app/components/template-only-module.hbs
 [DATA] processing file: /app/components/template-only-module.ts
+[DATA] processing file: /app/components/wrapper-component.hbs
 [DATA] processing file: /app/components/wrapper-component.ts
 [DATA] processing file: /app/controllers/classic-route.ts
 [DATA] processing file: /app/routes/classic-route.ts
+[DATA] processing file: /app/templates/application.hbs
+[DATA] processing file: /app/templates/classic-route.hbs
+[DATA] processing file: /app/components/bar/index.hbs
 [DATA] processing file: /app/components/bar/index.ts
+[DATA] processing file: /app/templates/components/qux.hbs
+[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
 [DATA] processing file: /app/components/test-cases/subclassing/parent.ts
 [DATA] processing file: /app/components/test-cases/subclassing/child.ts
+[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
 [DATA] processing file: /app/pods/components/baz/component.ts
+[DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   17 errors caught by rehearsal
+[TITLE]   12 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   16 errors need to be fixed manually
-[TITLE]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   11 errors need to be fixed manually
+[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 9 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   17 errors caught by rehearsal
+[SUCCESS]   12 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   16 errors need to be fixed manually
-[SUCCESS]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   11 errors need to be fixed manually
+[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 9 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 

--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -533,17 +533,17 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   13 errors caught by rehearsal
+[TITLE]   31 errors caught by rehearsal
 [TITLE]   2 have been fixed by rehearsal
-[TITLE]   11 errors need to be fixed manually
-[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   29 errors need to be fixed manually
+[TITLE]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 9 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   13 errors caught by rehearsal
+[SUCCESS]   31 errors caught by rehearsal
 [SUCCESS]   2 have been fixed by rehearsal
-[SUCCESS]   11 errors need to be fixed manually
-[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   29 errors need to be fixed manually
+[SUCCESS]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 9 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
@@ -586,17 +586,17 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   12 errors caught by rehearsal
+[TITLE]   26 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   11 errors need to be fixed manually
-[TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   25 errors need to be fixed manually
+[TITLE]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 9 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   12 errors caught by rehearsal
+[SUCCESS]   26 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   11 errors need to be fixed manually
-[SUCCESS]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   25 errors need to be fixed manually
+[SUCCESS]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 9 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -44,6 +44,19 @@ export default class Hello extends Component {
 "
 `;
 
+exports[`fix > .gts > with errors 1`] = `
+"import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}
+"
+`;
+
 exports[`fix > .gts > with non-qualified service 1`] = `
 "import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
@@ -51,22 +64,6 @@ import { inject as service } from '@ember/service';
 export default class SomeComponent extends Component {
   // @ts-expect-error @rehearsal TODO TS7008: Member 'authenticatedUser' implicitly has an 'any' type.
   @service('authenticated-user') authenticatedUser;
-}
-"
-`;
-
-exports[`fix > .gts > with qualified service 1`] = `
-"import type FooService from 'foo/services/foo-service';
-import type AuthenticatedUser from 'authentication/services/authenticated-user';
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-export default class SomeComponent extends Component {
-  @service(\\"authentication@authenticated-user\\")
-declare authenticatedUser: AuthenticatedUser;
-
-  @service(\\"foo@foo-service\\")
-declare otherProp: FooService;
 }
 "
 `;
@@ -104,20 +101,6 @@ exports[`fix > .gts > with template assigned to variable 1`] = `
 "
 `;
 
-exports[`fix > .hbs > do not add {{! @glint-expect-error }} directives into hbs 1`] = `"<span>Hello {{@name}}, your nickname is: {{this.nickname}}</span>"`;
-
-exports[`fix > .hbs > do not add {{! @glint-expect-error }} directives into hbs 2`] = `
-"import Component from \\"@glimmer/component\\";
-
-export default class Salutation extends Component {
-  get nickname() {
-    // @ts-expect-error @rehearsal TODO TS2339: Property 'nickname' does not exist on type 'Readonly<EmptyObject>'.
-    return this.args.nickname ?? \\"Unknown\\";
-  }
-}
-"
-`;
-
 exports[`fix > .hbs > more involved class 1`] = `"<span>Hello {{this.name}}</span>"`;
 
 exports[`fix > .hbs > more involved class 2`] = `
@@ -147,6 +130,20 @@ export default class Foo extends Component {}
 `;
 
 exports[`fix > .hbs > template only 1`] = `"Hello!"`;
+
+exports[`fix > .hbs > with errors 1`] = `"<span>Hello {{@name}}, your nickname is: {{this.nickname}}</span>"`;
+
+exports[`fix > .hbs > with errors 2`] = `
+"import Component from \\"@glimmer/component\\";
+
+export default class Salutation extends Component {
+  get nickname() {
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'nickname' does not exist on type 'Readonly<EmptyObject>'.
+    return this.args.nickname ?? \\"Unknown\\";
+  }
+}
+"
+`;
 
 exports[`fix > .ts > class with missing prop 1`] = `
 "class Foo {

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -22,10 +22,8 @@ export default class Foo extends Component {}
 
 exports[`fix > .gts > with bare template 1`] = `
 "<template>
-  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type '{}'. }}
   <span>Hello, {{@name}}!</span>
 
-  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'someCondition' does not exist on type '{}'. }}
   {{#if @someCondition}}
     <div>true!</div>
   {{/if}}
@@ -40,7 +38,6 @@ export default class Hello extends Component {
   name = 'world';
 
   <template>
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
     <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
   </template>
 }
@@ -102,9 +99,22 @@ declare mooService: MooService;
 
 exports[`fix > .gts > with template assigned to variable 1`] = `
 "const Hello = <template>
-  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type '{}'. }}
   <span>Hello, {{@name}}!</span>
 </template>
+"
+`;
+
+exports[`fix > .hbs > do not add {{! @glint-expect-error }} directives into hbs 1`] = `"<span>Hello {{@name}}, your nickname is: {{this.nickname}}</span>"`;
+
+exports[`fix > .hbs > do not add {{! @glint-expect-error }} directives into hbs 2`] = `
+"import Component from \\"@glimmer/component\\";
+
+export default class Salutation extends Component {
+  get nickname() {
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'nickname' does not exist on type 'Readonly<EmptyObject>'.
+    return this.args.nickname ?? \\"Unknown\\";
+  }
+}
 "
 `;
 
@@ -127,10 +137,7 @@ export default class Salutation extends Component {
 "
 `;
 
-exports[`fix > .hbs > simple class 1`] = `
-"{{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'. }}
-<span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>"
-`;
+exports[`fix > .hbs > simple class 1`] = `"<span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>"`;
 
 exports[`fix > .hbs > simple class 2`] = `
 "import Component from \\"@glimmer/component\\";
@@ -139,10 +146,7 @@ export default class Foo extends Component {}
 "
 `;
 
-exports[`fix > .hbs > template only 1`] = `
-"{{! @glint-expect-error @rehearsal TODO TS7006: Parameter '{0}' implicitly has an 'any' type. }}
-Hello!"
-`;
+exports[`fix > .hbs > template only 1`] = `"Hello!"`;
 
 exports[`fix > .ts > class with missing prop 1`] = `
 "class Foo {
@@ -161,7 +165,6 @@ export default class HelloWorld extends Component {
   name = \\"world\\";
 
   static template = hbs\`
-  {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
   <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
 \`;
 }
@@ -187,15 +190,10 @@ module(\\"Integration | Helper | grid-list\\", function (hooks) {
     assert.dom(\\"[data-test-el]\\").hasClass(\\"some-class\\", \\"has the border class\\");
 
     await render(hbs\`<Map
-      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'lat' does not exist on type 'void'. }}
       @lat={{this.lat}}
-      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'lng' does not exist on type 'void'. }}
       @lng={{this.lng}}
-      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'zoom' does not exist on type 'void'. }}
       @zoom={{this.zoom}}
-      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'width' does not exist on type 'void'. }}
       @width={{this.width}}
-      {{! @glint-expect-error @rehearsal TODO TS2339: Property 'height' does not exist on type 'void'. }}
       @height={{this.height}}
     />\`);
 

--- a/packages/migrate/test/fixtures/project/src/gts-with-errors.gts
+++ b/packages/migrate/test/fixtures/project/src/gts-with-errors.gts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}

--- a/packages/migrate/test/fixtures/project/src/with-errors.hbs
+++ b/packages/migrate/test/fixtures/project/src/with-errors.hbs
@@ -1,0 +1,1 @@
+<span>Hello {{@name}}, your nickname is: {{this.nickname}}</span>

--- a/packages/migrate/test/fixtures/project/src/with-errors.ts
+++ b/packages/migrate/test/fixtures/project/src/with-errors.ts
@@ -1,0 +1,7 @@
+import Component from "@glimmer/component";
+
+export default class Salutation extends Component {
+  get nickname() {
+    return this.args.nickname ?? "Unknown";
+  }
+}

--- a/packages/migration-graph/src/resolver.ts
+++ b/packages/migration-graph/src/resolver.ts
@@ -49,10 +49,7 @@ export class Resolver {
   ];
 
   constructor(options: ResolverOptions) {
-    this.ignorePatterns = [
-      '**/*.hbs', // +  // Ignoring .hbs until https://github.com/rehearsal-js/rehearsal-js/issues/1119 is resolved
-      ...(options?.ignore ?? []),
-    ];
+    this.ignorePatterns = [...(options?.ignore ?? [])];
     this.scanForImports = options?.scanForImports;
     this.includeExternals = options.includeExternals;
     this.fileResolver = enhancedResolve.create.sync({

--- a/packages/plugins/src/plugins/glint-comment.plugin.ts
+++ b/packages/plugins/src/plugins/glint-comment.plugin.ts
@@ -125,6 +125,12 @@ export class GlintCommentPlugin extends Plugin<GlintCommentPluginOptions> {
       index
     );
 
+    if (isInHbsContext) {
+      // Abort trying to comment an hbs context until https://github.com/rehearsal-js/rehearsal-js/issues/1119 is resolved
+      // For now, we DO NOT WANT add any {{! @glint-expect-errors }} directives in hbs contexts.
+      return;
+    }
+
     const message = `${commentTag} TODO TS${diagnostic.code}: ${hint}`;
 
     const tsIgnoreCommentText = isInHbsContext

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -63,7 +63,11 @@ export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
 
       // We only allow for a single entry per line
       if (!lineHasSupression[location.startLine]) {
-        context.reporter.addTSItemToRun(diagnostic, diagnostic.node, location, hint, helpUrl);
+        if (diagnostic.source === 'glint') {
+          context.reporter.addGlintItemToRun(diagnostic, diagnostic.node, location, hint, helpUrl);
+        } else {
+          context.reporter.addTSItemToRun(diagnostic, diagnostic.node, location, hint, helpUrl);
+        }
         lineHasSupression[location.startLine] = true;
       }
     }

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -1,6 +1,8 @@
 export * from './formatters/index.js';
 export { Reporter } from './reporter.js';
 
+export { ReportItemType } from './types.js';
+
 export type {
   Location,
   Report,

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -82,7 +82,7 @@ export class Reporter {
   }
 
   /**
-   * Appends am information about provided diagnostic and related node to the report
+   * Appends a information about provided TS diagnostic and related node to the report
    */
   addTSItemToRun(
     diagnostic: DiagnosticWithLocation,
@@ -96,6 +96,35 @@ export class Reporter {
       analysisTarget: this.normalizeFilePath(this.basePath, diagnostic.file.fileName),
       type: 0,
       ruleId: `TS${diagnostic.code}`,
+      category: DiagnosticCategory[diagnostic.category],
+      message: flattenDiagnosticMessageText(diagnostic.messageText, '. ').replace(
+        this.basePath,
+        '.'
+      ),
+      hint: hint,
+      hintAdded,
+      nodeKind: node ? SyntaxKind[node.kind] : undefined,
+      nodeText: node?.getText(),
+      helpUrl,
+      nodeLocation: triggeringLocation || undefined,
+    });
+  }
+
+  /**
+   * Appends a information about provided Glint diagnostic and related node to the report
+   */
+  addGlintItemToRun(
+    diagnostic: DiagnosticWithLocation,
+    node?: Node,
+    triggeringLocation?: Location,
+    hint = '',
+    helpUrl = '',
+    hintAdded = true
+  ): void {
+    this.currentRun.items.push({
+      analysisTarget: this.normalizeFilePath(this.basePath, diagnostic.file.fileName),
+      type: 2,
+      ruleId: `Glint${diagnostic.code}`,
       category: DiagnosticCategory[diagnostic.category],
       message: flattenDiagnosticMessageText(diagnostic.messageText, '. ').replace(
         this.basePath,

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -16,6 +16,7 @@ export interface Location {
 export enum ReportItemType {
   ts = 0,
   lint = 1,
+  glint = 2,
 }
 
 export type ReportItem = {

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -454,27 +454,43 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/router.ts
 [DATA] processing file: /app/adapters/application.ts
 [DATA] processing file: /app/components/hello-world.gts
+[DATA] processing file: /app/components/jumbo.hbs
+[DATA] processing file: /app/components/map.hbs
 [DATA] processing file: /app/components/map.ts
+[DATA] processing file: /app/components/nav-bar.hbs
+[DATA] processing file: /app/components/rental.hbs
+[DATA] processing file: /app/components/rentals.hbs
 [DATA] processing file: /app/components/rentals.ts
+[DATA] processing file: /app/components/share-button.hbs
 [DATA] processing file: /app/components/share-button.ts
 [DATA] processing file: /app/models/rental.ts
 [DATA] processing file: /app/routes/index.ts
 [DATA] processing file: /app/routes/rental.ts
 [DATA] processing file: /app/serializers/application.ts
 [DATA] processing file: /app/services/locale.ts
+[DATA] processing file: /app/templates/about.hbs
+[DATA] processing file: /app/templates/application.hbs
+[DATA] processing file: /app/templates/contact.hbs
+[DATA] processing file: /app/templates/index.hbs
+[DATA] processing file: /app/templates/rental.hbs
+[DATA] processing file: /app/components/rental/detailed.hbs
+[DATA] processing file: /app/components/rental/image.hbs
 [DATA] processing file: /app/components/rental/image.ts
+[DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
-[TITLE]   31 errors caught by rehearsal
+[TITLE]   66 errors caught by rehearsal
 [TITLE]   3 have been fixed by rehearsal
-[TITLE]   28 errors need to be fixed manually
-[TITLE]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   63 errors need to be fixed manually
+[TITLE]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 36 glint errors, with details in the report
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   31 errors caught by rehearsal
+[SUCCESS]   66 errors caught by rehearsal
 [SUCCESS]   3 have been fixed by rehearsal
-[SUCCESS]   28 errors need to be fixed manually
-[SUCCESS]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   63 errors need to be fixed manually
+[SUCCESS]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 36 glint errors, with details in the report
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
@@ -484,10 +500,10 @@ exports[`fix command > ember_js_app_4.11 2`] = `
     alt=\\"Map image at coordinates {{@lat}},{{@lng}}\\"
     ...attributes
     src={{this.src}}
-    width={{@width}} height={{@height}}
-  >
-</div>
-"
+    width={{@width}}
+    height={{@height}}
+  />
+</div>"
 `;
 
 exports[`fix command > ember_js_app_4.11 3`] = `
@@ -605,7 +621,6 @@ export default class Hello extends Component {
   name = 'world';
 
   <template>
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
     <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
   </template>
 }
@@ -624,16 +639,18 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [DATA] processing file: /src/SimpleComponent.ts
 [DATA] processing file: /src/index.ts
 [TITLE] Types Inferred
-[TITLE]   16 errors caught by rehearsal
+[TITLE]   17 errors caught by rehearsal
 [TITLE]   8 have been fixed by rehearsal
-[TITLE]   8 errors need to be fixed manually
-[TITLE]     -- 8 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   9 errors need to be fixed manually
+[TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 8 glint errors, with details in the report
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   16 errors caught by rehearsal
+[SUCCESS]   17 errors caught by rehearsal
 [SUCCESS]   8 have been fixed by rehearsal
-[SUCCESS]   8 errors need to be fixed manually
-[SUCCESS]     -- 8 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   9 errors need to be fixed manually
+[SUCCESS]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 8 glint errors, with details in the report
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
@@ -674,7 +691,6 @@ interface FormattedNameSignature {
 /** @extends {Component<FormattedNameSignature>} */
 class FormattedName extends Component {
   static template = hbs\`
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Readonly<EmptyObject>'. }}
     {{formatName this.args.name}}!
   \`;
 }
@@ -752,12 +768,9 @@ interface GreetingHeaderSignature {
 /** @extends {Component<GreetingHeaderSignature>} */
 export default class GreetingHeader extends Component {
   static template = hbs\`
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'greeting' does not exist on type '{}'. }}
     <h1>{{@greeting}}, {{or @target 'glimmerx'}}</h1>
     <img src={{this.src}}/>
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
     {{@age}}
-    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'onion' does not exist on type '{}'. }}
     {{@onion}}
   \`;
 


### PR DESCRIPTION
Adds feature described in #1105 

## Summary
- Re-enable parsing .hbs files in graph.
- Abort adding glint directives `{{! @glint-expect-error}}` to hbs contexts.
- Update reporter to aggregate glint errors.
- `fix` command output now prints total glint errors found

## Details
Changes across packages:
### packages/cli
- Update CLI report output (fix) to optionally display **glint** error summary

### packages/migrate
- Adds a test in `migrate` package for validating the errors with `ReportItemType.glint` show on the reporter.
- Validates that glint errors for `ReportItemType.glint` exist in `rehearal-report.json` output.

### packages/migration-graph
- Adds `.hbs` back into graph creation
  - I ignored .hbs after I discovered the injection issue.
- This is necessary so we can feed `.hbs` files into the GlintComment and GlintReport plugins.
- This will now show that `./path/to/some.hbs` will be processed during fix.

### packages/reporter
- Add `glint` to `ReportItemType` enum
- Expose `ReportItemType` enum
- Add API for adding a glint diagnostic to the report. 

## Testing

Verified against internal product `msg-cross-pillar`.

**Before** at `1.0.2` we would process hbs contexts but bundle those errors in the **ts** count.

```
info:    @rehearsal/fix 1.0.2
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Types Inferred
  106 errors caught by rehearsal
  9 have been fixed by rehearsal
  97 errors need to be fixed manually
  -- 56 ts errors, marked by @ts-expect-error @rehearsal TODO
  -- 41 eslint errors, with details in the report
```
**Before** at `1.0.3`
```
info:    @rehearsal/fix 1.0.3
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Types Inferred
  80 errors caught by rehearsal
  9 have been fixed by rehearsal
  71 errors need to be fixed manually
  -- 30 ts errors, marked by @ts-expect-error @rehearsal TODO
  -- 41 eslint errors, with details in the report
```

**After** (with these changes)
```
info:    @rehearsal/fix 1.0.3
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Initialize
✔ Analyzing project dependency graph ...
✔ Types Inferred
  106 errors caught by rehearsal
  9 have been fixed by rehearsal
  97 errors need to be fixed manually
  -- 30 ts errors, marked by @ts-expect-error @rehearsal TODO
  -- 26 glint errors, with details in the report
  -- 41 eslint errors, with details in the report
```