### PR TITLE
fix(migration-graph): expand hasTypes to include typesVersions check

### DIFF
--- a/packages/cli/test/commands/graph/__snapshots__/graph.test.ts.snap
+++ b/packages/cli/test/commands/graph/__snapshots__/graph.test.ts.snap
@@ -15,6 +15,7 @@ exports[`Task: graphOrderTask > can print graph order to stdout 1`] = `
 [DATA] ./module-b/src/tires.js
 [DATA] ./module-b/src/car.js
 [DATA] ./module-b/src/index.js
+[DATA] ./module-c/src/index.js
 [SUCCESS] Analyzing project dependency graph"
 `;
 

--- a/packages/cli/test/commands/graph/graph.test.ts
+++ b/packages/cli/test/commands/graph/graph.test.ts
@@ -183,6 +183,17 @@ describe('Task: graphOrderTask', () => {
           },
         ],
       },
+      {
+        name: 'module-c',
+        external: false,
+        files: [
+          {
+            name: './module-c/src/index.js',
+            hasTypes: true,
+            edges: [],
+          },
+        ],
+      },
     ]);
   });
 

--- a/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
+++ b/packages/cli/test/commands/move/__snapshots__/move.test.ts.snap
@@ -82,6 +82,7 @@ exports[`Command: move > move packages based on the graph 1`] = `
 [DATA] git mv failed, using mv
 [DATA] git mv failed, using mv
 [DATA] git mv failed, using mv
+[DATA] git mv failed, using mv
 [DATA] renamed: 
 [DATA] ./src/index.js -> ./src/index.ts
 [DATA] ./src/foo/baz.js -> ./src/foo/baz.ts
@@ -94,6 +95,7 @@ exports[`Command: move > move packages based on the graph 1`] = `
 [DATA] ./module-b/src/tires.js -> ./module-b/src/tires.ts
 [DATA] ./module-b/src/car.js -> ./module-b/src/car.ts
 [DATA] ./module-b/src/index.js -> ./module-b/src/index.ts
+[DATA] ./module-c/src/index.js -> ./module-c/src/index.ts
 [SUCCESS] Executing git mv"
 `;
 

--- a/packages/cli/test/commands/move/move.test.ts
+++ b/packages/cli/test/commands/move/move.test.ts
@@ -82,6 +82,7 @@ describe('Command: move', () => {
     const projectSourceDir = resolve(project.baseDir);
     const tsSourceFiles = fastGlob.sync(`${projectSourceDir}/**/*.{ts,gts}`, {
       cwd: project.baseDir,
+      ignore: ['**/types/**'],
     });
 
     expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
@@ -94,6 +95,7 @@ describe('Command: move', () => {
       '/module-b/src/car.ts',
       '/module-b/src/index.ts',
       '/module-b/src/tires.ts',
+      '/module-c/src/index.ts',
       '/src/foo/baz.ts',
       '/src/foo/biz.ts',
       '/src/foo/e.gts',
@@ -109,6 +111,7 @@ describe('Command: move', () => {
     const projectSourceDir = resolve(project.baseDir);
     const tsSourceFiles = fastGlob.sync(`${projectSourceDir}/**/*.{ts,gts}`, {
       cwd: project.baseDir,
+      ignore: ['**/types/**'],
     });
 
     expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
@@ -129,6 +132,7 @@ describe('Command: move', () => {
     const projectSourceDir = resolve(project.baseDir);
     const tsSourceFiles = fastGlob.sync(`${projectSourceDir}/**/*.{ts,gts}`, {
       cwd: project.baseDir,
+      ignore: ['**/types/**'],
     });
 
     expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();
@@ -150,6 +154,7 @@ describe('Command: move', () => {
     const projectSourceDir = resolve(project.baseDir);
     const tsSourceFiles = fastGlob.sync(`${projectSourceDir}/**/*.{ts,gts}`, {
       cwd: project.baseDir,
+      ignore: ['**/types/**'],
     });
 
     expect(cleanOutput(result.stdout, project.baseDir)).toMatchSnapshot();

--- a/packages/cli/test/fixtures/base_js_app/module-c/package.json
+++ b/packages/cli/test/fixtures/base_js_app/module-c/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "module-c",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "path": "*"
+  },
+  "packageManager": "pnpm@7.12.1",
+  "typesVersions": {
+    "*": {
+      "*": ["types/*"]
+    }
+  }
+}

--- a/packages/cli/test/fixtures/base_js_app/module-c/src/index.js
+++ b/packages/cli/test/fixtures/base_js_app/module-c/src/index.js
@@ -1,0 +1,13 @@
+function getFullName(first, last) {
+  return `${first} ${last}`;
+}
+
+function getCharCountInName(str) {
+  return str.length;
+}
+
+
+export {
+  getFullName,
+  getCharCountInName
+}

--- a/packages/cli/test/fixtures/base_js_app/module-c/types/global.d.ts
+++ b/packages/cli/test/fixtures/base_js_app/module-c/types/global.d.ts
@@ -1,0 +1,7 @@
+declare module 'module-c' {
+  const moduleC: {
+    getFullName(f: string, l: string): string;
+    getCharCountInName(s: string): number;
+  };
+  export = moduleC;
+}

--- a/packages/migration-graph/src/package-node.ts
+++ b/packages/migration-graph/src/package-node.ts
@@ -129,7 +129,7 @@ export class PackageNode {
       return true;
     }
     // this should be expanded to support export maps but its a bit of a nightmare
-    return !!(this.pkg.types || this.pkg.typings);
+    return !!(this.pkg.types || this.pkg.typings || this.pkg.typesVersions);
   }
 
   addFile(file: FileNode): void {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -37,6 +37,7 @@
     "version": "pnpm version"
   },
   "dependencies": {
+    "@glint/core": "^1.0.2",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/utils": "workspace:*",
     "find-up": "^6.3.0",
@@ -50,7 +51,6 @@
     "vitest": "^0.30.0"
   },
   "peerDependencies": {
-    "@glint/core": "^1.0.2",
     "typescript": "^5.1"
   },
   "packageManager": "pnpm@8.2.0",


### PR DESCRIPTION
This PR:

includes typesVersions as a viable key for package.json types in the migration-graph PackageNode class.

```
"typesVersions": {
    "*": {
      "*": [
        "types/*"
      ]
    }
  }
```