### PR TITLE
fix(migration-graph): expand hasTypes to include typesVersions check

### DIFF
--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -2,7 +2,7 @@ import { ReportItemType } from '@rehearsal/reporter';
 // eslint-disable-next-line no-restricted-imports
 import type { ReportItem } from '@rehearsal/reporter';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 const GlintReportItemType = ReportItemType.glint;
 
 /**

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -298,8 +298,8 @@ describe('fix', () => {
 
       const reportedItems = report.items.filter(
         (item) =>
+          item.analysisTarget.includes('src/gts-with-errors.gts') &&
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          item.analysisTarget.includes('src/gts/with-errors.gts') &&
           item.type == ReportItemType.glint
       );
 

--- a/packages/migration-graph/src/package-node.ts
+++ b/packages/migration-graph/src/package-node.ts
@@ -129,7 +129,7 @@ export class PackageNode {
       return true;
     }
     // this should be expanded to support export maps but its a bit of a nightmare
-    return !!(this.pkg.types || this.pkg.typings);
+    return !!(this.pkg.types || this.pkg.typings || this.pkg.typesVersions);
   }
 
   addFile(file: FileNode): void {

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -64,6 +64,7 @@ export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
       // We only allow for a single entry per line
       if (!lineHasSupression[location.startLine]) {
         if (diagnostic.source === 'glint') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           context.reporter.addGlintItemToRun(diagnostic, diagnostic.node, location, hint, helpUrl);
         } else {
           context.reporter.addTSItemToRun(diagnostic, diagnostic.node, location, hint, helpUrl);


### PR DESCRIPTION
This PR:

- includes `typesVersions` as a viable key for package.json types in the migration-graph PackageNode class.

```
"typesVersions": {
    "*": {
      "*": [
        "types/*"
      ]
    }
  }
```