### PR TITLE
fix: import types when infer from inheritance

### DIFF
--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInheritance.ts
@@ -138,7 +138,7 @@ export class AddMissingTypesBasedOnInheritanceCodeFix implements CodeFix {
 
         // Skipping "non-strict types"
         if (!type || type === 'any' || type === 'object') {
-          // If the type was too loose but we have an accesortor of the current class
+          // If the type was too loose, but we have an ancestor of the current class
           // recurse with the parent
           const parentClassMethod = findAncestor(
             ancestorMethodSymbol.declarations?.[0],

--- a/packages/codefixes/src/get-diagnostics.ts
+++ b/packages/codefixes/src/get-diagnostics.ts
@@ -3,10 +3,25 @@ import { SUPPORTED_DIAGNOSTICS } from './safe-codefixes.js';
 import type { DiagnosticWithLocation } from 'typescript';
 
 const PRIORITIZED_CODES: number[] = [
-  Diagnostics.TS80002.code,
+  // Convert `require` to `import`
   Diagnostics.TS80005.code,
+
+  // Fix missing imports
+  Diagnostics.TS1361.code,
+  Diagnostics.TS18004.code,
+  Diagnostics.TS2304.code,
+  Diagnostics.TS2503.code,
+  Diagnostics.TS2552.code,
+  Diagnostics.TS2662.code,
+  Diagnostics.TS2663.code,
+  Diagnostics.TS2686.code,
+  Diagnostics.TS2693.code,
+
+  // Infer types from JSDoc
   Diagnostics.TS80009.code,
   Diagnostics.TS80004.code,
+
+  // Infer types from usage
   Diagnostics.TS7005.code,
   Diagnostics.TS7006.code,
   Diagnostics.TS7008.code,
@@ -16,7 +31,11 @@ const PRIORITIZED_CODES: number[] = [
   Diagnostics.TS7045.code,
   Diagnostics.TS7046.code,
   Diagnostics.TS7050.code,
+
+  Diagnostics.TS80002.code,
+
   Diagnostics.TS2612.code,
+
   Diagnostics.TS4073.code,
 ];
 

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -658,6 +658,50 @@ exports[`fix > RehearsalService > EXPERIMENTAL_MODES mode: single-pass 1`] = `
 "
 `;
 
+exports[`fix > RehearsalService > import type after infer it from hierarchy 1`] = `
+"import { Food } from \\"./basic.food\\";
+
+export class Animal {
+  say(message: string): string {
+    return message;
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return false;
+  }
+}
+"
+`;
+
+exports[`fix > RehearsalService > import type after infer it from hierarchy 2`] = `
+"export class Food {
+  title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}
+"
+`;
+
+exports[`fix > RehearsalService > import type after infer it from hierarchy 3`] = `
+"import { Animal } from \\"./basic.animal\\";
+import { Food } from \\"./basic.food\\";
+
+export class Dog extends Animal {
+  say(message: string): string {
+    console.log(message);
+    return \\"bar\\";
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    return super.feed(food, quantity);
+  }
+}
+"
+`;
+
 exports[`fix > RehearsalService > more errors 1`] = `
 "export default class MyComponent {
   // @ts-expect-error @rehearsal TODO TS6133: The parameter 'a' is never used. Remove the parameter from function definition or use it.

--- a/packages/migrate/test/fixtures/project-basic/src/basic.animal.ts
+++ b/packages/migrate/test/fixtures/project-basic/src/basic.animal.ts
@@ -1,0 +1,12 @@
+import { Food } from './basic.food';
+
+export class Animal {
+  say(message: string): string {
+    return message;
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return false;
+  }
+}

--- a/packages/migrate/test/fixtures/project-basic/src/basic.food.ts
+++ b/packages/migrate/test/fixtures/project-basic/src/basic.food.ts
@@ -1,0 +1,7 @@
+export class Food {
+  title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}

--- a/packages/migrate/test/fixtures/project-basic/src/basic.index.ts
+++ b/packages/migrate/test/fixtures/project-basic/src/basic.index.ts
@@ -1,0 +1,12 @@
+import { Animal } from './basic.animal';
+
+export class Dog extends Animal {
+  say(message) {
+    console.log(message);
+    return 'bar';
+  }
+
+  feed(food, quantity) {
+    return super.feed(food, quantity);
+  }
+}

--- a/packages/migrate/test/fixtures/project-basic/tsconfig.json
+++ b/packages/migrate/test/fixtures/project-basic/tsconfig.json
@@ -15,6 +15,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "rootDir": ".",
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2017",

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -1207,6 +1207,7 @@ export default class LocaleService extends Service {
         packageDir: project.baseDir,
         filesToMigrate: inputs,
         reporter,
+        mode: 'drain',
       };
 
       for await (const _ of migrate(input)) {
@@ -1214,6 +1215,35 @@ export default class LocaleService extends Service {
       }
 
       expectFile(outputs[0]).toMatchSnapshot();
+    });
+
+    test('import type after infer it from hierarchy', async () => {
+      const [inputs, outputs] = prepareInputFiles(project, [
+        'basic.animal.ts',
+        'basic.food.ts',
+        'basic.index.ts',
+      ]);
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: project.baseDir,
+        filesToMigrate: inputs,
+        reporter,
+        mode: 'drain',
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[2]).contains('import { Food }');
+      expectFile(outputs[2]).contains('./basic.food');
+      expectFile(outputs[2]).contains('say(message: string): string');
+      expectFile(outputs[2]).contains('feed(food: Food, quantity: number): boolean');
+
+      expectFile(outputs[0]).toMatchSnapshot();
+      expectFile(outputs[1]).toMatchSnapshot();
+      expectFile(outputs[2]).toMatchSnapshot();
     });
   });
 });

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -229,15 +229,18 @@ exports[`fix command > base_ts_app 1`] = `
 [DATA] processing file: /src/apply-rules.ts
 [DATA] processing file: /src/gen-random-grid.ts
 [DATA] processing file: /src/app.ts
+[DATA] processing file: /src/basic.animal.ts
+[DATA] processing file: /src/basic.food.ts
+[DATA] processing file: /src/basic.index.ts
 [TITLE] Types Inferred
-[TITLE]   10 errors caught by rehearsal
-[TITLE]   4 have been fixed by rehearsal
+[TITLE]   18 errors caught by rehearsal
+[TITLE]   12 have been fixed by rehearsal
 [TITLE]   6 errors need to be fixed manually
 [TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   10 errors caught by rehearsal
-[SUCCESS]   4 have been fixed by rehearsal
+[SUCCESS]   18 errors caught by rehearsal
+[SUCCESS]   12 have been fixed by rehearsal
 [SUCCESS]   6 errors need to be fixed manually
 [SUCCESS]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 0 eslint errors, with details in the report"
@@ -440,6 +443,50 @@ stdout.write('\\\\x1b[?25l');
     update(newGrid, runTally);
   }, 150);
 })(GRID_SEED);
+"
+`;
+
+exports[`fix command > base_ts_app 6`] = `
+"import { Food } from './basic.food';
+
+export class Animal {
+  say(message: string): string {
+    return message;
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return false;
+  }
+}
+"
+`;
+
+exports[`fix command > base_ts_app 7`] = `
+"export class Food {
+  title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}
+"
+`;
+
+exports[`fix command > base_ts_app 8`] = `
+"import { Animal } from './basic.animal';
+    import { Food } from './basic.food';
+
+export class Dog extends Animal {
+  override say(message: string) : string {
+    console.log(message);
+    return 'bar';
+  }
+
+  override feed(food: Food, quantity: number) : boolean {
+    return super.feed(food, quantity);
+  }
+}
 "
 `;
 

--- a/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
@@ -26,6 +26,9 @@ exports[`graph command > base_ts_app 1`] = `
 [DATA] ./src/apply-rules.ts
 [DATA] ./src/gen-random-grid.ts
 [DATA] ./src/app.ts
