### PR TITLE
fix: suppress issue with a type detection in inferFromUsage codefix

### DIFF
--- a/packages/codefixes/src/typescript-codefix-collection.ts
+++ b/packages/codefixes/src/typescript-codefix-collection.ts
@@ -34,6 +34,10 @@ const SUPPRESSED_ERRORS: SuppressedError[] = [
     code: Diagnostics.TS2345.code,
     message: `Cannot read properties of undefined (reading 'flags')`,
   },
+  {
+    code: Diagnostics.TS7006.code,
+    message: `Debug Failure`,
+  },
 ];
 
 /**


### PR DESCRIPTION
Suppress the error happening during getCodeFixesAtPosition for TS7006 when TypeScript is struggling to detect the type.

The issues is happening during processing this kind of content:

```
import Route from '@ember/routing/route';

export default class BaseRoute extends Route {
  setupController(controller, params) {
    super.setupController(controller, params);
  }
}
```