### PR TITLE
fix: handle `@service() name` injection

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -113,7 +113,7 @@ declare booService: BooService;
   @service(\\"@some-org/some-package@mapped\\")
 declare something: Mapped;
 
-  @service
+  @service()
 declare gooService: GooService;
 
   @service
@@ -347,7 +347,7 @@ export default class SomeTsComponent extends Component {
   @service(\\"@some-org/some-package@mapped\\")
   declare something: Mapped;
 
-  @service
+  @service()
   declare gooService: GooService;
 
   @service

--- a/packages/migrate/test/fixtures/project/src/gts/with-mapped-service.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/with-mapped-service.gts
@@ -6,7 +6,7 @@ export default class TestWithMappedServiceGts extends Component {
 
   @service("@some-org/some-package@mapped") something;
 
-  @service gooService;
+  @service() gooService;
 
   @service mooService;
 

--- a/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
+++ b/packages/migrate/test/fixtures/project/src/with-mapped-service.ts
@@ -6,7 +6,7 @@ export default class SomeTsComponent extends Component {
 
   @service("@some-org/some-package@mapped") something;
 
-  @service gooService;
+  @service() gooService;
 
   @service mooService;
 }

--- a/packages/migration-graph/src/discover-services.ts
+++ b/packages/migration-graph/src/discover-services.ts
@@ -143,17 +143,22 @@ export function discoverServiceDependencies(serviceMap: Record<string, string>):
 
           if (!!maybeDecorator && isDecoratorWithExpressionTypeCallExpression(maybeDecorator)) {
             const callExpression = maybeDecorator.expression as CallExpression;
-            const arg = callExpression.arguments[0].expression as StringLiteral;
-            // someAddon@serviceName
 
-            if (serviceMap[arg.value]) {
-              return serviceMap[arg.value];
-            } else if (isFullyQualifiedService(arg.value)) {
-              const [packageName, serviceName] = parseFullyQualifiedService(arg.value);
-              return `${packageName}/services/${toKebabCase(serviceName)}`;
+            if (callExpression.arguments.length) {
+              const arg = callExpression.arguments[0].expression as StringLiteral;
+
+              if (serviceMap[arg.value]) {
+                return serviceMap[arg.value];
+              }
+
+              // someAddon@serviceName
+              if (isFullyQualifiedService(arg.value)) {
+                const [packageName, serviceName] = parseFullyQualifiedService(arg.value);
+                return `${packageName}/services/${toKebabCase(serviceName)}`;
+              }
+
+              return parseServiceMetaFromString(arg.value);
             }
-
-            return parseServiceMetaFromString(arg.value);
           }
         }
 
@@ -161,7 +166,9 @@ export function discoverServiceDependencies(serviceMap: Record<string, string>):
 
         if (serviceMap[keyName]) {
           return serviceMap[keyName];
-        } else if (isFullyQualifiedService(keyName)) {
+        }
+
+        if (isFullyQualifiedService(keyName)) {
           const [packageName, serviceName] = parseFullyQualifiedService(keyName);
           return `${packageName}/services/${toKebabCase(serviceName)}`;
         }

--- a/packages/migration-graph/test/discover-services.test.ts
+++ b/packages/migration-graph/test/discover-services.test.ts
@@ -203,18 +203,23 @@ describe('discoverServiceDependencies', () => {
       export default class Salutation extends Component {
         @service('authentication@authenticated-user') authenticatedUser;
         @service('@some-org/some-package@locale') myLocale;
-
+        @service() anotherService;
+        @service oneMoreService;
       }
     `;
 
     const results = discoverServiceDependencies({
       '@some-org/some-package@locale': 'foo/service/bar',
+      'anotherService': 'ano/service/ther',
+      'oneMoreService': 'one/service/more',
     })('ecmascript', content);
 
     expect(results).toBeTruthy();
-    expect(results.length).toBe(2);
+    expect(results.length).toBe(4);
     expect(results[0]).toBe('authentication/services/authenticated-user');
     expect(results[1]).toBe('foo/service/bar');
+    expect(results[2]).toBe('ano/service/ther');
+    expect(results[3]).toBe('one/service/more');
   });
 
   test('should ignore @classic decorator', () => {

--- a/packages/plugins/src/plugins/transform.plugin.ts
+++ b/packages/plugins/src/plugins/transform.plugin.ts
@@ -226,20 +226,17 @@ export class ServiceInjectionsTransformPlugin extends Plugin<ServiceInjectionsTr
   }
 
   getQualifiedServiceName(decorator: ts.Decorator, prop: ts.Node): string | undefined {
-    if (ts.isCallExpression(decorator.expression)) {
-      // Covers `@service('service-name')` and `@service('addon@service-name')`
-      if (decorator.expression.arguments.length) {
+    // Covers `@service('service-name')` and `@service('addon@service-name')`
+    if (ts.isCallExpression(decorator.expression) && decorator.expression.arguments.length) {
         const arg = decorator.expression.arguments[0];
         return ts.isStringLiteral(arg) ? arg.text : undefined;
-      }
-    } else {
-      // Covers `@service serviceName`
-      if (ts.isPropertyDeclaration(prop) && ts.isIdentifier(prop.name)) {
-        return this.toKebabCase(prop.name.escapedText.toString());
-      }
     }
 
-    // Covers @service() propName
+    // Covers `@service serviceName` and `@service() serviceName`
+    if (ts.isPropertyDeclaration(prop) && ts.isIdentifier(prop.name)) {
+        return this.toKebabCase(prop.name.escapedText.toString());
+    }
+
     return undefined;
   }
 


### PR DESCRIPTION
We currently handle next service injection cases:

- `@service('some@service') someService`
- `@service('service') someService`
- `@service someService`

this PR covers:

- `@service() someService`