### PR TITLE
feat: progress & duration in the CLI

### DIFF
--- a/packages/cli/src/commands/fix/tasks/convertWorker.ts
+++ b/packages/cli/src/commands/fix/tasks/convertWorker.ts
@@ -24,6 +24,12 @@ if (!isMainThread && (!process.env['TEST'] || process.env['TEST'] === 'false')) 
     projectRootDir: reporterOptionsProjectRootDir,
   });
 
+  const task = {
+    set output(text: string) {
+      parentPort?.postMessage({ type: 'logger', content: text });
+    },
+  };
+
   const migrateOptions = {
     mode,
     projectRootDir,
@@ -32,6 +38,7 @@ if (!isMainThread && (!process.env['TEST'] || process.env['TEST'] === 'false')) 
     reporter,
     ignore,
     configName,
+    task,
   };
 
   const migratedFiles = await drainMigrate(migrateOptions);
@@ -44,6 +51,7 @@ if (!isMainThread && (!process.env['TEST'] || process.env['TEST'] === 'false')) 
     content: {
       reportItems: reporter.report.items,
       fixedItemCount: reporter.report.fixedItemCount,
+      duration: reporter.duration,
     },
   });
   // resolves the promise in the parent thread
@@ -55,8 +63,6 @@ async function drainMigrate(migrateOptions: MigrateInput): Promise<string[]> {
 
   for await (const tsFile of migrate(migrateOptions)) {
     migratedFiles.push(tsFile);
-    // logs processing file: tsFile
-    parentPort?.postMessage({ type: 'logger', content: tsFile });
   }
 
   return migratedFiles;

--- a/packages/cli/src/helpers/report.ts
+++ b/packages/cli/src/helpers/report.ts
@@ -1,5 +1,6 @@
 import { ReportItemType } from '@rehearsal/reporter';
 // eslint-disable-next-line no-restricted-imports
+import { secondsToTime } from '@rehearsal/utils';
 import type { ReportItem } from '@rehearsal/reporter';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -8,7 +9,11 @@ const GlintReportItemType = ReportItemType.glint;
 /**
  * Reads report and generate migration summary
  */
-export function getReportSummary(reportItems: ReportItem[], fixedItemCount: number): string {
+export function getReportSummary(
+  reportItems: ReportItem[],
+  fixedItemCount: number,
+  duration: number
+): string {
   const fileMap = new Set<string>();
   let tsErrorCount = 0;
   let glintErrorCount = 0;
@@ -34,6 +39,7 @@ export function getReportSummary(reportItems: ReportItem[], fixedItemCount: numb
   const totalErrorCount = totalUnfixedCount + fixedItemCount;
 
   let summary = `Types Inferred\n\n
+  Duration: ${secondsToTime(duration)}\n\n
   ${totalErrorCount} errors caught by rehearsal\n
   ${fixedItemCount} have been fixed by rehearsal\n
   ${totalUnfixedCount} errors need to be fixed manually\n

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -95,6 +95,7 @@ export type GraphTaskOptions = {
 type MessageContent = {
   reportItems: ReportItem[];
   fixedItemCount: number;
+  duration: number;
 };
 type MessageResponse = { type: 'message'; content: MessageContent };
 type FilesResponse = { type: 'files'; content: string[] };

--- a/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
+++ b/packages/cli/test/commands/fix/__snapshots__/fix.test.ts.snap
@@ -7,18 +7,27 @@ exports[`Command: fix "base_ts_app" fixture > can fix starting with a directory 
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/get-live-neighbor-count.ts
-[DATA] processing file: /src/apply-rules.ts
-[DATA] processing file: /src/gen-random-grid.ts
-[DATA] processing file: /src/app.ts
-[DATA] processing file: /src/sub/grid.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/5 files | ETA: **:**:**
+[DATA]  processing file: /src/get-live-neighbor-count.ts
+[DATA] [====----------------] 1/5 files | ETA: **:**:**
+[DATA]  processing file: /src/apply-rules.ts
+[DATA] [========------------] 2/5 files | ETA: **:**:**
+[DATA]  processing file: /src/gen-random-grid.ts
+[DATA] [============--------] 3/5 files | ETA: **:**:**
+[DATA]  processing file: /src/app.ts
+[DATA] [================----] 4/5 files | ETA: **:**:**
+[DATA]  processing file: /src/sub/grid.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   16 errors caught by rehearsal
 [TITLE]   7 have been fixed by rehearsal
 [TITLE]   9 errors need to be fixed manually
 [TITLE]     -- 4 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 5 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   16 errors caught by rehearsal
 [SUCCESS]   7 have been fixed by rehearsal
 [SUCCESS]   9 errors need to be fixed manually
@@ -233,14 +242,19 @@ exports[`Command: fix "base_ts_app" fixture > can fix starting with a file 1`] =
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/gen-random-grid.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/1 files | ETA: **:**:**
+[DATA]  processing file: /src/gen-random-grid.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   3 errors caught by rehearsal
 [TITLE]   2 have been fixed by rehearsal
 [TITLE]   1 errors need to be fixed manually
 [TITLE]     -- 0 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   3 errors caught by rehearsal
 [SUCCESS]   2 have been fixed by rehearsal
 [SUCCESS]   1 errors need to be fixed manually
@@ -284,14 +298,19 @@ exports[`Command: fix "base_ts_app" fixture > can fix starting with a subdirecto
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/sub/grid.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/1 files | ETA: **:**:**
+[DATA]  processing file: /src/sub/grid.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   3 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
 [TITLE]   2 errors need to be fixed manually
 [TITLE]     -- 1 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 1 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   3 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
 [SUCCESS]   2 errors need to be fixed manually
@@ -502,37 +521,70 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /app/app.js
-[DATA] processing file: /app/router.js
-[DATA] processing file: /app/components/ember-component.hbs
-[DATA] processing file: /app/components/ember-component.ts
-[DATA] processing file: /app/components/foo.hbs
-[DATA] processing file: /app/components/foo.ts
-[DATA] processing file: /app/components/js-component.hbs
-[DATA] processing file: /app/components/js-component.js
-[DATA] processing file: /app/components/no-backing-module.hbs
-[DATA] processing file: /app/components/nocheck-me.hbs
-[DATA] processing file: /app/components/qux.ts
-[DATA] processing file: /app/components/template-only-module.hbs
-[DATA] processing file: /app/components/template-only-module.ts
-[DATA] processing file: /app/components/wrapper-component.hbs
-[DATA] processing file: /app/components/wrapper-component.ts
-[DATA] processing file: /app/controllers/classic-route.ts
-[DATA] processing file: /app/helpers/affix.ts
-[DATA] processing file: /app/helpers/repeat.ts
-[DATA] processing file: /app/routes/classic-route.ts
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/classic-route.hbs
-[DATA] processing file: /app/components/bar/index.hbs
-[DATA] processing file: /app/components/bar/index.ts
-[DATA] processing file: /app/templates/components/qux.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/parent.ts
-[DATA] processing file: /app/components/test-cases/subclassing/child.ts
-[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
-[DATA] processing file: /app/pods/components/baz/component.ts
-[DATA] processing file: /app/pods/components/baz/template.hbs
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/30 files | ETA: **:**:**
+[DATA]  processing file: /app/app.js
+[DATA] [--------------------] 1/30 files | ETA: **:**:**
+[DATA]  processing file: /app/router.js
+[DATA] [=-------------------] 2/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/ember-component.hbs
+[DATA] [==------------------] 3/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/ember-component.ts
+[DATA] [==------------------] 4/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/foo.hbs
+[DATA] [===-----------------] 5/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/foo.ts
+[DATA] [====----------------] 6/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/js-component.hbs
+[DATA] [====----------------] 7/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/js-component.js
+[DATA] [=====---------------] 8/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/no-backing-module.hbs
+[DATA] [======--------------] 9/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/nocheck-me.hbs
+[DATA] [======--------------] 10/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/qux.ts
+[DATA] [=======-------------] 11/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/template-only-module.hbs
+[DATA] [========------------] 12/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/template-only-module.ts
+[DATA] [========------------] 13/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/wrapper-component.hbs
+[DATA] [=========-----------] 14/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/wrapper-component.ts
+[DATA] [==========----------] 15/30 files | ETA: **:**:**
+[DATA]  processing file: /app/controllers/classic-route.ts
+[DATA] [==========----------] 16/30 files | ETA: **:**:**
+[DATA]  processing file: /app/helpers/affix.ts
+[DATA] [===========---------] 17/30 files | ETA: **:**:**
+[DATA]  processing file: /app/helpers/repeat.ts
+[DATA] [============--------] 18/30 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/classic-route.ts
+[DATA] [============--------] 19/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/application.hbs
+[DATA] [=============-------] 20/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/classic-route.hbs
+[DATA] [==============------] 21/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/bar/index.hbs
+[DATA] [==============------] 22/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/bar/index.ts
+[DATA] [===============-----] 23/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/components/qux.hbs
+[DATA] [================----] 24/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/child.hbs
+[DATA] [================----] 25/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/parent.ts
+[DATA] [=================---] 26/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/child.ts
+[DATA] [==================--] 27/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/parent.hbs
+[DATA] [==================--] 28/30 files | ETA: **:**:**
+[DATA]  processing file: /app/pods/components/baz/component.ts
+[DATA] [===================-] 29/30 files | ETA: **:**:**
+[DATA]  processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   69 errors caught by rehearsal
 [TITLE]   5 have been fixed by rehearsal
 [TITLE]   64 errors need to be fixed manually
@@ -540,6 +592,7 @@ exports[`Command: fix "ember-ts-app" fixture > can fix starting with a file 1`] 
 [TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   69 errors caught by rehearsal
 [SUCCESS]   5 have been fixed by rehearsal
 [SUCCESS]   64 errors need to be fixed manually
@@ -557,35 +610,66 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /app/app.js
-[DATA] processing file: /app/router.js
-[DATA] processing file: /app/components/ember-component.hbs
-[DATA] processing file: /app/components/ember-component.ts
-[DATA] processing file: /app/components/foo.hbs
-[DATA] processing file: /app/components/foo.ts
-[DATA] processing file: /app/components/js-component.hbs
-[DATA] processing file: /app/components/js-component.js
-[DATA] processing file: /app/components/no-backing-module.hbs
-[DATA] processing file: /app/components/nocheck-me.hbs
-[DATA] processing file: /app/components/qux.ts
-[DATA] processing file: /app/components/template-only-module.hbs
-[DATA] processing file: /app/components/template-only-module.ts
-[DATA] processing file: /app/components/wrapper-component.hbs
-[DATA] processing file: /app/components/wrapper-component.ts
-[DATA] processing file: /app/controllers/classic-route.ts
-[DATA] processing file: /app/routes/classic-route.ts
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/classic-route.hbs
-[DATA] processing file: /app/components/bar/index.hbs
-[DATA] processing file: /app/components/bar/index.ts
-[DATA] processing file: /app/templates/components/qux.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/child.hbs
-[DATA] processing file: /app/components/test-cases/subclassing/parent.ts
-[DATA] processing file: /app/components/test-cases/subclassing/child.ts
-[DATA] processing file: /app/components/test-cases/subclassing/parent.hbs
-[DATA] processing file: /app/pods/components/baz/component.ts
-[DATA] processing file: /app/pods/components/baz/template.hbs
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/28 files | ETA: **:**:**
+[DATA]  processing file: /app/app.js
+[DATA] [--------------------] 1/28 files | ETA: **:**:**
+[DATA]  processing file: /app/router.js
+[DATA] [=-------------------] 2/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/ember-component.hbs
+[DATA] [==------------------] 3/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/ember-component.ts
+[DATA] [==------------------] 4/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/foo.hbs
+[DATA] [===-----------------] 5/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/foo.ts
+[DATA] [====----------------] 6/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/js-component.hbs
+[DATA] [=====---------------] 7/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/js-component.js
+[DATA] [=====---------------] 8/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/no-backing-module.hbs
+[DATA] [======--------------] 9/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/nocheck-me.hbs
+[DATA] [=======-------------] 10/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/qux.ts
+[DATA] [=======-------------] 11/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/template-only-module.hbs
+[DATA] [========------------] 12/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/template-only-module.ts
+[DATA] [=========-----------] 13/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/wrapper-component.hbs
+[DATA] [==========----------] 14/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/wrapper-component.ts
+[DATA] [==========----------] 15/28 files | ETA: **:**:**
+[DATA]  processing file: /app/controllers/classic-route.ts
+[DATA] [===========---------] 16/28 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/classic-route.ts
+[DATA] [============--------] 17/28 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/application.hbs
+[DATA] [============--------] 18/28 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/classic-route.hbs
+[DATA] [=============-------] 19/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/bar/index.hbs
+[DATA] [==============------] 20/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/bar/index.ts
+[DATA] [===============-----] 21/28 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/components/qux.hbs
+[DATA] [===============-----] 22/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/child.hbs
+[DATA] [================----] 23/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/parent.ts
+[DATA] [=================---] 24/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/child.ts
+[DATA] [=================---] 25/28 files | ETA: **:**:**
+[DATA]  processing file: /app/components/test-cases/subclassing/parent.hbs
+[DATA] [==================--] 26/28 files | ETA: **:**:**
+[DATA]  processing file: /app/pods/components/baz/component.ts
+[DATA] [===================-] 27/28 files | ETA: **:**:**
+[DATA]  processing file: /app/pods/components/baz/template.hbs
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   63 errors caught by rehearsal
 [TITLE]   3 have been fixed by rehearsal
 [TITLE]   60 errors need to be fixed manually
@@ -593,6 +677,7 @@ exports[`Command: fix "ember-ts-app" fixture > fix package with src arg and grap
 [TITLE]     -- 44 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   63 errors caught by rehearsal
 [SUCCESS]   3 have been fixed by rehearsal
 [SUCCESS]   60 errors need to be fixed manually

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -101,6 +101,8 @@ export async function* migrate(input: MigrateInput): AsyncGenerator<string> {
   DEBUG_CALLBACK(` ignoredPaths: %O`, ignoredPaths);
   DEBUG_CALLBACK(` filteredFilesToMigrate: %O`, filteredFilesToMigrate);
 
+  listrTask.output = `preparing files ...`;
+
   const service = useGlint
     ? new GlintService(glintCore, packageDir)
     : new RehearsalService(tsCompilerOptions, filesToCompile);

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -37,6 +37,7 @@ export class Reporter {
   public report: Report;
   public currentRun: Run;
   public lastRun: Run | undefined;
+  public duration: number;
   private uniqueFiles: string[];
   private stemName: string;
 
@@ -64,6 +65,7 @@ export class Reporter {
       fixedItemCount: 0,
       items: [],
     };
+    this.duration = 0;
   }
 
   public getFileNames(): string[] {

--- a/packages/service/src/plugin.ts
+++ b/packages/service/src/plugin.ts
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@rehearsal/utils';
 import { Reporter } from '@rehearsal/reporter';
 import { Logger } from 'winston';
 import { Service } from './rehearsal-service.js';
@@ -122,18 +123,30 @@ export class PluginsRunner {
 
   // generator to yield at every file in processFilesGenerator
   async *run(fileNames: string[], logger?: PluginLogger): AsyncGenerator<string> {
-    const fileIteratorProcessor = this.processFilesGenerator(fileNames, logger);
+    const progress = new ProgressBar(fileNames.length, !!process.env['TEST']);
+
+    const fileIteratorProcessor = this.processFilesGenerator(fileNames, progress, logger);
     for await (const fileName of fileIteratorProcessor) {
       yield fileName;
     }
+
+    this.context.reporter.duration = progress.secondsPassed;
   }
 
   // Async generator to process files
   // Since this is a long-running process, we need to yield to the event loop
   // So we don't block the main thread
-  async *processFilesGenerator(fileNames: string[], logger?: PluginLogger): AsyncGenerator<string> {
+  async *processFilesGenerator(
+    fileNames: string[],
+    progress: ProgressBar,
+    logger?: PluginLogger
+  ): AsyncGenerator<string> {
     for (const fileName of fileNames) {
-      logger?.log(`processing file: ${fileName.replace(this.context.basePath, '')}`);
+      logger?.log(
+        `[${progress.printBar(20)}] ${progress.done}/${progress.total} files` +
+          ` | ETA: ${progress.secondsLeft ? progress.timeLeft : '**:**:**'}` +
+          `\n processing file: ${fileName.replace(this.context.basePath, '')}`
+      );
 
       const allChangedFiles: Set<string> = new Set();
       const pluginIteratorProcessor = this.processPlugins(fileName, allChangedFiles);
@@ -152,6 +165,8 @@ export class PluginsRunner {
 
         await next();
       }
+
+      progress.increment();
 
       yield fileName;
     }

--- a/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
+++ b/packages/smoke-test/test/commands/__snapshots__/fix.test.ts.snap
@@ -7,14 +7,19 @@ exports[`fix command > base_ts_app (file only) 1`] = `
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/app.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/1 files | ETA: **:**:**
+[DATA]  processing file: /src/app.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   3 errors caught by rehearsal
 [TITLE]   1 have been fixed by rehearsal
 [TITLE]   2 errors need to be fixed manually
 [TITLE]     -- 2 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   3 errors caught by rehearsal
 [SUCCESS]   1 have been fixed by rehearsal
 [SUCCESS]   2 errors need to be fixed manually
@@ -225,21 +230,33 @@ exports[`fix command > base_ts_app 1`] = `
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/get-live-neighbor-count.ts
-[DATA] processing file: /src/apply-rules.ts
-[DATA] processing file: /src/gen-random-grid.ts
-[DATA] processing file: /src/app.ts
-[DATA] processing file: /src/basic.animal.ts
-[DATA] processing file: /src/basic.food.ts
-[DATA] processing file: /src/basic.index.ts
-[DATA] processing file: /src/greeting.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/8 files | ETA: **:**:**
+[DATA]  processing file: /src/get-live-neighbor-count.ts
+[DATA] [==------------------] 1/8 files | ETA: **:**:**
+[DATA]  processing file: /src/apply-rules.ts
+[DATA] [=====---------------] 2/8 files | ETA: **:**:**
+[DATA]  processing file: /src/gen-random-grid.ts
+[DATA] [=======-------------] 3/8 files | ETA: **:**:**
+[DATA]  processing file: /src/app.ts
+[DATA] [==========----------] 4/8 files | ETA: **:**:**
+[DATA]  processing file: /src/basic.animal.ts
+[DATA] [============--------] 5/8 files | ETA: **:**:**
+[DATA]  processing file: /src/basic.food.ts
+[DATA] [===============-----] 6/8 files | ETA: **:**:**
+[DATA]  processing file: /src/basic.index.ts
+[DATA] [=================---] 7/8 files | ETA: **:**:**
+[DATA]  processing file: /src/greeting.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   21 errors caught by rehearsal
 [TITLE]   15 have been fixed by rehearsal
 [TITLE]   6 errors need to be fixed manually
 [TITLE]     -- 6 ts errors, marked by @ts-expect-error @rehearsal TODO
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   21 errors caught by rehearsal
 [SUCCESS]   15 have been fixed by rehearsal
 [SUCCESS]   6 errors need to be fixed manually
@@ -498,37 +515,70 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /app/app.ts
-[DATA] processing file: /app/router.ts
-[DATA] processing file: /app/adapters/application.ts
-[DATA] processing file: /app/components/audience-demographics.hbs
-[DATA] processing file: /app/components/audience-demographics.ts
-[DATA] processing file: /app/components/hello-world.gts
-[DATA] processing file: /app/components/jumbo.hbs
-[DATA] processing file: /app/components/map.hbs
-[DATA] processing file: /app/components/map.ts
-[DATA] processing file: /app/components/nav-bar.hbs
-[DATA] processing file: /app/components/rental.hbs
-[DATA] processing file: /app/components/rentals.hbs
-[DATA] processing file: /app/components/rentals.ts
-[DATA] processing file: /app/components/share-button.hbs
-[DATA] processing file: /app/components/share-button.ts
-[DATA] processing file: /app/models/rental.ts
-[DATA] processing file: /app/routes/index.ts
-[DATA] processing file: /app/routes/rental.ts
-[DATA] processing file: /app/serializers/application.ts
-[DATA] processing file: /app/services/locale.ts
-[DATA] processing file: /app/templates/about.hbs
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/contact.hbs
-[DATA] processing file: /app/templates/index.hbs
-[DATA] processing file: /app/templates/rental.hbs
-[DATA] processing file: /app/components/rental/detailed.hbs
-[DATA] processing file: /app/components/rental/image.hbs
-[DATA] processing file: /app/components/rental/image.ts
-[DATA] processing file: /app/components/rentals/filter.hbs
-[DATA] processing file: /app/components/rentals/filter.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/30 files | ETA: **:**:**
+[DATA]  processing file: /app/app.ts
+[DATA] [--------------------] 1/30 files | ETA: **:**:**
+[DATA]  processing file: /app/router.ts
+[DATA] [=-------------------] 2/30 files | ETA: **:**:**
+[DATA]  processing file: /app/adapters/application.ts
+[DATA] [==------------------] 3/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/audience-demographics.hbs
+[DATA] [==------------------] 4/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/audience-demographics.ts
+[DATA] [===-----------------] 5/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/hello-world.gts
+[DATA] [====----------------] 6/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/jumbo.hbs
+[DATA] [====----------------] 7/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/map.hbs
+[DATA] [=====---------------] 8/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/map.ts
+[DATA] [======--------------] 9/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/nav-bar.hbs
+[DATA] [======--------------] 10/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental.hbs
+[DATA] [=======-------------] 11/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals.hbs
+[DATA] [========------------] 12/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals.ts
+[DATA] [========------------] 13/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/share-button.hbs
+[DATA] [=========-----------] 14/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/share-button.ts
+[DATA] [==========----------] 15/30 files | ETA: **:**:**
+[DATA]  processing file: /app/models/rental.ts
+[DATA] [==========----------] 16/30 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/index.ts
+[DATA] [===========---------] 17/30 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/rental.ts
+[DATA] [============--------] 18/30 files | ETA: **:**:**
+[DATA]  processing file: /app/serializers/application.ts
+[DATA] [============--------] 19/30 files | ETA: **:**:**
+[DATA]  processing file: /app/services/locale.ts
+[DATA] [=============-------] 20/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/about.hbs
+[DATA] [==============------] 21/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/application.hbs
+[DATA] [==============------] 22/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/contact.hbs
+[DATA] [===============-----] 23/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/index.hbs
+[DATA] [================----] 24/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/rental.hbs
+[DATA] [================----] 25/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/detailed.hbs
+[DATA] [=================---] 26/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/image.hbs
+[DATA] [==================--] 27/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/image.ts
+[DATA] [==================--] 28/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals/filter.hbs
+[DATA] [===================-] 29/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   107 errors caught by rehearsal
 [TITLE]   22 have been fixed by rehearsal
 [TITLE]   85 errors need to be fixed manually
@@ -536,6 +586,7 @@ exports[`fix command > ember_js_app_4.11 --mode=single-pass 1`] = `
 [TITLE]     -- 54 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   107 errors caught by rehearsal
 [SUCCESS]   22 have been fixed by rehearsal
 [SUCCESS]   85 errors need to be fixed manually
@@ -751,37 +802,70 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /app/app.ts
-[DATA] processing file: /app/router.ts
-[DATA] processing file: /app/adapters/application.ts
-[DATA] processing file: /app/components/audience-demographics.hbs
-[DATA] processing file: /app/components/audience-demographics.ts
-[DATA] processing file: /app/components/hello-world.gts
-[DATA] processing file: /app/components/jumbo.hbs
-[DATA] processing file: /app/components/map.hbs
-[DATA] processing file: /app/components/map.ts
-[DATA] processing file: /app/components/nav-bar.hbs
-[DATA] processing file: /app/components/rental.hbs
-[DATA] processing file: /app/components/rentals.hbs
-[DATA] processing file: /app/components/rentals.ts
-[DATA] processing file: /app/components/share-button.hbs
-[DATA] processing file: /app/components/share-button.ts
-[DATA] processing file: /app/models/rental.ts
-[DATA] processing file: /app/routes/index.ts
-[DATA] processing file: /app/routes/rental.ts
-[DATA] processing file: /app/serializers/application.ts
-[DATA] processing file: /app/services/locale.ts
-[DATA] processing file: /app/templates/about.hbs
-[DATA] processing file: /app/templates/application.hbs
-[DATA] processing file: /app/templates/contact.hbs
-[DATA] processing file: /app/templates/index.hbs
-[DATA] processing file: /app/templates/rental.hbs
-[DATA] processing file: /app/components/rental/detailed.hbs
-[DATA] processing file: /app/components/rental/image.hbs
-[DATA] processing file: /app/components/rental/image.ts
-[DATA] processing file: /app/components/rentals/filter.hbs
-[DATA] processing file: /app/components/rentals/filter.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/30 files | ETA: **:**:**
+[DATA]  processing file: /app/app.ts
+[DATA] [--------------------] 1/30 files | ETA: **:**:**
+[DATA]  processing file: /app/router.ts
+[DATA] [=-------------------] 2/30 files | ETA: **:**:**
+[DATA]  processing file: /app/adapters/application.ts
+[DATA] [==------------------] 3/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/audience-demographics.hbs
+[DATA] [==------------------] 4/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/audience-demographics.ts
+[DATA] [===-----------------] 5/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/hello-world.gts
+[DATA] [====----------------] 6/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/jumbo.hbs
+[DATA] [====----------------] 7/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/map.hbs
+[DATA] [=====---------------] 8/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/map.ts
+[DATA] [======--------------] 9/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/nav-bar.hbs
+[DATA] [======--------------] 10/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental.hbs
+[DATA] [=======-------------] 11/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals.hbs
+[DATA] [========------------] 12/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals.ts
+[DATA] [========------------] 13/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/share-button.hbs
+[DATA] [=========-----------] 14/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/share-button.ts
+[DATA] [==========----------] 15/30 files | ETA: **:**:**
+[DATA]  processing file: /app/models/rental.ts
+[DATA] [==========----------] 16/30 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/index.ts
+[DATA] [===========---------] 17/30 files | ETA: **:**:**
+[DATA]  processing file: /app/routes/rental.ts
+[DATA] [============--------] 18/30 files | ETA: **:**:**
+[DATA]  processing file: /app/serializers/application.ts
+[DATA] [============--------] 19/30 files | ETA: **:**:**
+[DATA]  processing file: /app/services/locale.ts
+[DATA] [=============-------] 20/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/about.hbs
+[DATA] [==============------] 21/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/application.hbs
+[DATA] [==============------] 22/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/contact.hbs
+[DATA] [===============-----] 23/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/index.hbs
+[DATA] [================----] 24/30 files | ETA: **:**:**
+[DATA]  processing file: /app/templates/rental.hbs
+[DATA] [================----] 25/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/detailed.hbs
+[DATA] [=================---] 26/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/image.hbs
+[DATA] [==================--] 27/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rental/image.ts
+[DATA] [==================--] 28/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals/filter.hbs
+[DATA] [===================-] 29/30 files | ETA: **:**:**
+[DATA]  processing file: /app/components/rentals/filter.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   123 errors caught by rehearsal
 [TITLE]   46 have been fixed by rehearsal
 [TITLE]   77 errors need to be fixed manually
@@ -789,6 +873,7 @@ exports[`fix command > ember_js_app_4.11 1`] = `
 [TITLE]     -- 47 glint errors, with details in the report
 [TITLE]     -- 2 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   123 errors caught by rehearsal
 [SUCCESS]   46 have been fixed by rehearsal
 [SUCCESS]   77 errors need to be fixed manually
@@ -859,11 +944,18 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [STARTED] Analyzing project dependency graph
 [SUCCESS] Analyzing project dependency graph
 [STARTED] Infer Types
-[DATA] processing file: /src/GreetingHeader.ts
-[DATA] processing file: /src/App.ts
-[DATA] processing file: /src/SimpleComponent.ts
-[DATA] processing file: /src/index.ts
+[DATA] starting...
+[DATA] preparing files ...
+[DATA] [--------------------] 0/4 files | ETA: **:**:**
+[DATA]  processing file: /src/GreetingHeader.ts
+[DATA] [=====---------------] 1/4 files | ETA: **:**:**
+[DATA]  processing file: /src/App.ts
+[DATA] [==========----------] 2/4 files | ETA: **:**:**
+[DATA]  processing file: /src/SimpleComponent.ts
+[DATA] [===============-----] 3/4 files | ETA: **:**:**
+[DATA]  processing file: /src/index.ts
 [TITLE] Types Inferred
+[TITLE]   Duration: 00:00
 [TITLE]   27 errors caught by rehearsal
 [TITLE]   16 have been fixed by rehearsal
 [TITLE]   11 errors need to be fixed manually
@@ -871,6 +963,7 @@ exports[`fix command > glimmerx_js_app 1`] = `
 [TITLE]     -- 10 glint errors, with details in the report
 [TITLE]     -- 0 eslint errors, with details in the report
 [SUCCESS] Types Inferred
+[SUCCESS]   Duration: 00:00
 [SUCCESS]   27 errors caught by rehearsal
 [SUCCESS]   16 have been fixed by rehearsal
 [SUCCESS]   11 errors need to be fixed manually

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -160,9 +160,19 @@ export function parseCommaSeparatedList(value: string): string[] {
 
 /**
  * Reads a tsConfig file
- * @param configPath
- * @returns
  */
 export function readTSConfig<T>(configPath: string): T {
   return json5.parse(readFileSync(configPath, 'utf-8'));
+}
+
+/**
+ * Converts seconds to 00:00 or 00:00:00 format
+ */
+
+export function secondsToTime(seconds: number): string {
+  const time = new Date(0);
+  time.setSeconds(seconds);
+  const iso = time.toISOString();
+
+  return iso.substring(11, 13) === '00' ? iso.substring(14, 19) : iso.substring(11, 19);
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export * from './cli.js';
+export * from './progress-bar.js';

--- a/packages/utils/src/progress-bar.ts
+++ b/packages/utils/src/progress-bar.ts
@@ -1,0 +1,89 @@
+export class ProgressBar {
+  private itemsTotal = 0;
+  private itemsDone = 0;
+
+  private timeStart = 0;
+  private timeAverage = 0;
+  private timeLast = Infinity;
+
+  private testMode = false;
+
+  constructor(total: number, testMode?: boolean) {
+    this.testMode = !!testMode;
+    this.reset(total);
+  }
+
+  get now(): number {
+    return this.testMode ? 0 : Date.now();
+  }
+
+  get total(): number {
+    return this.itemsTotal;
+  }
+
+  get done(): number {
+    return this.itemsDone;
+  }
+
+  get left(): number {
+    return this.itemsTotal - this.itemsDone;
+  }
+
+  get secondsPassed(): number {
+    return Math.floor((this.timeLast - this.timeStart) / 1000);
+  }
+
+  get timePassed(): string {
+    return this.secondsToTime(this.secondsPassed);
+  }
+
+  get secondsLeft(): number {
+    return Math.ceil((this.timeAverage * this.left) / 1000);
+  }
+
+  get timeLeft(): string {
+    return this.secondsToTime(this.secondsLeft);
+  }
+
+  reset(total: number): void {
+    this.itemsTotal = total;
+    this.itemsDone = 0;
+    this.timeStart = this.now;
+    this.timeAverage = 0;
+    this.timeLast = this.now;
+  }
+
+  increment(): void {
+    if (this.itemsDone === this.itemsTotal) {
+      return;
+    }
+
+    const timeNow = this.now;
+    const timeAfterIncrement = timeNow - this.timeLast;
+
+    this.timeAverage =
+      (this.timeAverage * this.itemsDone + timeAfterIncrement) / (this.itemsDone + 1);
+
+    this.itemsDone += 1;
+    this.timeLast = timeNow;
+  }
+
+  currentProgress(base = 100): number {
+    return this.itemsDone > this.itemsTotal
+      ? base
+      : Math.floor((this.itemsDone * base) / this.itemsTotal);
+  }
+
+  printBar(base = 100, fillSymbol = '=', emptySymbol = '-'): string {
+    const progress = this.currentProgress(base);
+    return `${fillSymbol.repeat(progress)}${emptySymbol.repeat(base - progress)}`;
+  }
+
+  private secondsToTime(seconds: number): string {
+    const time = new Date(0);
+    time.setSeconds(seconds);
+    const iso = time.toISOString();
+
+    return iso.substring(11, 14) === '00' ? iso.substring(14, 19) : iso.substring(11, 19);
+  }
+}

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -8,6 +8,7 @@ import {
   isYarnManager,
   isBinExisted,
   getManagerBinPath,
+  secondsToTime,
 } from '../src/index.js';
 
 export function removeSpecialChars(input: string): string {
@@ -122,5 +123,13 @@ describe('utils', () => {
       '--save-dev',
       '--ignore-scripts',
     ]);
+  });
+
+  test('secondsToTime()', () => {
+    expect(secondsToTime(0)).equal(`00:00`);
+    expect(secondsToTime(30)).equal(`00:30`);
+    expect(secondsToTime(60)).equal(`01:00`);
+    expect(secondsToTime(3723)).equal(`01:02:03`);
+    expect(secondsToTime(-50)).equal(`23:59:10`);
   });
 });

--- a/packages/utils/test/progress-bar.test.ts
+++ b/packages/utils/test/progress-bar.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+import { ProgressBar } from '../src/index.js';
+
+describe('progress bar', () => {
+  test('workflow, real mode', async () => {
+    const progress = new ProgressBar(3);
+
+    expect(progress.done).toEqual(0);
+    expect(progress.left).toEqual(3);
+    expect(progress.secondsPassed).toEqual(0);
+    expect(progress.timePassed).toEqual('00:00:00');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(0);
+    expect(progress.printBar(20)).toEqual('--------------------');
+
+    await new Promise((r) => setTimeout(r, 1000));
+
+    progress.increment();
+
+    expect(progress.done).toEqual(1);
+    expect(progress.left).toEqual(2);
+    expect(progress.secondsPassed).toEqual(1);
+    expect(progress.timePassed).toEqual('00:00:01');
+    expect(progress.secondsLeft).toEqual(3);
+    expect(progress.timeLeft).toEqual('00:00:03');
+    expect(progress.currentProgress(30)).toEqual(10);
+    expect(progress.printBar(20)).toEqual('======--------------');
+
+    progress.increment();
+
+    expect(progress.done).toEqual(2);
+    expect(progress.left).toEqual(1);
+    expect(progress.secondsPassed).toEqual(1);
+    expect(progress.timePassed).toEqual('00:00:01');
+    expect(progress.secondsLeft).toEqual(1);
+    expect(progress.timeLeft).toEqual('00:00:01');
+    expect(progress.currentProgress(30)).toEqual(20);
+    expect(progress.printBar(20)).toEqual('=============-------');
+
+    progress.increment();
+
+    expect(progress.done).toEqual(3);
+    expect(progress.left).toEqual(0);
+    expect(progress.secondsPassed).toEqual(1);
+    expect(progress.timePassed).toEqual('00:00:01');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(30);
+    expect(progress.printBar(20)).toEqual('====================');
+
+    progress.increment();
+
+    expect(progress.done).toEqual(3);
+    expect(progress.left).toEqual(0);
+    expect(progress.secondsPassed).toEqual(1);
+    expect(progress.timePassed).toEqual('00:00:01');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(30);
+    expect(progress.printBar(20)).toEqual('====================');
+  });
+
+  test('workflow, test mode', async () => {
+    const progress = new ProgressBar(3, true);
+
+    expect(progress.done).toEqual(0);
+    expect(progress.left).toEqual(3);
+    expect(progress.secondsPassed).toEqual(0);
+    expect(progress.timePassed).toEqual('00:00:00');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(0);
+    expect(progress.printBar(20)).toEqual('--------------------');
+
+    await new Promise((r) => setTimeout(r, 1000));
+
+    progress.increment();
+
+    expect(progress.done).toEqual(1);
+    expect(progress.left).toEqual(2);
+    expect(progress.secondsPassed).toEqual(0);
+    expect(progress.timePassed).toEqual('00:00:00');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(10);
+    expect(progress.printBar(20)).toEqual('======--------------');
+  });
+
+  test('reset', () => {
+    const progress = new ProgressBar(3);
+
+    expect(progress.done).toEqual(0);
+    expect(progress.left).toEqual(3);
+    expect(progress.secondsPassed).toEqual(0);
+    expect(progress.timePassed).toEqual('00:00:00');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(0);
+    expect(progress.printBar(20)).toEqual('--------------------');
+
+    progress.increment();
+    progress.increment();
+
+    progress.reset(50);
+
+    expect(progress.done).toEqual(0);
+    expect(progress.left).toEqual(50);
+    expect(progress.secondsPassed).toEqual(0);
+    expect(progress.timePassed).toEqual('00:00:00');
+    expect(progress.secondsLeft).toEqual(0);
+    expect(progress.timeLeft).toEqual('00:00:00');
+    expect(progress.currentProgress(30)).toEqual(0);
+    expect(progress.printBar(20)).toEqual('--------------------');
+  });
+});


### PR DESCRIPTION
Closes #1239 

Adds progress bar during type inferring and duration takes to process files at the end.

```
✔ Initialize
✔ Analyzing project dependency graph ...
⠼ Infer Types
  › starting...
  
  › preparing files ...
  
  › [--------------------] 0/4 files | ETA: **:**:**
     processing file: /src/GreetingHeader.ts

  › [=====---------------] 1/4 files | ETA: 00:00:06
     processing file: /src/App.ts
     
  › [==========----------] 2/4 files | ETA: 00:00:05
     processing file: /src/SimpleComponent.ts
     
  › [===============-----] 3/4 files | ETA: 00:00:02
     processing file: /src/index.ts
     
✔ Types Inferred
     Duration: 00:09
     ... errors caught by rehearsal
```