### PR TITLE
Test to demonstrate jsDoc overriding actual usage

### DIFF
--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -229,15 +229,16 @@ exports[`fix command > base_ts_app 1`] = `
 [DATA] processing file: /src/apply-rules.ts
 [DATA] processing file: /src/gen-random-grid.ts
 [DATA] processing file: /src/app.ts
+[DATA] processing file: /src/simple.ts
 [TITLE] Types Inferred
-[TITLE]   10 errors caught by rehearsal
-[TITLE]   4 have been fixed by rehearsal
+[TITLE]   14 errors caught by rehearsal
+[TITLE]   8 have been fixed by rehearsal
 [TITLE]   6 errors need to be fixed manually
 [TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   10 errors caught by rehearsal
-[SUCCESS]   4 have been fixed by rehearsal
+[SUCCESS]   14 errors caught by rehearsal
+[SUCCESS]   8 have been fixed by rehearsal
 [SUCCESS]   6 errors need to be fixed manually
 [SUCCESS]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
@@ -440,6 +441,24 @@ stdout.write('\\\\x1b[?25l');
     update(newGrid, runTally);
   }, 150);
 })(GRID_SEED);
+"
+`;
+
+exports[`fix command > base_ts_app 6`] = `
+"// no jsdoc for this function
+export function plusOneStr(a: number): string  {
+  const plusOne = a + 1;
+  return \`\${a} + 1 = \${plusOne}\`;
+}
+
+/**
+ * jsdoc is wrong/outdated for this function
+ * @return {number}
+ */
+export function plusTwoStr(a: number): number {
+  const plusTwo = a + 2;
+  return \`\${a} + 2 = \${plusTwo}\`;
+}
 "
 `;
 

--- a/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
@@ -26,6 +26,7 @@ exports[`graph command > base_ts_app 1`] = `
 [DATA] ./src/apply-rules.ts
 [DATA] ./src/gen-random-grid.ts
 [DATA] ./src/app.ts
+[DATA] ./src/simple.ts
 [SUCCESS] Analyzing project dependency graph"
 `;
 

--- a/packages/smoke-test/test/commands/fix.test.ts
+++ b/packages/smoke-test/test/commands/fix.test.ts
@@ -29,6 +29,7 @@ describe('fix command', () => {
     expectFile(join(projectRoot, 'src/apply-rules.ts')).toMatchSnapshot();
     expectFile(join(projectRoot, 'src/get-live-neighbor-count.ts')).toMatchSnapshot();
     expectFile(join(projectRoot, 'src/app.ts')).toMatchSnapshot();
+    expectFile(join(projectRoot, 'src/simple.ts')).toMatchSnapshot();
   });
 
   test('base_ts_app (file only)', async () => {

--- a/packages/smoke-test/test/fixtures/base_ts_app/src/simple.ts
+++ b/packages/smoke-test/test/fixtures/base_ts_app/src/simple.ts
@@ -1,0 +1,14 @@
+// no jsdoc for this function
+export function plusOneStr(a) {
+  const plusOne = a + 1;
+  return `${a} + 1 = ${plusOne}`;
+}
+
+/**
+ * jsdoc is wrong/outdated for this function
+ * @return {number}
+ */
+export function plusTwoStr(a) {
+  const plusTwo = a + 2;
+  return `${a} + 2 = ${plusTwo}`;
+}


### PR DESCRIPTION
I added a test to reproduce #1182.

The jsDoc specifies `number`, but the actual usage is `string`. Rehearsal can figure this out, because the same function without the jsDoc correctly infers `string` as the return type.