### PR TITLE
fix: engines pnpm from pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "packageManager": "pnpm@8.6.7",
   "engines": {
-    "pnpm": "8.6.7"
+    "pnpm": ">=8.6"
   },
   "volta": {
     "node": "18.16.1"


### PR DESCRIPTION
This PR changes the pnpm engine to be a min vs a specific version. Otherwise the GH Action will fail as mismatch.