### PR TITLE
chore: insure the right version of pnpm is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
     "walk-sync": "^3.0.0"
   },
   "packageManager": "pnpm@8.6.7",
+  "engines": {
+    "pnpm": "8.6.7"
+  },
   "volta": {
     "node": "18.16.1"
   }


### PR DESCRIPTION
This should help dev to ensure that the right version of `pnpm` is used while both `corepack` (`packageManager`) and `volta` supports `pnpm` in experimental mode:

![image](https://github.com/rehearsal-js/rehearsal-js/assets/1502496/2b7d3270-e9ea-4f9b-aeff-b3ee1acbac04)
