### PR TITLE
feat: stubMissingNameJSDocParam

### DIFF
--- a/packages/codefixes/src/codefixes.ts
+++ b/packages/codefixes/src/codefixes.ts
@@ -11,7 +11,7 @@ import { AddMissingTypesBasedOnInlayHintsCodeFix } from './fixes/addMissingTypes
 import { AnnotateWithStrictTypeFromJSDoc } from './fixes/annotateWithStrictTypeFromJSDoc.js';
 import { GlintCodeFixCollection } from './glint-codefix-collection.js';
 import { MakeMemberOptionalCodeFix } from './fixes/makeMemberOptional.js';
-import { StubMissingNameJSDocParam } from './fixes/stubMissingNameJSDocParam.js';
+import { StubMissingJSDocParamName } from './fixes/stubMissingJSDocParamName.js';
 import type { CodeFixAction } from 'typescript';
 
 export const codefixes = new CodeFixesProvider([
@@ -22,6 +22,7 @@ export const codefixes = new CodeFixesProvider([
     new AddMissingTypesBasedOnInlayHintsCodeFix(),
     new AnnotateWithStrictTypeFromJSDoc(),
     new MakeMemberOptionalCodeFix(),
+    new StubMissingJSDocParamName(),
   ]),
   new TypescriptCodeFixCollection(),
 ]);
