### PR TITLE
feat: expose diagnostic fixing modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Options:
                          tests/**/*,types/**/*' (default: [])
   -f, --format <format>  report format separated by comma, e.g. -f json,sarif,md,sonarqube
                          (default: ["sarif"])
+  -m, --mode <mode>      the application of codefixes (choices: "drain", "single-pass",
+                         default: "drain")
   -h, --help             display help for command
 ```
 
@@ -277,7 +279,7 @@ rehearsal move . --ignore 'docs, vitest.*'
     ./test/main.test.js -> ./test/main.test.ts
 ```
 
-We've pointed Rehearsal at the root of our project `.`, ignored some files and directories and had Rehearsal `move` while leveraging the import graph. Our project is now partially migrated to TypeScript. Before we can continue to the next step of implementing types, we need to manually configure our project and install missing devDependencies. 
+We've pointed Rehearsal at the root of our project `.`, ignored some files and directories and had Rehearsal `move` while leveraging the import graph. Our project is now partially migrated to TypeScript. Before we can continue to the next step of implementing types, we need to manually configure our project and install missing devDependencies.
 
 ## Fix
 Let's run Rehearsal `fix` without doing this and see what happens.

--- a/Supported-Fixes.md
+++ b/Supported-Fixes.md
@@ -1,6 +1,6 @@
 # Supported CodeFixes
 
-The following 40 codefixes are supported by Rehearsal, which resolve 110 different TypeScript diagnostics errors.
+The following 39 codefixes are supported by Rehearsal, which resolve 103 different TypeScript diagnostics errors.
 
 ## Add Missing `async` Keyword
 
@@ -727,33 +727,6 @@ id: _strictClassInitialization_
 
 Fixes classes so they are initialized correctly.
 
-
-
-## Remove Unused Identifier
-
-id: _unusedIdentifier_
-
-Removes any unused identifiers.
-**Input:**
-
-```ts
-{
-  const o = { x: 1, y: 2 };
-  const { x, y } = o;
-  x;
-}
-
-```
-**Output:**
-
-```ts
-{
-  const o = { x: 1, y: 2 };
-  const { x } = o;
-  x;
-}
-
-```
 
 
 ## Use Default Import

