### PR TITLE
[chore] updated README so that docs for --skipChecks flag exist under info about rehearsal fix and not rehearsal move

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,6 @@ Options:
                             tests/**/*,types/**/*' (default: [])
   -d, --dryRun              do nothing; only show what would happen (default: false)
   -h, --help                display help for command'
-  --skipChecks [checks...]  skip specified pre-flights checks (not recommended), eg.
-                            --skipChecks eslint,deps
 ```
 
 This command performs a file rename (e.g. `.ts`, `.tsx`, `.gts`, `.mjs`) and git move against the targeted files in your project and will leverage the migration graph. Once this command has finished running, commit the changes and continue to the `fix` command.

--- a/README.md
+++ b/README.md
@@ -210,15 +210,17 @@ Arguments:
 
 
 Options:
-  --graph                fixing all file(s) within the graph, which might include files
-                         outside of the current directory
-  --ignore [globs...]    comma-delimited list of globs to ignore eg. '--ignore
-                         tests/**/*,types/**/*' (default: [])
-  -f, --format <format>  report format separated by comma, e.g. -f json,sarif,md,sonarqube
-                         (default: ["sarif"])
-  -m, --mode <mode>      the application of codefixes (choices: "drain", "single-pass",
-                         default: "drain")
-  -h, --help             display help for command
+  --graph                   fixing all file(s) within the graph, which might include files
+                            outside of the current directory
+  --ignore [globs...]       comma-delimited list of globs to ignore eg. '--ignore
+                            tests/**/*,types/**/*' (default: [])
+  -f, --format <format>     report format separated by comma, e.g. -f json,sarif,md,sonarqube
+                            (default: ["sarif"])
+  -m, --mode <mode>         the application of codefixes (choices: "drain", "single-pass",
+                            default: "drain")
+  -h, --help                display help for command
+  --skipChecks [checks...]  skip specified pre-flights checks (not recommended), eg.
+                            --skipChecks eslint,deps
 ```
 
 This command will run against a TypeScript project and infer types for you. There's a lot going on under the hood here!


### PR DESCRIPTION
PR #1178 introduced an issue with the README.  The `--skipChecks` docs are added to the wrong command.  This fixes that issue.