### PR TITLE
fix: Glint Service is not inferring return types from inlay hints

### DIFF
--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -533,15 +533,15 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   66 errors caught by rehearsal
-[TITLE]   2 have been fixed by rehearsal
+[TITLE]   69 errors caught by rehearsal
+[TITLE]   5 have been fixed by rehearsal
 [TITLE]   64 errors need to be fixed manually
 [TITLE]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   66 errors caught by rehearsal
-[SUCCESS]   2 have been fixed by rehearsal
+[SUCCESS]   69 errors caught by rehearsal
+[SUCCESS]   5 have been fixed by rehearsal
 [SUCCESS]   64 errors need to be fixed manually
 [SUCCESS]     -- 18 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 44 glint errors, with details in the report
@@ -586,15 +586,15 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [DATA] processing file: /app/pods/components/baz/component.ts
 [DATA] processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
-[TITLE]   61 errors caught by rehearsal
-[TITLE]   1 have been fixed by rehearsal
+[TITLE]   63 errors caught by rehearsal
+[TITLE]   3 have been fixed by rehearsal
 [TITLE]   60 errors need to be fixed manually
 [TITLE]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   61 errors caught by rehearsal
-[SUCCESS]   1 have been fixed by rehearsal
+[SUCCESS]   63 errors caught by rehearsal
+[SUCCESS]   3 have been fixed by rehearsal
 [SUCCESS]   60 errors need to be fixed manually
 [SUCCESS]     -- 14 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 44 glint errors, with details in the report

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -111,85 +111,7 @@ export default class WithMissingInterface extends Component<WithMissingInterface
 "
 `;
 
-exports[`fix > .gts > component signature codefix > with misssing jsdoc param name 1`] = `
-"import Component from \\"@glimmer/component\\";
-
-export class Something extends Component {
-  /** */
-  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
-  reset(...args) {
-    console.log(args);
-  }
-
-  shouldExist() {
-    console.log(\\"should exist in output\\");
-  }
-}
-"
-`;
-
 exports[`fix > .gts > component signature codefix > with typedef for component signature interface 1`] = `