+[DATA] ./src/basic.animal.ts
+[DATA] ./src/basic.food.ts
+[DATA] ./src/basic.index.ts
 [SUCCESS] Analyzing project dependency graph"
 `;
 

--- a/packages/smoke-test/test/commands/fix.test.ts
+++ b/packages/smoke-test/test/commands/fix.test.ts
@@ -29,6 +29,9 @@ describe('fix command', () => {
     expectFile(join(projectRoot, 'src/apply-rules.ts')).toMatchSnapshot();
     expectFile(join(projectRoot, 'src/get-live-neighbor-count.ts')).toMatchSnapshot();
     expectFile(join(projectRoot, 'src/app.ts')).toMatchSnapshot();
+    expectFile(join(projectRoot, 'src/basic.animal.ts')).toMatchSnapshot();
+    expectFile(join(projectRoot, 'src/basic.food.ts')).toMatchSnapshot();
+    expectFile(join(projectRoot, 'src/basic.index.ts')).toMatchSnapshot();
   });
 
   test('base_ts_app (file only)', async () => {

--- a/packages/smoke-test/test/fixtures/base_ts_app/src/basic.animal.ts
+++ b/packages/smoke-test/test/fixtures/base_ts_app/src/basic.animal.ts
@@ -1,0 +1,12 @@
+import { Food } from './basic.food';
+
+export class Animal {
+  say(message: string): string {
+    return message;
+  }
+
+  feed(food: Food, quantity: number): boolean {
+    console.log(food, quantity);
+    return false;
+  }
+}

--- a/packages/smoke-test/test/fixtures/base_ts_app/src/basic.food.ts
+++ b/packages/smoke-test/test/fixtures/base_ts_app/src/basic.food.ts
@@ -1,0 +1,7 @@
+export class Food {
+  title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}

--- a/packages/smoke-test/test/fixtures/base_ts_app/src/basic.index.ts
+++ b/packages/smoke-test/test/fixtures/base_ts_app/src/basic.index.ts
@@ -1,0 +1,12 @@
+import { Animal } from './basic.animal';
+
+export class Dog extends Animal {
+  say(message) {
+    console.log(message);
+    return 'bar';
+  }
+
+  feed(food, quantity) {
+    return super.feed(food, quantity);
+  }
+}


### PR DESCRIPTION
Prioritize "Fixes missing imports" error codes to make sure we don't have missing types before start types inferring process.

This helps to solve the issue when type are inferred from inheritance or from inlay type hints without been imported. The type will be imported next cycle (in drain mode) and the rest of codefixes expected to be applied without issues. 

Also fixes: 
- module resolutions on case-insensitive filesystems

Fixes https://github.com/rehearsal-js/rehearsal-js/issues/1187