### PR TITLE
fix(codefix): drop inlay hints that contain `...`

### DIFF
--- a/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints.ts
+++ b/packages/codefixes/src/fixes/addMissingTypesBasedOnInlayHints.ts
@@ -52,7 +52,14 @@ export class AddMissingTypesBasedOnInlayHintsCodeFix implements CodeFix {
       (hint) => hint.position >= targetPosition && hint.position <= targetPosition + 1
     );
 
-    if (!hint || hint.text.includes('any') || hint.text.includes('object')) {
+    if (
+      !hint ||
+      hint.text.includes('any') ||
+      hint.text.includes('object') ||
+      // Some hints will be truncated with three periods not ellipsis character.
+      // This can break syntax if injected.
+      hint.text.includes('...')
+    ) {
       return undefined;
     }
 

--- a/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
+++ b/packages/codefixes/test/__snapshots__/base-codefixes.test.ts.snap
@@ -382,6 +382,41 @@ export class TestClass extends BaseTestClass implements TestInterface {
 "
 `;
 
+exports[`Test base codefixes > addMissingTypesBasedOnInlayHints 2`] = `
+"// Use Case
+//
+// In the folllowing code, an inlay hint will sugggest a return type
+// for \`someFunctionWithManyReturnTypes\` with the following:
+// \`: string | Greeting<string> |...\`
+// Any suggestions with three-periods should NOT be added.
+
+class Greeting<T> {
+  phrase;
+  constructor(phrase: string) {
+    this.phrase = phrase;
+  }
+}
+
+class SomeClass {
+  constructor() {}
+
+  someFunctionWithManyReturnTypes(arg1: boolean, arg2: boolean) {
+    let result;
+
+    if (arg1) {
+      result = \\"Hello\\";
+    } else if (arg2) {
+      result = new Greeting<string>(\\"Hey\\");
+    } else {
+      result = Promise.resolve(new Greeting<string>(\\"Hola\\"));
+    }
+
+    return result;
+  }
+}
+"
+`;
+
 exports[`Test base codefixes > annotateWithStrictTypeFromJSDoc 1`] = `
 "export class Foo {
   value = 0;

--- a/packages/codefixes/test/fixtures/base-codefixes/addMissingTypesBasedOnInlayHints/ts-should-not-append-types-with-ellipsis.ts
+++ b/packages/codefixes/test/fixtures/base-codefixes/addMissingTypesBasedOnInlayHints/ts-should-not-append-types-with-ellipsis.ts
@@ -1,0 +1,31 @@
+// Use Case
+//
+// In the folllowing code, an inlay hint will sugggest a return type
+// for `someFunctionWithManyReturnTypes` with the following:
+// `: string | Greeting<string> |...`
+// Any suggestions with three-periods should NOT be added.
+
+class Greeting<T> {
+  phrase;
+  constructor(phrase) {
+    this.phrase = phrase;
+  }
+}
+
+class SomeClass {
+  constructor() {}
+
+  someFunctionWithManyReturnTypes(arg1: boolean, arg2: boolean) {
+    let result;
+
+    if (arg1) {
+      result = 'Hello';
+    } else if (arg2) {
+      result = new Greeting<string>('Hey');
+    } else {
+      result = Promise.resolve(new Greeting<string>('Hola'));
+    }
+
+    return result;
+  }
+}

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -499,269 +499,35 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/router.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/adapters/application.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/audience-demographics.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/audience-demographics.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/hello-world.gts
-{ plugins: [ prettier-plugin-ember-template-tag ] }
-{ plugins: [ prettier-plugin-ember-template-tag ] }
 [DATA] processing file: /app/components/jumbo.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/map.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/map.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/nav-bar.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/share-button.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/share-button.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/models/rental.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/routes/index.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/routes/rental.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/serializers/application.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/services/locale.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/templates/about.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/application.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/contact.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/index.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/rental.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/detailed.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/image.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/image.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/rentals/filter.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals/filter.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [TITLE] Types Inferred
 [TITLE]   102 errors caught by rehearsal
 [TITLE]   15 have been fixed by rehearsal
@@ -989,269 +755,35 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/router.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/adapters/application.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/audience-demographics.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/audience-demographics.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/hello-world.gts
-{ plugins: [ prettier-plugin-ember-template-tag ] }
-{ plugins: [ prettier-plugin-ember-template-tag ] }
 [DATA] processing file: /app/components/jumbo.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/map.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/map.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/nav-bar.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/share-button.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/share-button.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/models/rental.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/routes/index.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/routes/rental.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/serializers/application.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/services/locale.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/templates/about.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/application.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/contact.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/index.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/templates/rental.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/detailed.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/image.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rental/image.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [DATA] processing file: /app/components/rentals/filter.hbs
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  parser: glimmer
-}
 [DATA] processing file: /app/components/rentals/filter.ts
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
-{
-  plugins: [ prettier-plugin-ember-template-tag ],
-  singleQuote: true
-}
 [TITLE] Types Inferred
 [TITLE]   118 errors caught by rehearsal
 [TITLE]   41 have been fixed by rehearsal

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -226,61 +226,25 @@ exports[`fix command > base_ts_app 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /src/get-live-neighbor-count.ts
-{
-  text: : number,
-  position: 158,
-  kind: Type,
-  whitespaceBefore: true
-}
 [DATA] processing file: /src/apply-rules.ts
-{
-  text: : any[],
-  position: 120,
-  kind: Type,
-  whitespaceBefore: true
-}
 [DATA] processing file: /src/gen-random-grid.ts
-{
-  text: : string[][],
-  position: 161,
-  kind: Type,
-  whitespaceBefore: true
-}
 [DATA] processing file: /src/app.ts
 [DATA] processing file: /src/basic.animal.ts
 [DATA] processing file: /src/basic.food.ts
 [DATA] processing file: /src/basic.index.ts
-{
-  text: : string,
-  position: 139,
-  kind: Type,
-  whitespaceBefore: true
-}
-{
-  text: : boolean,
-  position: 236,
-  kind: Type,
-  whitespaceBefore: true
-}
 [DATA] processing file: /src/greeting.ts
-{
-  text: : string | Greeting<string> |...,
-  position: 169,
-  kind: Type,
-  whitespaceBefore: true
-}
 [TITLE] Types Inferred
-[TITLE]   25 errors caught by rehearsal
-[TITLE]   14 have been fixed by rehearsal
-[TITLE]   11 errors need to be fixed manually
-[TITLE]     -- 10 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 1 eslint errors, with details in the report
+[TITLE]   19 errors caught by rehearsal
+[TITLE]   13 have been fixed by rehearsal
+[TITLE]   6 errors need to be fixed manually
+[TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   25 errors caught by rehearsal
-[SUCCESS]   14 have been fixed by rehearsal
-[SUCCESS]   11 errors need to be fixed manually
-[SUCCESS]     -- 10 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 1 eslint errors, with details in the report"
+[SUCCESS]   19 errors caught by rehearsal
+[SUCCESS]   13 have been fixed by rehearsal
+[SUCCESS]   6 errors need to be fixed manually
+[SUCCESS]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 0 eslint errors, with details in the report"
 `;
 
 exports[`fix command > base_ts_app 2`] = `
@@ -535,60 +499,269 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/router.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/adapters/application.ts
 {
-  text: : string,
-  position: 166,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/components/audience-demographics.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/audience-demographics.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/hello-world.gts
+{ plugins: [ prettier-plugin-ember-template-tag ] }
+{ plugins: [ prettier-plugin-ember-template-tag ] }
 [DATA] processing file: /app/components/jumbo.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/map.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/map.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/nav-bar.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/share-button.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/share-button.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/models/rental.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/routes/index.ts
 {
-  text: : Promise<any>,
-  position: 167,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/routes/rental.ts
 {
-  text: : Promise<any>,
-  position: 174,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/serializers/application.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/services/locale.ts
 {
-  text: : string,
-  position: 103,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/templates/about.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/application.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/contact.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/index.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/rental.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/detailed.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/image.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/image.ts
-{ text: : void, position: 243, kind: Type, whitespaceBefore: true }
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/rentals/filter.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals/filter.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [TITLE] Types Inferred
 [TITLE]   102 errors caught by rehearsal
 [TITLE]   15 have been fixed by rehearsal
@@ -816,60 +989,269 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /app/app.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/router.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/adapters/application.ts
 {
-  text: : string,
-  position: 166,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/components/audience-demographics.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/audience-demographics.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/hello-world.gts
+{ plugins: [ prettier-plugin-ember-template-tag ] }
+{ plugins: [ prettier-plugin-ember-template-tag ] }
 [DATA] processing file: /app/components/jumbo.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/map.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/map.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/nav-bar.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/share-button.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/share-button.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/models/rental.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/routes/index.ts
 {
-  text: : Promise<any>,
-  position: 167,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/routes/rental.ts
 {
-  text: : Promise<any>,
-  position: 174,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/serializers/application.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/services/locale.ts
 {
-  text: : string,
-  position: 103,
-  kind: Type,
-  whitespaceBefore: true
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
 }
 [DATA] processing file: /app/templates/about.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/application.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/contact.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/index.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/templates/rental.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/detailed.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/image.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rental/image.ts
-{ text: : void, position: 243, kind: Type, whitespaceBefore: true }
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [DATA] processing file: /app/components/rentals/filter.hbs
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  parser: glimmer
+}
 [DATA] processing file: /app/components/rentals/filter.ts
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
+{
+  plugins: [ prettier-plugin-ember-template-tag ],
+  singleQuote: true
+}
 [TITLE] Types Inferred
 [TITLE]   118 errors caught by rehearsal
 [TITLE]   41 have been fixed by rehearsal
@@ -950,7 +1332,6 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [STARTED] Infer Types
 [DATA] processing file: /src/GreetingHeader.ts
 [DATA] processing file: /src/App.ts
-undefined
 [DATA] processing file: /src/SimpleComponent.ts
 [DATA] processing file: /src/index.ts
 [TITLE] Types Inferred

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -226,24 +226,61 @@ exports[`fix command > base_ts_app 1`] = `
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
 [DATA] processing file: /src/get-live-neighbor-count.ts
+{
+  text: : number,
+  position: 158,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /src/apply-rules.ts
+{
+  text: : any[],
+  position: 120,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /src/gen-random-grid.ts
+{
+  text: : string[][],
+  position: 161,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /src/app.ts
 [DATA] processing file: /src/basic.animal.ts
 [DATA] processing file: /src/basic.food.ts
 [DATA] processing file: /src/basic.index.ts
+{
+  text: : string,
+  position: 139,
+  kind: Type,
+  whitespaceBefore: true
+}
+{
+  text: : boolean,
+  position: 236,
+  kind: Type,
+  whitespaceBefore: true
+}
+[DATA] processing file: /src/greeting.ts
+{
+  text: : string | Greeting<string> |...,
+  position: 169,
+  kind: Type,
+  whitespaceBefore: true
+}
 [TITLE] Types Inferred
-[TITLE]   18 errors caught by rehearsal
-[TITLE]   12 have been fixed by rehearsal
-[TITLE]   6 errors need to be fixed manually
-[TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
-[TITLE]     -- 0 eslint errors, with details in the report
+[TITLE]   25 errors caught by rehearsal
+[TITLE]   14 have been fixed by rehearsal
+[TITLE]   11 errors need to be fixed manually
+[TITLE]     -- 10 ts errors, marked by @ts-expect-error @rehearsal TODO
+[TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Types Inferred
-[SUCCESS]   18 errors caught by rehearsal
-[SUCCESS]   12 have been fixed by rehearsal
-[SUCCESS]   6 errors need to be fixed manually
-[SUCCESS]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
-[SUCCESS]     -- 0 eslint errors, with details in the report"
+[SUCCESS]   25 errors caught by rehearsal
+[SUCCESS]   14 have been fixed by rehearsal
+[SUCCESS]   11 errors need to be fixed manually
+[SUCCESS]     -- 10 ts errors, marked by @ts-expect-error @rehearsal TODO
+[SUCCESS]     -- 1 eslint errors, with details in the report"
 `;
 
 exports[`fix command > base_ts_app 2`] = `
@@ -500,6 +537,12 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [DATA] processing file: /app/app.ts
 [DATA] processing file: /app/router.ts
 [DATA] processing file: /app/adapters/application.ts
+{
+  text: : string,
+  position: 166,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/components/audience-demographics.hbs
 [DATA] processing file: /app/components/audience-demographics.ts
 [DATA] processing file: /app/components/hello-world.gts
@@ -514,9 +557,27 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [DATA] processing file: /app/components/share-button.ts
 [DATA] processing file: /app/models/rental.ts
 [DATA] processing file: /app/routes/index.ts
+{
+  text: : Promise<any>,
+  position: 167,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/routes/rental.ts
+{
+  text: : Promise<any>,
+  position: 174,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/serializers/application.ts
 [DATA] processing file: /app/services/locale.ts
+{
+  text: : string,
+  position: 103,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/templates/about.hbs
 [DATA] processing file: /app/templates/application.hbs
 [DATA] processing file: /app/templates/contact.hbs
@@ -525,6 +586,7 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [DATA] processing file: /app/components/rental/detailed.hbs
 [DATA] processing file: /app/components/rental/image.hbs
 [DATA] processing file: /app/components/rental/image.ts
+{ text: : void, position: 243, kind: Type, whitespaceBefore: true }
 [DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
@@ -756,6 +818,12 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/app.ts
 [DATA] processing file: /app/router.ts
 [DATA] processing file: /app/adapters/application.ts
+{
+  text: : string,
+  position: 166,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/components/audience-demographics.hbs
 [DATA] processing file: /app/components/audience-demographics.ts
 [DATA] processing file: /app/components/hello-world.gts
@@ -770,9 +838,27 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/components/share-button.ts
 [DATA] processing file: /app/models/rental.ts
 [DATA] processing file: /app/routes/index.ts
+{
+  text: : Promise<any>,
+  position: 167,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/routes/rental.ts
+{
+  text: : Promise<any>,
+  position: 174,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/serializers/application.ts
 [DATA] processing file: /app/services/locale.ts
+{
+  text: : string,
+  position: 103,
+  kind: Type,
+  whitespaceBefore: true
+}
 [DATA] processing file: /app/templates/about.hbs
 [DATA] processing file: /app/templates/application.hbs
 [DATA] processing file: /app/templates/contact.hbs
@@ -781,6 +867,7 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [DATA] processing file: /app/components/rental/detailed.hbs
 [DATA] processing file: /app/components/rental/image.hbs
 [DATA] processing file: /app/components/rental/image.ts
+{ text: : void, position: 243, kind: Type, whitespaceBefore: true }
 [DATA] processing file: /app/components/rentals/filter.hbs
 [DATA] processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
@@ -863,6 +950,7 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [STARTED] Infer Types
 [DATA] processing file: /src/GreetingHeader.ts
 [DATA] processing file: /src/App.ts
+undefined
 [DATA] processing file: /src/SimpleComponent.ts
 [DATA] processing file: /src/index.ts
 [TITLE] Types Inferred

--- a/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/graph.test.ts.snap
@@ -29,6 +29,7 @@ exports[`graph command > base_ts_app 1`] = `
 [DATA] ./src/basic.animal.ts
 [DATA] ./src/basic.food.ts
 [DATA] ./src/basic.index.ts
+[DATA] ./src/greeting.ts
 [SUCCESS] Analyzing project dependency graph"
 `;
 

--- a/packages/smoke-test/test/fixtures/base_ts_app/src/greeting.ts
+++ b/packages/smoke-test/test/fixtures/base_ts_app/src/greeting.ts
@@ -1,0 +1,24 @@
+class Greeting<T> {
+  phrase;
+  constructor(phrase) {
+    this.phrase = phrase;
+  }
+}
+
+class Salutation {
+  constructor() {}
+
+  say(arg1: boolean, arg2: boolean) {
+    let result;
+
+    if (arg1) {
+      result = 'Hello';
+    } else if (arg2) {
+      result = new Greeting<string>('Hey');
+    } else {
+      result = Promise.resolve(new Greeting<string>('Hola'));
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
### TL;DR
The text coming back from an inlay hint isn't always valid syntax, so we don't use inlay hint types if they have `...` three-periods (like an ellipsis but not the character code). 


### Details
Inlays hints may provide a list of a types that a function may return.

Given some code like the following:

```typescript
// Use Case
class Greeting<T> {
  phrase;
  constructor(phrase) {
    this.phrase = phrase;
  }
}

class SomeClass {
  constructor() {}

  someFunctionWithManyReturnTypes(arg1: boolean, arg2: boolean) {
    let result;

    if (arg1) {
      result = 'Hello';
    } else if (arg2) {
      result = new Greeting<string>('Hey');
    } else {
      result = Promise.resolve(new Greeting<string>('Hola'));
    }

    return result;
  }
}

```

The Inlay hints will suggest a return type for `someFunctionWithManyReturnTyupes` to be:

```
-  someFunctionWithManyReturnTypes(arg1: boolean, arg2: boolean) {
+  someFunctionWithManyReturnTypes(arg1: boolean, arg2: boolean): string | Greeting<string> |... { 
```
If we inject this without checking the validity it will break syntax of the target fixed file.