-"import Component from \\"@glimmer/component\\";
-
-export interface RepeatSignature {
-  Args: { phrase: any };
-}
-
-//
-// UseCase: Should generate a component signature interface
-//
-
-export class Repeat extends Component<RepeatSignature> {
-  <template>
-    <span>{{@phrase}}</span>
-  </template>
-}
-
-//
-// UseCase: Should infer relationship from comment, update heritage clause with signature
-//
-
-interface MyComponentSignature {
-  Args: { snack: any; age: any };
-}
-
-/**
- * @extends {Component<MyComponentSignature>}
- */
-export class MyComponent extends Component<MyComponentSignature> {
-  name = \\"Bob\\";
-
-  <template>
-    <Repeat @phrase={{@age}} />
-    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
-    <span>My favorite snack is {{@snack}}.</span>
-  </template>
-}
-
-//
-// UseCase: Should generate an interface from all comments
-//
-
-interface InterfaceFromCommentSignature {
-  Args: InterfaceFromCommentArgs;
-}
-
-interface InterfaceFromCommentArgs {
-  someArg: number;
-}
-
-/**
- * @extends {Component<InterfaceFromCommentSignature>}
- */
-export class Something extends Component<InterfaceFromCommentSignature> {
-  <template>
-    <span>{{@someArg}}</span>
-  </template>
-}
-"
-`;
-
-exports[`fix > .gts > component signature codefix > with-typedef for component signature interface 1`] = `
 "import Component from \\"@glimmer/component\\";
 
 export interface RepeatSignature {
@@ -268,11 +190,12 @@ exports[`fix > .gts > strips jsdoc param with missing name 1`] = `
 
 export class Something extends Component {
   /** */
-  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'reset' lacks a return-type annotation.
   reset(...args) {
     console.log(args);
   }
 
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'shouldExist' lacks a return-type annotation.
   shouldExist() {
     console.log(\\"should exist in output\\");
   }
@@ -286,11 +209,12 @@ exports[`fix > .gts > strips jsdoc param with missing name 2`] = `
 export class Something extends Component {
   /** */
 
-  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'reset' lacks a return-type annotation.
   reset(...args) {
     console.log(args);
   }
 
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'shouldExist' lacks a return-type annotation.
   shouldExist() {
     console.log(\\"should exist in output\\");
   }
@@ -366,6 +290,7 @@ export default class MyComponent {
     b = 2;
   }
 
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'containsUnsupportedDiagnostic' lacks a return-type annotation.
   containsUnsupportedDiagnostic() {
     return function () {
       // @ts-expect-error @rehearsal TODO TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
@@ -687,10 +612,11 @@ export default class SomeComponent extends Component {
   declare mooService: MooService;
 
   // Has to be fixes, but no additional import statement added
-  @service(\\"boo-service\\") secondBooService;
+  @service(\\"boo-service\\")
+  declare secondBooService: BooService;
 
   // @ts-expect-error @rehearsal TODO TS7008: Member 'nonQualified' implicitly has an 'any' type.
-  @service('non-qualified') nonQualified;
+  @service(\\"non-qualified\\") nonQualified;
 
   <template>
     <span>Hello, I am human, and I am 10 years old!</span>
@@ -720,7 +646,7 @@ exports[`fix > EXPERIMENTAL_MODES, GlintService > mode: drain 1`] = `
     this.name = name;
   }
 
-  hello() {
+  hello(): number {
     return this.name + 1;
   }
 }

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -971,7 +971,7 @@ export default class SomeComponent extends Component {
     test('previously migrated .gts', async () => {
       await project.write();
 
-      const [inputs, outputs] = prepareInputFiles(project, ['already-migrated.gjs']);
+      const [inputs, outputs] = prepareInputFiles(project, ['already-migrated.gts']);
 
       const input: MigrateInput = {
         projectRootDir: project.baseDir,

--- a/packages/service/src/rehearsal-service.ts
+++ b/packages/service/src/rehearsal-service.ts
@@ -122,7 +122,9 @@ export class RehearsalService implements Service {
           length: node.getEnd() - node.getStart(),
           category: DiagnosticCategory.Suggestion,
           code: 7050,
-          messageText: `${node.name.getText()} don't have a return type, but the type may be inferred from usage.`,
+          messageText:
+            (isFunctionDeclaration(node) ? `Function` : `Method`) +
+            ` '${node.name.getText()}' lacks a return-type annotation.`,
         });
 
         return undefined;

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -526,17 +526,17 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
-[TITLE]   92 errors caught by rehearsal
-[TITLE]   9 have been fixed by rehearsal
-[TITLE]   83 errors need to be fixed manually
-[TITLE]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]   98 errors caught by rehearsal
+[TITLE]   14 have been fixed by rehearsal
+[TITLE]   84 errors need to be fixed manually
+[TITLE]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 54 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   92 errors caught by rehearsal
-[SUCCESS]   9 have been fixed by rehearsal
-[SUCCESS]   83 errors need to be fixed manually
-[SUCCESS]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]   98 errors caught by rehearsal
+[SUCCESS]   14 have been fixed by rehearsal
+[SUCCESS]   84 errors need to be fixed manually
+[SUCCESS]     -- 28 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 54 glint errors, with details in the report
 [SUCCESS]     -- 2 eslint errors, with details in the report"
 `;
@@ -759,19 +759,19 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
-[TITLE]   104 errors caught by rehearsal
-[TITLE]   31 have been fixed by rehearsal
-[TITLE]   73 errors need to be fixed manually
+[TITLE]   114 errors caught by rehearsal
+[TITLE]   40 have been fixed by rehearsal
+[TITLE]   74 errors need to be fixed manually
 [TITLE]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 46 glint errors, with details in the report
-[TITLE]     -- 0 eslint errors, with details in the report
+[TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   104 errors caught by rehearsal
-[SUCCESS]   31 have been fixed by rehearsal
-[SUCCESS]   73 errors need to be fixed manually
+[SUCCESS]   114 errors caught by rehearsal
+[SUCCESS]   40 have been fixed by rehearsal
+[SUCCESS]   74 errors need to be fixed manually
 [SUCCESS]     -- 27 ts errors, marked by @ts-expect-error @rehearsal TODO
 [SUCCESS]     -- 46 glint errors, with details in the report
-[SUCCESS]     -- 0 eslint errors, with details in the report"
+[SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
 exports[`fix command > ember_js_app_4.11 2`] = `
@@ -935,6 +935,7 @@ class IncrementableButton extends Component {
   // @ts-expect-error @rehearsal TODO TS2339: Property 'startCount' does not exist on type 'Readonly<EmptyObject>'.
   @tracked count: number = this.args.startCount;
 
+  // @ts-expect-error @rehearsal TODO TS7050: Method 'increment' lacks a return-type annotation.
   @action increment() {
     this.count++;
   }

--- a/packages/smoke-test/test/fixtures/base_ts_app/test/__snapshots__/main.test.ts.snap
+++ b/packages/smoke-test/test/fixtures/base_ts_app/test/__snapshots__/main.test.ts.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`applyRules() > the new grid should have all cells alive 1`] = `
+[
+  [
+    "X",
+    "X",
+    "X",
+    "X",
+  ],
+  [
+    "X",
+    "X",
+    "X",
+    "X",
+  ],
+  [
+    "X",
+    "X",
+    "X",
+    "X",
+  ],
+  [
+    "X",
+    "X",
+    "X",
+    "X",
+  ],
+]
+`;
+
+exports[`generateRandomGrid() > grid cells should all be the same 1`] = `
+[
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+  [
+    "P",
+    "P",
+    "P",
+    "P",
+    "P",
+  ],
+]
+`;


### PR DESCRIPTION
Adds a `getAdditionalDiagnostics` function to Glint Service to infer return types based on inlay hints.

Also:
- Starting now, `.gts` files have `Method 'containsUnsupportedDiagnostic' lacks a return-type annotation.` comments over function with missing return type.
- `.ts` under Glint projects will have return types inferred where type hints are available..
- SourceFiles produced by Glint Service for .gts now compatible with TS helper functions, so base codefixes will be easier to run on them as well! :)