### PR TITLE
feat: add strict type from jsdocs to .gts files

### DIFF
--- a/packages/codefixes/src/codefixes.ts
+++ b/packages/codefixes/src/codefixes.ts
@@ -28,7 +28,11 @@ export const codefixes = new CodeFixesProvider([
 ]);
 
 export const glintCodeFixes = new CodeFixesProvider([
-  new BaseCodeFixCollection([new AddMissingReturnTypesCodeFix(), new StubMissingJSDocParamName()]),
+  new BaseCodeFixCollection([
+    new AddMissingReturnTypesCodeFix(),
+    new AnnotateWithStrictTypeFromJSDoc(),
+    new StubMissingJSDocParamName(),
+  ]),
   new GlintCodeFixCollection(),
   new BaseCodeFixCollection([
     // Need to be run after standard "typedef to type" fix applied

--- a/packages/codefixes/src/codefixesMessages.json
+++ b/packages/codefixes/src/codefixesMessages.json
@@ -10,7 +10,8 @@
     "description": "Adds the missing `await` keyword where a promise should be returned but not being properly handled.",
     "messages": [95083],
     "diagnostics": [
-      2356, 2362, 2363, 2736, 2365, 2367, 2801, 2461, 2495, 2802, 2549, 2548, 2488, 2504, 2345, 2339, 2349, 2351
+      2356, 2362, 2363, 2736, 2365, 2367, 2801, 2461, 2495, 2802, 2549, 2548, 2488, 2504, 2345,
+      2339, 2349, 2351
     ]
   },
   "addMissingAwaitToInitializer": {
@@ -18,7 +19,8 @@
     "description": "Adds missing `await` keyword to declarations and expressions.",
     "messages": [95084, 95089],
     "diagnostics": [
-      2339, 2349, 2351, 2356, 2362, 2363, 2736, 2365, 2367, 2801, 2461, 2495, 2802, 2549, 2548, 2488, 2504, 2345
+      2339, 2349, 2351, 2356, 2362, 2363, 2736, 2365, 2367, 2801, 2461, 2495, 2802, 2549, 2548,
+      2488, 2504, 2345
     ]
   },
   "addMissingConst": {
@@ -164,7 +166,8 @@
     "description": "Infers the types based on how the value is being used.",
     "messages": [95011, 95012, 95080],
     "diagnostics": [
-      7034, 7005, 7006, 7019, 7033, 7010, 7032, 7008, 7046, 7043, 7044, 7047, 7048, 7050, 7049, 7045, 2683
+      7034, 7005, 7006, 7019, 7033, 7010, 7032, 7008, 7046, 7043, 7044, 7047, 7048, 7050, 7049,
+      7045, 2683
     ]
   },
   "invalidImportSyntax": {
@@ -197,12 +200,11 @@
     "messages": [95013],
     "diagnostics": [80003]
   },
-
   "annotateWithStrictTypeFromJSDoc": {
     "title": "Annotate Strict Types From JSDoc",
     "description": "Annotates code with the only strict types from the declared JSDoc comments. Strict replacement for annotateWithTypeFromJSDoc",
     "diagnostics": [80004],
-    "messages": [95009],
+    "messages": [],
     "builtIn": true
   },
   "addErrorTypeGuard": {

--- a/packages/codefixes/src/glint-codefix-collection.ts
+++ b/packages/codefixes/src/glint-codefix-collection.ts
@@ -1,13 +1,13 @@
 import { type Diagnostic, CodeActionKind } from 'vscode-languageserver';
+import ts, { type FormatCodeSettings, type CodeFixAction } from 'typescript';
 import { TypescriptCodeFixCollection } from './typescript-codefix-collection.js';
 import { isCodeFixSupportedByDescription } from './safe-codefixes.js';
 import type { GlintService } from '@rehearsal/service';
-import ts, { type FormatCodeSettings, type CodeFixAction } from 'typescript';
 import type { CodeFixCollectionFilter, DiagnosticWithContext } from './types.js';
 
 const { getDefaultFormatCodeSettings } = ts;
 
-interface GlintDiagnosticWithContext extends DiagnosticWithContext {
+export interface GlintDiagnosticWithContext extends DiagnosticWithContext {
   glintService: GlintService;
   glintDiagnostic: Diagnostic;
 }

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -1,5 +1,251 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`fix > .gts > annotate with strict types 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+export interface SomethingSignature {
+  Args: { age: any };
+}
+
+export class Something extends Component<SomethingSignature> {
+  /** */
+  // @ts-expect-error @rehearsal TODO TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
+  reset(...args): void {
+    console.log(args);
+  }
+
+  shouldExist(): void {
+    console.log(\\"should exist in output\\");
+  }
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}
+
+export class Foo {
+  value = 0;
+}
+
+export class GenericClass<something = number, somethingElse = number> {
+  // @ts-expect-error @rehearsal TODO TS7050: Function 'thing' lacks a return-type annotation.
+  thing(a: something, b: somethingElse) {
+    console.log(a, b);
+  }
+}
+
+/** @type {number | string} */
+export const a: number | string = 0;
+
+/** @type {number | string | UnavailableType} */
+// @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+export const b = 0;
+
+/** @type {GenericClass<string, string, string>} */
+// @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+export const c = 0;
+
+export class ThinkClass {
+  /** @type {number | null} */
+  a: number | null = 0;
+
+  /** @type {number | UnavailableType} */
+  // @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+  b = 0;
+
+  /**
+   * JSDoc
+   *
+   * @param {number} a                                //
+   * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+   * @param {Foo} c                                   // TypeReference
+   * @param {number|UnavailableType} d                // UnionType
+   * @param {() => boolean} e                         // FunctionType
+   * @param {GenericClass<string, string>} f          // TypeReference
+
+   * @param {<callbackFunction>} g                    // FunctionType
+
+   * @param {UnavailableType} h                       // TypeReference
+   * @param {Foo|UnavailableType} i                   // UnionType
+   * @param {() => UnavailableType} j                 // FunctionType
+   * @param {GenericClass<string, UnavailableType>} k // TypeReference
+   * @param {number|() => UnavailableType} l          // UnionType
+   * @param {(a: UnavailableType) => void} m          // FunctionType
+   * @param {(a, b: string) => void} n                // FunctionType
+
+   * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+   * @param {{ a: string, b: Date }} p
+   * @param {{ a: string, b: UnavailableType }} q
+   * @param {function(this:{ a: string}, string, number): boolean} r
+
+   * @return {void}
+   */
+  // @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+  more(
+    a: number,
+    b: string | number,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'c' implicitly has an 'any' type.
+    c,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'd' implicitly has an 'any' type.
+    d,
+    e: () => boolean,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'f' implicitly has an 'any' type.
+    f,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'g' implicitly has an 'any' type.
+    g,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'h' implicitly has an 'any' type.
+    h,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'i' implicitly has an 'any' type.
+    i,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'j' implicitly has an 'any' type.
+    j,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'k' implicitly has an 'any' type.
+    k,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'l' implicitly has an 'any' type.
+    l,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'm' implicitly has an 'any' type.
+    m,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'a' implicitly has an 'any' type.
+    n: (a, b: string) => void,
+    o: GenericClass<string, string, string>,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'p' implicitly has an 'any' type.
+    p,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 'q' implicitly has an 'any' type.
+    q,
+    r: (this: { a: string }, arg1: string, arg2: number) => boolean,
+    // @ts-expect-error @rehearsal TODO TS7006: Parameter 's' implicitly has an 'any' type.
+    s
+  ): void {
+    return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+  }
+
+  /**
+   * Some function
+   * @param {UnavailableType} a
+   * @return {UnavailableType}
+   */
+  // @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+  twice(a) {
+    return a;
+  }
+}
+
+/**
+ * JSDoc
+ *
+ * @param {number} a                                //
+ * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+ * @param {Foo} c                                   // TypeReference
+ * @param {number|UnavailableType} d                // UnionType
+ * @param {() => boolean} e                         // FunctionType
+ * @param {GenericClass<string, string>} f          // TypeReference
+
+ * @param {<callbackFunction>} g                    // FunctionType
+
+ * @param {UnavailableType} h                       // TypeReference
+ * @param {Foo|UnavailableType} i                   // UnionType
+ * @param {() => UnavailableType} j                 // FunctionType
+ * @param {GenericClass<string, UnavailableType>} k // TypeReference
+ * @param {number|() => UnavailableType} l          // UnionType
+ * @param {(a: UnavailableType) => void} m          // FunctionType
+ * @param {(a, b: string) => void} n                // FunctionType
+
+ * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+ * @param {{ a: string, b: Date }} p                //
+ * @param {{ a: string, b: UnavailableType }} q     //
+ * @param {function(this:{ a: string}, string, number): boolean} r
+
+ * @return {void}
+ */
+// @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+export function think(
+  a: number,
+  b: string | number,
+  c: Foo,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'd' implicitly has an 'any' type.
+  d,
+  e: () => boolean,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'f' implicitly has an 'any' type.
+  f,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'g' implicitly has an 'any' type.
+  g,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'h' implicitly has an 'any' type.
+  h,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'i' implicitly has an 'any' type.
+  i,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'j' implicitly has an 'any' type.
+  j,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'k' implicitly has an 'any' type.
+  k,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'l' implicitly has an 'any' type.
+  l,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'm' implicitly has an 'any' type.
+  m,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'a' implicitly has an 'any' type.
+  n: (a, b: string) => void,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'o' implicitly has an 'any' type.
+  o,
+  p: { a: string; b: Date },
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 'q' implicitly has an 'any' type.
+  q,
+  r: (this: { a: string }, arg1: string, arg2: number) => boolean,
+  // @ts-expect-error @rehearsal TODO TS7006: Parameter 's' implicitly has an 'any' type.
+  s
+): void {
+  return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+}
+
+/**
+ * Some function
+ * @param {UnavailableType} a
+ * @return {UnavailableType}
+ */
+// @ts-expect-error @rehearsal TODO TS80004: JSDoc types may be moved to TypeScript types.
+export function thinkTwice(a) {
+  return a;
+}
+
+/**
+ * The return type is throwing an error
+ * @param {[number, number]} a-and-b
+ * @param {Array<string>} c
+ * @return {Array<{content: string}>}
+ */
+export function issueWithTheReturnType(
+  [a, b]: [number, number],
+  c: Array<string>
+): Array<{ content: string }> {
+  a;
+  b;
+  c;
+  // @ts-expect-error @rehearsal TODO TS2322: Type 'string' is being returned or assigned, but type 'content: string' is expected. Please convert type 'string' to type 'content: string', or return or assign a variable of type 'content: string'
+  return c;
+}
+
+/**
+ * The example of type inference of destructured parameters
+ * @param {[number, number]} a-and-b
+ * @param {[string, string]} the next one
+ * @param {boolean} e
+ * @return void
+ */
+// @ts-expect-error @rehearsal TODO TS7050: Function 'inferenceOfDestructuredParams' lacks a return-type annotation.
+export function inferenceOfDestructuredParams(
+  [a, b]: [number, number],
+  [c, d]: [string, string],
+  e: boolean
+) {
+  a;
+  b;
+  c;
+  d;
+  e;
+}
+"
+`;
+
 exports[`fix > .gts > component signature codefix > add component signature interface 1`] = `
 "import Component from \\"@glimmer/component\\";
 

--- a/packages/migrate/test/fixtures/project/src/gts/with-strict-types.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/with-strict-types.gts
@@ -1,0 +1,158 @@
+import Component from "@glimmer/component";
+
+export class Something extends Component {
+  /**
+   * @param {Event} -- Something
+   * @param {string} -- Another
+   * @param {*} -- I don't know
+   */
+
+  reset(...args) {
+    console.log(args);
+  }
+
+  shouldExist() {
+    console.log("should exist in output");
+  }
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}
+
+export class Foo {
+  value = 0;
+}
+
+export class GenericClass<something = number, somethingElse = number> {
+  thing(a: something, b: somethingElse) {
+    console.log(a, b);
+  }
+}
+
+/** @type {number | string} */
+export const a = 0;
+
+/** @type {number | string | UnavailableType} */
+export const b = 0;
+
+/** @type {GenericClass<string, string, string>} */
+export const c = 0;
+
+export class ThinkClass {
+  /** @type {number | null} */
+  a = 0;
+
+  /** @type {number | UnavailableType} */
+  b = 0;
+
+  /**
+   * JSDoc
+   *
+   * @param {number} a                                //
+   * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+   * @param {Foo} c                                   // TypeReference
+   * @param {number|UnavailableType} d                // UnionType
+   * @param {() => boolean} e                         // FunctionType
+   * @param {GenericClass<string, string>} f          // TypeReference
+
+   * @param {<callbackFunction>} g                    // FunctionType
+
+   * @param {UnavailableType} h                       // TypeReference
+   * @param {Foo|UnavailableType} i                   // UnionType
+   * @param {() => UnavailableType} j                 // FunctionType
+   * @param {GenericClass<string, UnavailableType>} k // TypeReference
+   * @param {number|() => UnavailableType} l          // UnionType
+   * @param {(a: UnavailableType) => void} m          // FunctionType
+   * @param {(a, b: string) => void} n                // FunctionType
+
+   * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+   * @param {{ a: string, b: Date }} p
+   * @param {{ a: string, b: UnavailableType }} q
+   * @param {function(this:{ a: string}, string, number): boolean} r
+
+   * @return {void}
+   */
+  more(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
+    return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+  }
+
+  /**
+   * Some function
+   * @param {UnavailableType} a
+   * @return {UnavailableType}
+   */
+  twice(a) {
+    return a;
+  }
+}
+
+/**
+ * JSDoc
+ *
+ * @param {number} a                                //
+ * @param {(string|number)} b                       // ParenthesizedType.type => UnionType
+ * @param {Foo} c                                   // TypeReference
+ * @param {number|UnavailableType} d                // UnionType
+ * @param {() => boolean} e                         // FunctionType
+ * @param {GenericClass<string, string>} f          // TypeReference
+
+ * @param {<callbackFunction>} g                    // FunctionType
+
+ * @param {UnavailableType} h                       // TypeReference
+ * @param {Foo|UnavailableType} i                   // UnionType
+ * @param {() => UnavailableType} j                 // FunctionType
+ * @param {GenericClass<string, UnavailableType>} k // TypeReference
+ * @param {number|() => UnavailableType} l          // UnionType
+ * @param {(a: UnavailableType) => void} m          // FunctionType
+ * @param {(a, b: string) => void} n                // FunctionType
+
+ * @param {GenericClass<string, string, string>} o  // TypeReference... 3 args instead of 2
+
+ * @param {{ a: string, b: Date }} p                //
+ * @param {{ a: string, b: UnavailableType }} q     //
+ * @param {function(this:{ a: string}, string, number): boolean} r
+
+ * @return {void}
+ */
+export function think(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
+  return console.log(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
+}
+
+/**
+ * Some function
+ * @param {UnavailableType} a
+ * @return {UnavailableType}
+ */
+export function thinkTwice(a) {
+  return a;
+}
+
+/**
+ * The return type is throwing an error
+ * @param {[number, number]} a-and-b
+ * @param {Array<string>} c
+ * @return {Array<{content: string}>}
+ */
+export function issueWithTheReturnType([a, b], c) {
+  a;
+  b;
+  c;
+  return c;
+}
+
+/**
+ * The example of type inference of destructured parameters
+ * @param {[number, number]} a-and-b
+ * @param {[string, string]} the next one
+ * @param {boolean} e
+ * @return void
+ */
+export function inferenceOfDestructuredParams([a, b], [c, d], e) {
+  a;
+  b;
+  c;
+  d;
+  e;
+}

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -147,6 +147,29 @@ describe('fix', () => {
       project.dispose();
     });
 
+    test('annotate with strict types', async () => {
+      // since we are no longer doing a file conversion input and output are the same
+      const [inputs, outputs] = prepareInputFiles(project, ['gts/with-strict-types.gts']);
+
+      const input: MigrateInput = {
+        projectRootDir: project.baseDir,
+        packageDir: project.baseDir,
+        filesToMigrate: inputs,
+        reporter,
+        mode: 'drain',
+      };
+
+      for await (const _ of migrate(input)) {
+        // no ops
+      }
+
+      expectFile(outputs[0]).contains('export const a: number | string = 0;');
+      expectFile(outputs[0]).contains(
+        `// @ts-expect-error @rehearsal TODO TS7006: Parameter 'm' implicitly has an 'any' type.`
+      );
+      expectFile(outputs[0]).toMatchSnapshot();
+    });
+
     test('with bare template', async () => {
       // since we are no longer doing a file conversion input and output are the same
       const [inputs, outputs] = prepareInputFiles(project, ['gts/template-only.gts']);


### PR DESCRIPTION
Co-authored-by: @egorio 

- Added `AnnotateWithStrictTypeFromJSDoc` to the list of `glintCodeFixes`.
- Refactored `AnnotateWithStrictTypeFromJSDoc` to support a glint diagnotics.
  - This is not ideal, but it works. Ideally we shouldn't muddle an existing CodeFix for TS with glint specifics.
- Removed  diagnostic `95009` from `annotateWithStrictTypes.messages` in `packages/codefixes/src/codefixesMessages.json`.
```
  "annotateWithStrictTypeFromJSDoc": {
    "title": "Annotate Strict Types From JSDoc",
    "description": "Annotates code with the only strict types from the declared JSDoc comments. Strict replacement for annotateWithTypeFromJSDoc",
    "diagnostics": [80004],
-    "messages": [95009],
+    "messages": [],
    "builtIn": true
  },
```
This diagnostic message was causing the our strict types fix to be filtered out.

