### PR TITLE
fix: do not add empty lines before @ts-expect-error on sequential runs

### DIFF
--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -192,6 +192,30 @@ export class Something extends Component<InterfaceFromCommentSignature> {
 "
 `;
 
+exports[`fix > .gts > fix .gts file twice, no changes expected 1`] = `
+"export class Foo {
+  // @ts-expect-error @rehearsal TODO TS7050: Function 'hello' lacks a return-type annotation.
+  hello() {
+    // Existing comment
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'.
+    return this.name;
+  }
+}
+"
+`;
+
+exports[`fix > .gts > fix .gts file twice, no changes expected 2`] = `
+"export class Foo {
+  // @ts-expect-error @rehearsal TODO TS7050: Function 'hello' lacks a return-type annotation.
+  hello() {
+    // Existing comment
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'.
+    return this.name;
+  }
+}
+"
+`;
+
 exports[`fix > .gts > still fixes the file if there are no errors 1`] = `
 "import Component from \\"@glimmer/component\\";
 
@@ -239,7 +263,6 @@ export interface SomethingSignature {
 
 export class Something extends Component<SomethingSignature> {
   /** */
-
   // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
   reset(...args): void {
     console.log(args);
@@ -446,6 +469,28 @@ exports[`fix > .hbs > template only 1`] = `"Hello!"`;
 exports[`fix > .ts > class with missing prop 1`] = `
 "class Foo {
   hello() {
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'.
+    return this.name;
+  }
+}
+"
+`;
+
+exports[`fix > .ts > fix .ts file twice, no changes expected 1`] = `
+"export class Foo {
+  hello() {
+    // Existing comment
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'.
+    return this.name;
+  }
+}
+"
+`;
+
+exports[`fix > .ts > fix .ts file twice, no changes expected 2`] = `
+"export class Foo {
+  hello() {
+    // Existing comment
     // @ts-expect-error @rehearsal TODO TS2339: Property 'name' does not exist on type 'Foo'.
     return this.name;
   }

--- a/packages/migrate/test/fixtures/project/src/gts/foo.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/foo.gts
@@ -1,0 +1,6 @@
+export class Foo {
+  hello() {
+    // Existing comment
+    return this.name;
+  }
+}

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -385,6 +385,32 @@ describe('fix', () => {
       expectFile(outputs[0]).toMatchSnapshot();
     });
 
+    test('fix .gts file twice, no changes expected', async () => {
+      const [inputs, outputs] = prepareInputFiles(project, ['gts/foo.gts']);
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: project.baseDir,
+        filesToMigrate: inputs,
+        reporter,
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).toMatchSnapshot();
+
+      const theFirstPassOutput = readFileSync(outputs[0]).toString();
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).toMatchSnapshot();
+      expectFile(outputs[0]).toEqual(theFirstPassOutput);
+    });
+
     describe('component signature codefix', () => {
       test('with typedef for component signature interface', async () => {
         const [inputs, outputs] = prepareInputFiles(project, ['gts/signatures/with-typedef.gts']);
@@ -890,6 +916,47 @@ describe('fix', () => {
       }
 
       expectFile(outputs[0]).toMatchSnapshot();
+    });
+
+    test('fix .ts file twice, no changes expected', async () => {
+      project.mergeFiles({
+        src: {
+          'foo.ts': `
+export class Foo {
+  hello() {
+    // Existing comment
+    return this.name;
+  }
+}
+`,
+        },
+      });
+
+      await project.write();
+
+      const [inputs, outputs] = prepareInputFiles(project, ['foo.ts']);
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: project.baseDir,
+        filesToMigrate: inputs,
+        reporter,
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).toMatchSnapshot();
+
+      const theFirstPassOutput = readFileSync(outputs[0]).toString();
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).toMatchSnapshot();
+      expectFile(outputs[0]).toEqual(theFirstPassOutput);
     });
   });
 

--- a/packages/plugins/src/plugins/re-rehearse.plugin.ts
+++ b/packages/plugins/src/plugins/re-rehearse.plugin.ts
@@ -1,9 +1,8 @@
-import ts from 'typescript';
 import { PluginOptions, Plugin } from '@rehearsal/service';
 import debug from 'debug';
+import { getBoundaryOfCommentBlock } from './utils.js';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:rerehearse');
-const { isLineBreak } = ts;
 
 export interface ReRehearsePluginOptions extends PluginOptions {
   commentTag: string;
@@ -33,8 +32,8 @@ export class ReRehearsePlugin extends Plugin<ReRehearsePluginOptions> {
       }
 
       // Remove comment, together with the {} that wraps around comments in React
-      const boundary = this.getBoundaryOfCommentBlock(commentSpan.start, commentSpan.length, text);
-      text = text.substring(0, boundary.start) + text.substring(boundary.end);
+      const boundary = getBoundaryOfCommentBlock(commentSpan.start, commentSpan.length, text);
+      text = text.substring(0, boundary.start) + text.substring(boundary.end + 1);
     }
 
     context.service.setFileText(fileName, text);
@@ -42,23 +41,5 @@ export class ReRehearsePlugin extends Plugin<ReRehearsePluginOptions> {
     DEBUG_CALLBACK(`Plugin 'ReRehearse' run on %O:`, fileName);
 
     return Promise.resolve([fileName]);
-  }
-
-  getBoundaryOfCommentBlock(
-    start: number,
-    length: number,
-    text: string
-  ): { start: number; end: number } {
-    const newStart = start - 1 >= 0 && text[start - 1] === '{' ? start - 1 : start;
-
-    let end = start + length - 1;
-
-    end = end + 1 < text.length && text[end + 1] === '}' ? end + 1 : end;
-    end = isLineBreak(text.charCodeAt(end + 1)) ? end + 1 : end;
-
-    return {
-      start: newStart,
-      end,
-    };
   }
 }

--- a/packages/plugins/src/plugins/utils.ts
+++ b/packages/plugins/src/plugins/utils.ts
@@ -137,3 +137,21 @@ export function inJsxText(sourceFile: ts.SourceFile, pos: number): boolean {
 
   return !!ts.forEachChild(sourceFile, visitor);
 }
+
+export function getBoundaryOfCommentBlock(
+  start: number,
+  length: number,
+  text: string
+): { start: number; end: number } {
+  const newStart = start - 1 >= 0 && text[start - 1] === '{' ? start - 1 : start;
+
+  let end = start + length - 1;
+
+  end = end + 1 < text.length && text[end + 1] === '}' ? end + 1 : end;
+  end = ts.isLineBreak(text.charCodeAt(end + 1)) ? end + 1 : end;
+
+  return {
+    start: newStart,
+    end,
+  };
+}

--- a/packages/plugins/test/__snapshots__/re-rehearse.plugin.test.ts.snap
+++ b/packages/plugins/test/__snapshots__/re-rehearse.plugin.test.ts.snap
@@ -6,31 +6,24 @@ exports[`Test ReRehearsalPlugin > run 1`] = `
  */
 import fs from 'fs';
 
-
 function unusedFunction(): boolean {
   return fs.existsSync('.');
 }
 
-
 let unusedVariable: number;
 
 /* This is just a second comment that should not be touch */
-
 const unusedConst1 = null;
-
 
 const unusedConst2 = null;
 
-fs.existsSync('.'); 
-const unusedConst3 = null;
+fs.existsSync('.'); const unusedConst3 = null;
 
 fs.existsSync('@rehearsal');
 const unusedConstWithoutCommentButWithRehearsalTagAbove =
   null;
 
 const resultValue = something
-  ? 
-    missingVar
-  : 
-    missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;"
+  ?     missingVar
+  :     missingVarAsWellButThisTimeWeUseVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString;"
 `;


### PR DESCRIPTION
The `re-rehearse` plugin removes existing comments with `@rehearsal` without including `\n`.

This PR fixes the issue and `@rehearsal` comments will be removed correctly (including `\n` at the end).

Fixes https://github.com/rehearsal-js/rehearsal-js/issues/1246