### PR TITLE
fix: wrap es-module-lexer parse in a try/catch better error handling

### DIFF
--- a/packages/migration-graph/test/resolver.test.ts
+++ b/packages/migration-graph/test/resolver.test.ts
@@ -161,7 +161,6 @@ describe('Resolver', () => {
             },
           }),
         },
-
         'package-e': {
           'dist-types': {
             src: {
@@ -207,7 +206,6 @@ describe('Resolver', () => {
             },
           }),
         },
-
         'package-f': {
           unresolvable: {
             'index.js': `
@@ -330,6 +328,26 @@ describe('Resolver', () => {
           },
           'package.json': JSON.stringify({
             name: '@company/package-4',
+            dependencies: {},
+          }),
+        },
+
+        'parse-failure': {
+          src: {
+            'index.js': `
+            import MDXComponents from '@theme/MDXComponents';
+            function TokensHeader() {
+              return (
+                <section>
+                  <H1>blah</H1>
+                  <p>foo</p>
+                </section>
+              );
+            }
+            `,
+          },
+          'package.json': JSON.stringify({
+            name: '@company/package-5',
             dependencies: {},
           }),
         },
@@ -491,6 +509,12 @@ describe('Resolver', () => {
     expect(
       generateJson(project.baseDir, resolver.graph, topSortFiles(resolver.graph))
     ).toMatchSnapshot();
+  });
+
+  test('it throws with path to file', () => {
+    expect(() => {
+      resolver.walk(project.baseDir + '/packages/parse-failure/src/index.js');
+    }).toThrowError(`Failed to parse contents of file:`);
   });
 });
 


### PR DESCRIPTION
This small PR improves the DX by implementing error handling when the migration-graph resolver chokes via `es-module-lexer:parse`. 

## BEFORE
It isn't obvious why the `rehearsal graph` command is failing

```
rehearsal graph                               

yarn run v1.22.15
✖ Parse error @:17:22

node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^
Error: Parse error @:17:22
    at parse (file:///hue-web-foundations/node_modules/@rehearsal/migration-graph/node_modules/es-module-lexer/dist/lexer.js:2:358)
    at Resolver.walk (file:///hue-web-foundations/node_modules/@rehearsal/migration-graph/dist/src/resolver.js:65:27)
    at file:///hue-web-foundations/node_modules/@rehearsal/cli/dist/src/commands/graph/tasks/graphWorker.js:19:18 {
  idx: 550
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## AFTER
The command is clearly failing because of a parsing error in `tokens.js`

```
rehearsal graph                               

yarn run v1.22.15
✖ Failed to parse contents of file: hue-web-foundations/docusaurus/src/pages/tokens.js

node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^
Error: Failed to parse contents of file: hue-web-foundations/docusaurus/src/pages/tokens.js
    at Resolver.walk (file:///hue-web-foundations/node_modules/@rehearsal/migration-graph/dist/src/resolver.js:65:27)
    at file:///hue-web-foundations/node_modules/@rehearsal/cli/dist/src/commands/graph/tasks/graphWorker.js:19:18 {
  idx: 550
}
```