### PR TITLE
feat(glint): add this.args usage to signature

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -77,6 +77,25 @@ export class SomeComponent extends Component<BarSignature> {
   </template>
 }
 
+export interface InferMultipleArgsSignature {
+  Args: { snack: any; beverage: any };
+}
+
+//
+// UseCase: Should add usage of this.args to the args interface
+//
+
+export class InferMultipleArgs extends Component<InferMultipleArgsSignature> {
+  get drink() {
+    return this.args.beverage;
+  }
+
+  <template>
+    <span>My favorite snack is {{@snack}}.</span>
+    <span>My favorite drink is {{this.drink}}.</span>
+  </template>
+}
+
 //
 // UseCase: Should update object literal
 //

--- a/packages/migrate/test/fixtures/project/src/gts/signatures/with-missing-args.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/signatures/with-missing-args.gts
@@ -35,6 +35,21 @@ export class SomeComponent extends Component<BarSignature> {
 }
 
 //
+// UseCase: Should add usage of this.args to the args interface
+//
+
+export class InferMultipleArgs extends Component {
+  get drink() {
+    return this.args.beverage;
+  }
+
+  <template>
+    <span>My favorite snack is {{@snack}}.</span>
+    <span>My favorite drink is {{this.drink}}.</span>
+  </template>
+}
+
+//
 // UseCase: Should update object literal
 //
 

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -482,13 +482,22 @@ describe('fix', () => {
           outputs[0],
           'Expecting any for both args as they were both not defined on the interface'
         ).contains(`interface FooArgs {\n  snack: any;\n  age: any;\n}`);
+
         expectFile(outputs[0], 'Expecting any for snack arg because it was not defined').contains(
           `interface BarArgs {\n  snack: any;\n  age: number;\n}`
         );
+
         expectFile(
           outputs[0],
           'Expecting any for both args as they were both not defined on the interface'
-        ).contains(`export interface BazSignature {\n  Args: { snack: any; age: any };\n}`);
+        ).contains(`interface BazSignature {\n  Args: { snack: any; age: any };\n}`);
+
+        expectFile(
+          outputs[0],
+          'Expecting this.args usage to be updated to use the Args property'
+        ).contains(
+          'export interface InferMultipleArgsSignature {\n  Args: { snack: any; beverage: any };\n}'
+        );
 
         expectFile(outputs[0]).toMatchSnapshot();
       });


### PR DESCRIPTION
This addresses #1228, Adds support for populating component signatures with usages like: `this.args.someParam` in `gts` files.