### PR TITLE
fix: graph is trying to scan .d.ts files

### DIFF
--- a/packages/migration-graph/src/resolver.ts
+++ b/packages/migration-graph/src/resolver.ts
@@ -49,7 +49,7 @@ export class Resolver {
   ];
 
   constructor(options: ResolverOptions) {
-    this.ignorePatterns = [...(options?.ignore ?? [])];
+    this.ignorePatterns = [...(options?.ignore ?? []), '*/**.d.ts'];
     this.scanForImports = options?.scanForImports;
     this.includeExternals = options.includeExternals;
     this.fileResolver = enhancedResolve.create.sync({


### PR DESCRIPTION
Fixes issue of walking through .d.ts files in `fix graph`

Fixes #1134 