@@ -29,7 +30,7 @@ export const codefixes = new CodeFixesProvider([
 export const glintCodeFixes = new CodeFixesProvider([
   new GlintCodeFixCollection(),
   new BaseCodeFixCollection([
-    new StubMissingNameJSDocParam(),
+    new StubMissingJSDocParamName(),
     // Need to be run after standard "typedef to type" fix applied
     new AddMissingArgToComponentSignature(),
   ]),

--- a/packages/codefixes/src/codefixes.ts
+++ b/packages/codefixes/src/codefixes.ts
@@ -11,6 +11,7 @@ import { AddMissingTypesBasedOnInlayHintsCodeFix } from './fixes/addMissingTypes
 import { AnnotateWithStrictTypeFromJSDoc } from './fixes/annotateWithStrictTypeFromJSDoc.js';
 import { GlintCodeFixCollection } from './glint-codefix-collection.js';
 import { MakeMemberOptionalCodeFix } from './fixes/makeMemberOptional.js';
+import { StubMissingNameJSDocParam } from './fixes/stubMissingNameJSDocParam.js';
 import type { CodeFixAction } from 'typescript';
 
 export const codefixes = new CodeFixesProvider([
@@ -28,6 +29,7 @@ export const codefixes = new CodeFixesProvider([
 export const glintCodeFixes = new CodeFixesProvider([
   new GlintCodeFixCollection(),
   new BaseCodeFixCollection([
+    new StubMissingNameJSDocParam(),
     // Need to be run after standard "typedef to type" fix applied
     new AddMissingArgToComponentSignature(),
   ]),

--- a/packages/codefixes/src/fixes/stubMissingJSDocParamName.ts
+++ b/packages/codefixes/src/fixes/stubMissingJSDocParamName.ts
@@ -6,15 +6,14 @@ import { Diagnostics } from '../diagnosticInformationMap.generated.js';
 import type { CodeFix, DiagnosticWithContext } from '../types.js';
 
 function createUniqueIdentifier(data: string): string {
-  const hash = createHash('md5').update(data).digest('base64');
+  const hash = createHash('md5').update(data).digest('hex');
   return hash.substring(0, 6);
 }
 
-export class StubMissingNameJSDocParam implements CodeFix {
+export class StubMissingJSDocParamName implements CodeFix {
   getErrorCodes = (): number[] => [Diagnostics.TS8024.code];
 
   getCodeAction(diagnostic: DiagnosticWithContext): CodeFixAction | undefined {
-    const fileName = diagnostic.file.fileName;
     const originalStart = diagnostic.start;
     const originalEnd = originalStart + diagnostic.length;
     const content = diagnostic.file.getFullText(diagnostic.file);
@@ -23,13 +22,15 @@ export class StubMissingNameJSDocParam implements CodeFix {
       return;
     }
 
-    const uniqueIdentifier = createUniqueIdentifier(
-      `${fileName}-${content}-${originalStart}-${originalEnd}`
-    );
+    const uniqueIdentifier = createUniqueIdentifier(`${content}-${originalStart}-${originalEnd}`);
 
     const changes: [ts.FileTextChanges] = [
       // Augment the SuperClass signature first as it's lower in the file
-      ChangesFactory.insertText(diagnostic.file, originalStart, `unnamedParam${uniqueIdentifier}`),
+      ChangesFactory.insertText(
+        diagnostic.file,
+        originalStart,
+        `unnamedParam_${uniqueIdentifier} `
+      ),
     ];
 
     return createCodeFixAction(

--- a/packages/codefixes/src/fixes/stubMissingJSDocParamName.ts
+++ b/packages/codefixes/src/fixes/stubMissingJSDocParamName.ts
@@ -36,7 +36,7 @@ export class StubMissingJSDocParamName implements CodeFix {
     return createCodeFixAction(
       'stubMissingNameJSDocParam',
       changes,
-      'adds a unique name to the unamed JSDoc @param'
+      'adds a unique name to the unnamed JSDoc @param'
     );
   }
 }

--- a/packages/codefixes/src/fixes/stubMissingNameJSDocParam.ts
+++ b/packages/codefixes/src/fixes/stubMissingNameJSDocParam.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+import ts, { CodeFixAction } from 'typescript';
+import { ChangesFactory } from '@rehearsal/ts-utils';
+import { createCodeFixAction } from '../hints-codefix-collection.js';
+import { Diagnostics } from '../diagnosticInformationMap.generated.js';
+import type { CodeFix, DiagnosticWithContext } from '../types.js';
+
+function createUniqueIdentifier(data: string): string {
+  const hash = createHash('md5').update(data).digest('base64');
+  return hash.substring(0, 6);
+}
+
+export class StubMissingNameJSDocParam implements CodeFix {
+  getErrorCodes = (): number[] => [Diagnostics.TS8024.code];
+
+  getCodeAction(diagnostic: DiagnosticWithContext): CodeFixAction | undefined {
+    const fileName = diagnostic.file.fileName;
+    const originalStart = diagnostic.start;
+    const originalEnd = originalStart + diagnostic.length;
+    const content = diagnostic.file.getFullText(diagnostic.file);
+
+    if (originalStart !== originalEnd) {
+      return;
+    }
+
+    const uniqueIdentifier = createUniqueIdentifier(
+      `${fileName}-${content}-${originalStart}-${originalEnd}`
+    );
+
+    const changes: [ts.FileTextChanges] = [
+      // Augment the SuperClass signature first as it's lower in the file
+      ChangesFactory.insertText(diagnostic.file, originalStart, `unnamedParam${uniqueIdentifier}`),
+    ];
+
+    return createCodeFixAction(
+      'stubMissingNameJSDocParam',
+      changes,
+      'adds a unique name to the unamed JSDoc @param'
+    );
+  }
+}

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -728,3 +728,23 @@ const oak: Tree = {
 delete oak.height;
 "
 `;
+
+exports[`Test base codefixes > stubMissingJSDocParamName 1`] = `
+"export class Something {
+  /**
+   * @param {Event} unnamedParam_4a0b63 -- Something
+   * @param {string} unnamedParam_3544a2 -- Another
+   * @param {*} unnamedParam_f10fcb -- I don't know
+   */
+
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args): void {
+    console.log(args);
+  }
+
+  shouldExist(): void {
+    console.log(\\"should exist in output\\");
+  }
+}
+"
+`;

--- a/packages/codefixes/test/fixtures/base-codefixes/stubMissingJSDocParamName/8024-jsdoc-missing-param-name.ts
+++ b/packages/codefixes/test/fixtures/base-codefixes/stubMissingJSDocParamName/8024-jsdoc-missing-param-name.ts
@@ -1,0 +1,15 @@
+export class Something {
+  /**
+   * @param {Event} -- Something
+   * @param {string} -- Another
+   * @param {*} -- I don't know
+   */
+
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log('should exist in output');
+  }
+}

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -111,6 +111,84 @@ export default class WithMissingInterface extends Component<WithMissingInterface
 "
 `;
 
+exports[`fix > .gts > component signature codefix > with misssing jsdoc param name 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+export class Something extends Component {
+  /** */
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log(\\"should exist in output\\");
+  }
+}
+"
+`;
+
+exports[`fix > .gts > component signature codefix > with typedef for component signature interface 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+export interface RepeatSignature {
+  Args: { phrase: any };
+}
+
+//
+// UseCase: Should generate a component signature interface
+//
+
+export class Repeat extends Component<RepeatSignature> {
+  <template>
+    <span>{{@phrase}}</span>
+  </template>
+}
+
+//
+// UseCase: Should infer relationship from comment, update heritage clause with signature
+//
+
+interface MyComponentSignature {
+  Args: { snack: any; age: any };
+}
+
+/**
+ * @extends {Component<MyComponentSignature>}
+ */
+export class MyComponent extends Component<MyComponentSignature> {
+  name = \\"Bob\\";
+
+  <template>
+    <Repeat @phrase={{@age}} />
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+    <span>My favorite snack is {{@snack}}.</span>
+  </template>
+}
+
+//
+// UseCase: Should generate an interface from all comments
+//
+
+interface InterfaceFromCommentSignature {
+  Args: InterfaceFromCommentArgs;
+}
+
+interface InterfaceFromCommentArgs {
+  someArg: number;
+}
+
+/**
+ * @extends {Component<InterfaceFromCommentSignature>}
+ */
+export class Something extends Component<InterfaceFromCommentSignature> {
+  <template>
+    <span>{{@someArg}}</span>
+  </template>
+}
+"
+`;
+
 exports[`fix > .gts > component signature codefix > with-typedef for component signature interface 1`] = `
 "import Component from \\"@glimmer/component\\";
 
@@ -181,6 +259,41 @@ export default class TestGjsNoErrors extends Component {
   <template>
     <span>Hello, I am {{this.name}}!</span>
   </template>
+}
+"
+`;
+
+exports[`fix > .gts > strips jsdoc param with missing name 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+export class Something extends Component {
+  /** */
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log(\\"should exist in output\\");
+  }
+}
+"
+`;
+
+exports[`fix > .gts > strips jsdoc param with missing name 2`] = `
+"import Component from \\"@glimmer/component\\";
+
+export class Something extends Component {
+  /** */
+
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log(\\"should exist in output\\");
+  }
 }
 "
 `;

--- a/packages/migrate/test/fixtures/project/src/gts/with-missing-jsdoc-param-name.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/with-missing-jsdoc-param-name.gts
@@ -1,0 +1,17 @@
+import Component from "@glimmer/component";
+
+export class Something extends Component {
+  /**
+   * @param {Event} -- Something
+   * @param {string} -- Another
+   * @param {*} -- I don't know
+   */
+
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log("should exist in output");
+  }
+}


### PR DESCRIPTION
This PR addresses #1192 

## Summary

There is a use case in an internal app where a JSDoc `@param` is defined but has no variable name. This creates a case where we inject a rehearsal TODO into the doc block, and subsequent invocations of `rehearsal fix` will mangle the file after the affected region.

## Root Cause

Transforming a doc block with this will cause a second pass with fix to mangle the output of the file there after.

```diff
  /**
+   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {Event} -- Something
+   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {string} -- Another
+   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {*} -- I don't know
   */
```

## Details

The type error we have is `TS8024`, is for a JSDoc Param name that doesn’t appear in the scope of the function.

Use Case

```typescript
  /**
   * This action is yielded to the consumer to allow them to
   * set/reset the keywords based on some user action. The primary
   * use case intended is for an input clear button.
   *
   * @param {Event} -- Optional DOM event passed when action is bound to event element attribute
   * @param {string} -- Optional value to reset keywords to
   * @param {*} -- Optional value to reset selection state to
   */
  @action
  reset(...args) {
    const firstArg = args[0];
    let resetArgs;

    // the first argument may be an event if
    // the action is bound to an event attribute
    // if that's the case we don't want to include
    // the event in the args passed to `this.reset`
    if (firstArg instanceof window.Event) {
      resetArgs = args.slice(1);
    } else {
      resetArgs = args;
    }

    this._reset(...resetArgs);
  }
```

```typescript
import Component from '@glimmer/component';

export class Something extends Component {
  /**
   * @param {Event} -- Something
   * @param {string} -- Another
   * @param {*} -- I don't know
   */
  reset(...args) {
    console.log(args);
  }

  shouldExist() {
    console.log('should exist in output');
  }
}
```

```typescript
import Component from '@glimmer/component';

export class Something extends Component {
  /**
   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {Event} -- Something
   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {string} -- Another
   // @ts-expect-error @rehearsal TODO TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
   * @param {*} -- I don't know
   */
  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
  reset(...args) {
    console.log(args);
  }

  shouldExist() {
    console.log('should exist in output');
  }
}
```

When ever a rehearsal todo like above is injected into a doc block subsequent applications of `fix` mangle the file to look like:

```typescript
import Component from "@glimmer/component";

export class Something extends Component {
```

## Solution

Stubbing the missing parameter name will trigger the unused argument codefix as it’s able to check for the value in scope and remove the unused param.

With stubbing the argument to something like `@param Event unnamedParam_sha123`

## Alternatives

### Adding `eslint-plugin-jsdoc` can help with general JSDoc errors

This works for some errors, but not in our use case.

https://github.com/gajus/eslint-plugin-jsdoc#readme

For something like:

```
  /**
   * @param {Event} -- Something
   * @param {string} -- Another
   * @param {*} -- I don't know
   */
```

eslint naively sees `--` as the param name, and sees those entries as duplicates.

```
   4:1  warning  Duplicate @param "--"     jsdoc/check-param-names
```

### Use existing AnnotateWithStrictTypeFromJSDoc CodeFix to `.gts` files

That CodeFix does apply to the error we are trying to suppress.
