### PR TITLE
fix: enable AddMissingTypesBasedOnInlayHintsCodeFix for .gts files

### DIFF
--- a/packages/codefixes/src/codefixes.ts
+++ b/packages/codefixes/src/codefixes.ts
@@ -28,9 +28,12 @@ export const codefixes = new CodeFixesProvider([
 ]);
 
 export const glintCodeFixes = new CodeFixesProvider([
+  new BaseCodeFixCollection([
+    new AddMissingTypesBasedOnInlayHintsCodeFix(),
+    new StubMissingJSDocParamName(),
+  ]),
   new GlintCodeFixCollection(),
   new BaseCodeFixCollection([
-    new StubMissingJSDocParamName(),
     // Need to be run after standard "typedef to type" fix applied
     new AddMissingArgToComponentSignature(),
   ]),

--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints.ts
@@ -28,8 +28,12 @@ export class AddMissingTypesBasedOnInlayHintsCodeFix implements CodeFix {
 
     const targetPosition = closeParen.getEnd();
 
+    // TODO: Remove this hack for Glint's .gts files to be processed as .ts
+    // The Glint's `program` doesn't know about .gts and represents them as .ts files under the hood
+    const fileName = diagnostic.file.fileName.replace(/.gts$/, '.ts');
+
     const hints = diagnostic.service.provideInlayHints(
-      diagnostic.file.fileName,
+      fileName,
       {
         start: targetPosition,
         length: targetPosition + 1,

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -188,17 +188,24 @@ export default class TestGjsNoErrors extends Component {
 exports[`fix > .gts > strips jsdoc param with missing name 1`] = `
 "import Component from \\"@glimmer/component\\";
 
-export class Something extends Component {
+export interface SomethingSignature {
+  Args: { age: any };
+}
+
+export class Something extends Component<SomethingSignature> {
   /** */
-  // @ts-expect-error @rehearsal TODO TS7050: Method 'reset' lacks a return-type annotation.
-  reset(...args) {
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args): void {
     console.log(args);
   }
 
-  // @ts-expect-error @rehearsal TODO TS7050: Method 'shouldExist' lacks a return-type annotation.
-  shouldExist() {
+  shouldExist(): void {
     console.log(\\"should exist in output\\");
   }
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
 }
 "
 `;
@@ -206,18 +213,25 @@ export class Something extends Component {
 exports[`fix > .gts > strips jsdoc param with missing name 2`] = `
 "import Component from \\"@glimmer/component\\";
 
-export class Something extends Component {
+export interface SomethingSignature {
+  Args: { age: any };
+}
+
+export class Something extends Component<SomethingSignature> {
   /** */
 
-  // @ts-expect-error @rehearsal TODO TS7050: Method 'reset' lacks a return-type annotation.
-  reset(...args) {
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args): void {
     console.log(args);
   }
 
-  // @ts-expect-error @rehearsal TODO TS7050: Method 'shouldExist' lacks a return-type annotation.
-  shouldExist() {
+  shouldExist(): void {
     console.log(\\"should exist in output\\");
   }
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
 }
 "
 `;
@@ -290,8 +304,7 @@ export default class MyComponent {
     b = 2;
   }
 
-  // @ts-expect-error @rehearsal TODO TS7050: Method 'containsUnsupportedDiagnostic' lacks a return-type annotation.
-  containsUnsupportedDiagnostic() {
+  containsUnsupportedDiagnostic(): () => void {
     return function () {
       // @ts-expect-error @rehearsal TODO TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
       console.log(this);

--- a/packages/migrate/test/fixtures/project/src/gts/with-missing-jsdoc-param-name.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/with-missing-jsdoc-param-name.gts
@@ -14,4 +14,8 @@ export class Something extends Component {
   shouldExist() {
     console.log("should exist in output");
   }
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
 }


### PR DESCRIPTION
Enable AddMissingTypesBasedOnInlayHintsCodeFix for .gts files

To do this we have to use .ts file extension when call `service.provideInlayHints` function because Glint's `program` doesn't know about .gts and represents them as .ts files under the hood.

This hack is plan to be removed during https://github.com/rehearsal-js/rehearsal-js/issues/1084