--- a/packages/cli/src/commands/fix/command.ts
+++ b/packages/cli/src/commands/fix/command.ts
@@ -48,6 +48,11 @@ fixCommand
     ['sarif']
   )
   .addOption(
+    new Option('-m, --mode <mode>', `the application of codefixes`)
+      .choices(['drain', 'single-pass'])
+      .default('drain')
+  )
+  .addOption(
     new Option('--rootPath <project root directory>', '-- HIDDEN LOCAL DEV TESTING ONLY --')
       .default(process.cwd())
       .hideHelp()
@@ -73,11 +78,6 @@ async function fix(srcPath: string, options: FixCommandOptions): Promise<void> {
     // we don't want to try and fix JS files
     options.ignore.push(...javascriptGlobs);
   }
-
-  options.mode =
-    process.env['EXPERIMENTAL_MODES'] === 'drain'
-      ? process.env['EXPERIMENTAL_MODES']
-      : 'single-pass';
 
   // graph mode is default on in all instances. exception is for testing only with node process env variable "GRAPH_MODES=off"
   // source with a direct filepath ignores the migration graph

--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -13,14 +13,14 @@ exports[`Command: fix "base_ts_app" fixture > can fix starting with a directory 
 [DATA] processing file: /src/app.ts
 [DATA] processing file: /src/sub/grid.ts
 [TITLE] Types Inferred
-[TITLE]   17 errors caught by rehearsal
-[TITLE]   8 have been fixed by rehearsal
+[TITLE]   15 errors caught by rehearsal
+[TITLE]   6 have been fixed by rehearsal
 [TITLE]   9 errors need to be fixed manually
 [TITLE]     -- 4 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 5 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   17 errors caught by rehearsal
-[SUCCESS]   8 have been fixed by rehearsal
+[SUCCESS]   15 errors caught by rehearsal
+[SUCCESS]   6 have been fixed by rehearsal
 [SUCCESS]   9 errors need to be fixed manually
 [SUCCESS]     -- 4 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 5 eslint errors, with details in the report"
@@ -533,18 +533,18 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   31 errors caught by rehearsal
+[TITLE]   66 errors caught by rehearsal
 [TITLE]   2 have been fixed by rehearsal
-[TITLE]   29 errors need to be fixed manually
+[TITLE]   64 errors need to be fixed manually
 [TITLE]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 9 glint errors, with details in the report
+[TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   31 errors caught by rehearsal
+[SUCCESS]   66 errors caught by rehearsal
 [SUCCESS]   2 have been fixed by rehearsal
-[SUCCESS]   29 errors need to be fixed manually
+[SUCCESS]   64 errors need to be fixed manually
 [SUCCESS]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 9 glint errors, with details in the report
+[SUCCESS]     -- 44 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 
@@ -586,18 +586,18 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   26 errors caught by rehearsal
+[TITLE]   61 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
-[TITLE]   25 errors need to be fixed manually
+[TITLE]   60 errors need to be fixed manually
 [TITLE]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 9 glint errors, with details in the report
+[TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   26 errors caught by rehearsal
+[SUCCESS]   61 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
-[SUCCESS]   25 errors need to be fixed manually
+[SUCCESS]   60 errors need to be fixed manually
 [SUCCESS]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 9 glint errors, with details in the report
+[SUCCESS]     -- 44 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
 

--- a/packages/codefixes/src/codefixesMessages.json
+++ b/packages/codefixes/src/codefixesMessages.json
@@ -160,11 +160,6 @@
     "description": "Fixes classes so they are initialized correctly.",
     "diagnostics": [2564]
   },
-  "unusedIdentifier": {
-    "title": "Remove Unused Identifier",
-    "description": "Removes any unused identifiers.",
-    "diagnostics": [6133, 6196, 6138, 6192, 6198, 6199, 6205]
-  },
   "useDefaultImport": {
     "title": "Use Default Import",
     "description": "Converts namespaced import default imports.",

--- a/packages/codefixes/src/get-diagnostics.ts
+++ b/packages/codefixes/src/get-diagnostics.ts
@@ -5,6 +5,7 @@ import type { DiagnosticWithLocation } from 'typescript';
 const PRIORITIZED_CODES: number[] = [
   Diagnostics.TS80002.code,
   Diagnostics.TS80005.code,
+  Diagnostics.TS80009.code,
   Diagnostics.TS80004.code,
   Diagnostics.TS7005.code,
   Diagnostics.TS7006.code,

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -39,10 +39,7 @@ dummy.key;
 `;
 
 exports[`Test base codefixes > addMissingExport 1`] = `
-"// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations.
-import React from \\"react\\";
-
-export interface Props {
+"export interface Props {
   name: string;
   age: string;
 }
@@ -130,10 +127,7 @@ export default <P extends InjectedProps>(Component: React.ComponentType<P>) =>
 `;
 
 exports[`Test base codefixes > addMissingExport 4`] = `
-"// @ts-expect-error @rehearsal TODO TS2307: Cannot find module 'react' or its corresponding type declarations.
-import React from \\"react\\";
-
-import makeToDo, { AllProps } from \\"./4082-2-import\\";
+"import makeToDo, { AllProps } from \\"./4082-2-import\\";
 
 const ToDo = (props: AllProps) => {
   return (

--- a/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-1-import.tsx
+++ b/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-1-import.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface Props {
   name: string;
   age: string;

--- a/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-1.tsx
+++ b/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-1.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-
 import Kid from './4082-1-import';
 
 export default {
-    kid: Kid,
-    title: 'Kid',
-}
+  kid: Kid,
+  title: 'Kid',
+};

--- a/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-2.tsx
+++ b/packages/codefixes/test/fixtures/base-codefixes/addMissingExport/4082-2.tsx
@@ -1,21 +1,19 @@
-import React from 'react';
-
-import makeToDo, {AllProps} from './4082-2-import';
+import makeToDo, { AllProps } from './4082-2-import';
 
 const ToDo = (props: AllProps) => {
   return (
     <div style={props.style}>
-      {
-        props.todos.map((todo) => (
-          <div key={todo.id}>
-            <div>{todo.title}</div>
-            <div>{todo.content}</div>
-            <button data-id={todo.id} onClick={() => props.onRemove(todo.id)}>Remove</button>
-          </div>
-        ))
-      }
+      {props.todos.map((todo) => (
+        <div key={todo.id}>
+          <div>{todo.title}</div>
+          <div>{todo.content}</div>
+          <button data-id={todo.id} onClick={() => props.onRemove(todo.id)}>
+            Remove
+          </button>
+        </div>
+      ))}
       <button onClick={props.onAdd}>Add</button>
     </div>
-  )
-}
+  );
+};
 export default makeToDo(ToDo);

--- a/packages/codefixes/test/ts-codefixes.test.ts
+++ b/packages/codefixes/test/ts-codefixes.test.ts
@@ -238,15 +238,15 @@ describe('ts-codefixes', () => {
     );
   });
 
-  /*
-  test('requireInTs', async () => {
+  // Codefix disabled due to the issue, see https://github.com/rehearsal-js/rehearsal-js/issues/873
+  test.skip('requireInTs', async () => {
     await runTest('requireInTs/failing/fail-1.ts', 'requireInTs/passing/pass-1.ts', [
       'requireInTs/a.ts',
     ]);
   });
-   */
 
-  test('unusedIdentifier', async () => {
+  // Codefix disabled due to conflicts with others and confusion it makes in results
+  test.skip('unusedIdentifier', async () => {
     await runTest('unusedIdentifier/failing/fail-1.ts', 'unusedIdentifier/passing/pass-1.ts');
   });
 });

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -1,4 +1,4 @@
-import { DiagnosticWithContext, hints, getDiagnosticOrder } from '@rehearsal/codefixes';
+import { DiagnosticWithContext, hints } from '@rehearsal/codefixes';
 import { GlintService, PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
 import debug from 'debug';
@@ -83,9 +83,7 @@ export class GlintReportPlugin extends Plugin<GlintReportPluginOptions> {
     const program = languageService.getProgram()!;
     const checker = program.getTypeChecker();
 
-    const diagnostics = getDiagnosticOrder(service.getDiagnostics(fileName)).filter((d) =>
-      this.isErrorDiagnostic(d)
-    );
+    const diagnostics = service.getDiagnostics(fileName).filter((d) => this.isErrorDiagnostic(d));
 
     return diagnostics.reduce<DiagnosticWithLocation[]>((acc, diagnostic) => {
       const location = getLocation(diagnostic.file, diagnostic.start, diagnostic.length);

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -230,14 +230,14 @@ exports[`fix command > base_ts_app 1`] = `
 [DATA] processing file: /src/gen-random-grid.ts
 [DATA] processing file: /src/app.ts
 [TITLE] Types Inferred
-[TITLE]   12 errors caught by rehearsal
-[TITLE]   6 have been fixed by rehearsal
+[TITLE]   10 errors caught by rehearsal
+[TITLE]   4 have been fixed by rehearsal
 [TITLE]   6 errors need to be fixed manually
 [TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   12 errors caught by rehearsal
-[SUCCESS]   6 have been fixed by rehearsal
+[SUCCESS]   10 errors caught by rehearsal
+[SUCCESS]   4 have been fixed by rehearsal
 [SUCCESS]   6 errors need to be fixed manually
 [SUCCESS]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
@@ -479,18 +479,18 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
-[TITLE]   66 errors caught by rehearsal
-[TITLE]   3 have been fixed by rehearsal
-[TITLE]   63 errors need to be fixed manually
+[TITLE]   80 errors caught by rehearsal
+[TITLE]   6 have been fixed by rehearsal
+[TITLE]   74 errors need to be fixed manually
 [TITLE]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 36 glint errors, with details in the report
+[TITLE]     -- 47 glint errors, with details in the report
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   66 errors caught by rehearsal
-[SUCCESS]   3 have been fixed by rehearsal
-[SUCCESS]   63 errors need to be fixed manually
+[SUCCESS]   80 errors caught by rehearsal
+[SUCCESS]   6 have been fixed by rehearsal
+[SUCCESS]   74 errors need to be fixed manually
 [SUCCESS]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 36 glint errors, with details in the report
+[SUCCESS]     -- 47 glint errors, with details in the report
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
@@ -539,12 +539,11 @@ import Component from '@glimmer/component';
 const TWEET_INTENT = 'https://twitter.com/intent/tweet';
 
 export default class ShareButtonComponent extends Component {
-  // @ts-expect-error @rehearsal TODO TS2564: Property 'router' has no initializer and is not definitely assigned in the constructor.
-  @service router: { currentURL: string | URL };
-  // @ts-expect-error @rehearsal TODO TS2564: Property 'locale' has no initializer and is not definitely assigned in the constructor.
-  @service locale: { current: () => string };
+  @service router: { currentURL: string | URL } | undefined;
+  @service locale: { current: () => string } | undefined;
 
   get currentURL() {
+    // @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'.
     return new URL(this.router.currentURL, window.location.origin);
   }
 
@@ -572,6 +571,7 @@ export default class ShareButtonComponent extends Component {
       url.searchParams.set('via', this.args.via);
     }
 
+    // @ts-expect-error @rehearsal TODO TS2532: Object is possibly 'undefined'.
     url.searchParams.set('locale', this.locale.current());
 
     return url;
@@ -594,8 +594,7 @@ export default class RentalModel extends Model {
   @attr city;
   // @ts-expect-error @rehearsal TODO TS7008: Member 'location' implicitly has an 'any' type.
   @attr location;
-  // @ts-expect-error @rehearsal TODO TS2564: Property 'category' has no initializer and is not definitely assigned in the constructor.
-  @attr category: string;
+  @attr category: string | undefined;
   // @ts-expect-error @rehearsal TODO TS7008: Member 'image' implicitly has an 'any' type.
   @attr image;
   // @ts-expect-error @rehearsal TODO TS7008: Member 'bedrooms' implicitly has an 'any' type.
@@ -604,6 +603,7 @@ export default class RentalModel extends Model {
   @attr description;
 
   get type() {
+    // @ts-expect-error @rehearsal TODO TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '(this.category as string)', or using type guard: 'if (this.category instanceof string) { ... }'.
     if (COMMUNITY_CATEGORIES.includes(this.category)) {
       return 'Community';
     } else {
@@ -639,18 +639,18 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [DATA] processing file: /src/SimpleComponent.ts
 [DATA] processing file: /src/index.ts
 [TITLE] Types Inferred
-[TITLE]   17 errors caught by rehearsal
-[TITLE]   8 have been fixed by rehearsal
-[TITLE]   9 errors need to be fixed manually
+[TITLE]   27 errors caught by rehearsal
+[TITLE]   16 have been fixed by rehearsal
+[TITLE]   11 errors need to be fixed manually
 [TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 8 glint errors, with details in the report
+[TITLE]     -- 10 glint errors, with details in the report
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   17 errors caught by rehearsal
-[SUCCESS]   8 have been fixed by rehearsal
-[SUCCESS]   9 errors need to be fixed manually
+[SUCCESS]   27 errors caught by rehearsal
+[SUCCESS]   16 have been fixed by rehearsal
+[SUCCESS]   11 errors need to be fixed manually
 [SUCCESS]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 8 glint errors, with details in the report
+[SUCCESS]     -- 10 glint errors, with details in the report
 [SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
@@ -721,7 +721,6 @@ export default class HelloWorld extends Component {
   \`;
 }
 
-// @ts-expect-error @rehearsal TODO TS6196: 'IncrementableButtonSignature' is declared but never used.
 interface IncrementableButtonSignature {
   Args: {
     startCount: number;
@@ -756,7 +755,6 @@ const or = helper(
   ([a, b]) => a || b
 );
 
-// @ts-expect-error @rehearsal TODO TS6196: 'GreetingHeaderSignature' is declared but never used.
 interface GreetingHeaderSignature {
   Args: {
     greeting: string;


### PR DESCRIPTION
Add the `--mode` option to `fix` command. 
Makes `drain` default mode for fix.

PR includes next bug fixes and improvements:
- adds additional exit criteria to the loop of drain mode 
- prioritizes fix (TS80009) that converts typedefs to interfaces
- fixes "error fixed" report counter in drain mode
- fixes types of errors (suggestions) rehearsal is trying to fix in glint-fix plugin
- fixes the list of errors reported in glint-report plugin
- disables "Remove Unused Identifier" codefix