### PR TITLE
chore: unwind circular monorepo deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "tmp": "^0.2.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
-    "vite": "^4.2.1",
-    "vitest": "^0.30.0",
+    "vite": "^4.4.9",
+    "vitest": "^0.34.3",
     "walk-sync": "^3.0.0"
   },
   "packageManager": "pnpm@8.6.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch --config ./vitest.config.ts",
     "version": "pnpm version"
   },
@@ -68,11 +68,11 @@
     "@rehearsal/test-support": "workspace:*",
     "@types/js-yaml": "^4.0.5",
     "@types/which": "^3.0.0",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify-project": "^5.2.0",
     "scenario-tester": "^2.1.2",
     "typescript-json-schema": "^0.56.0",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.3"
   },
   "packageManager": "pnpm@8.6.7",
   "engines": {

--- a/packages/cli/test/commands/fix/fix.test.ts
+++ b/packages/cli/test/commands/fix/fix.test.ts
@@ -1,7 +1,7 @@
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync, statSync } from 'node:fs';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi, type Assertion } from 'vitest';
 import { Project } from 'fixturify-project';
 import { createLogger, format, transports } from 'winston';
 import { getEmberProject } from '@rehearsal/test-support';
@@ -39,7 +39,7 @@ function projectInit(project: Project, type: ProjectType): void {
   });
 }
 
-function expectFile(filePath: string): Vi.Assertion<string> {
+function expectFile(filePath: string): Assertion<string> {
   return expect(readFileSync(filePath, 'utf-8'));
 }
 

--- a/packages/cli/test/fixtures/base_ts_app/package.json
+++ b/packages/cli/test/fixtures/base_ts_app/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "ts-node": "^10.9.1",
     "vite": "^4.0.4",
-    "vitest": "^0.27.2"
+    "vitest": "^0.34.3"
   }
 }

--- a/packages/codefixes/package.json
+++ b/packages/codefixes/package.json
@@ -33,7 +33,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
@@ -46,14 +46,14 @@
     "@rehearsal/migrate": "workspace:*",
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/service": "workspace:*",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify": "^3.0.0",
     "fixturify-project": "^5.2.0",
     "fs-extra": "^11.1.1",
     "json5": "^2.2.3",
     "prettier": "^3.0.2",
     "tmp": "^0.2.1",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.3"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -34,7 +34,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "pnpm fixtures:prepare && vitest --run --config ./vitest.config.ts --coverage",
+    "test": "pnpm fixtures:prepare && vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
@@ -54,10 +54,10 @@
     "winston": "^3.8.2"
   },
   "devDependencies": {
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify-project": "^5.2.0",
     "json5": "^2.2.3",
-    "vitest": "^0.30.0",
+    "vitest": "^0.34.3",
     "winston": "^3.8.2"
   },
   "peerDependencies": {

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -1,18 +1,10 @@
 import { join } from 'node:path';
 import { findUpSync } from 'find-up';
 import { readTSConfig, readJSON } from '@rehearsal/utils';
+import { RehearsalService, isGlintFile, isGlintProject, GlintService } from '@rehearsal/service';
 import {
   PluginsRunner,
-  RehearsalService,
-  isGlintFile,
-  isGlintProject,
-  GlintService,
   DummyPlugin,
-} from '@rehearsal/service';
-import debug from 'debug';
-import ts from 'typescript';
-import fastGlob from 'fast-glob';
-import {
   DiagnosticFixPlugin,
   DiagnosticCommentPlugin,
   isPrettierUsedForFormatting,
@@ -25,6 +17,9 @@ import {
   GlintCommentPlugin,
   GlintReportPlugin,
 } from '@rehearsal/plugins';
+import debug from 'debug';
+import ts from 'typescript';
+import fastGlob from 'fast-glob';
 import { getExcludePatterns } from '@rehearsal/migration-graph';
 import * as glintCore from '@glint/core';
 import type { Reporter } from '@rehearsal/reporter';

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -3,7 +3,7 @@ import path, { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Project } from 'fixturify-project';
 import { type Report, Reporter } from '@rehearsal/reporter';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, type Assertion } from 'vitest';
 import { getExcludePatterns } from '@rehearsal/migration-graph';
 import { ReportItemType } from '@rehearsal/reporter';
 import { migrate, MigrateInput, resolveIgnoredPaths } from '../src/migrate.js';
@@ -96,7 +96,7 @@ function isValidExtension(ext: string): ext is ValidExtension {
   return validExtensions.includes(ext);
 }
 
-function expectFile(filePath: string, message?: string): Vi.Assertion<string> {
+function expectFile(filePath: string, message?: string): Assertion<string> {
   return expect(readFileSync(filePath, 'utf-8'), message);
 }
 

--- a/packages/migration-graph/package.json
+++ b/packages/migration-graph/package.json
@@ -21,7 +21,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "version": "pnpm version"
   },
   "dependencies": {
@@ -41,11 +41,11 @@
   },
   "devDependencies": {
     "@rehearsal/test-support": "workspace:*",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify": "^3.0.0",
     "fixturify-project": "^5.2.0",
     "tmp": "^0.2.1",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.3"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,9 +38,8 @@
   },
   "dependencies": {
     "@rehearsal/codefixes": "workspace:*",
-    "@rehearsal/reporter": "workspace:*",
-    "@rehearsal/service": "workspace:*",
     "@rehearsal/ts-utils": "workspace:*",
+    "@rehearsal/utils": "workspace:*",
     "@types/object-hash": "^3.0.2",
     "debug": "^4.3.4",
     "eslint": "^8.40.0",
@@ -49,11 +48,14 @@
     "vscode-languageserver": "^8.1.0"
   },
   "devDependencies": {
+    "@rehearsal/reporter": "workspace:*",
+    "@rehearsal/service": "workspace:*",
     "@types/eslint": "^8.37.0",
     "@vitest/coverage-c8": "^0.33.0",
     "fixturify-project": "^5.2.0",
     "prettier": "^3.0.2",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.0",
+    "winston": "^3.8.2"
   },
   "peerDependencies": {
     "@glint/core": "^1.0.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,10 +51,10 @@
     "@rehearsal/reporter": "workspace:*",
     "@rehearsal/service": "workspace:*",
     "@types/eslint": "^8.37.0",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify-project": "^5.2.0",
     "prettier": "^3.0.2",
-    "vitest": "^0.34.0",
+    "vitest": "^0.34.3",
     "winston": "^3.8.2"
   },
   "peerDependencies": {

--- a/packages/plugins/src/helpers.ts
+++ b/packages/plugins/src/helpers.ts
@@ -2,8 +2,8 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Module from 'node:module';
 import ts, { type FormatCodeSettings, type SourceFile } from 'typescript';
-import { Location } from '@rehearsal/reporter';
 import { Options as PrettierOptions } from 'prettier';
+import type { Location } from '@rehearsal/reporter';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -1,1 +1,10 @@
 export * from './plugins/index.js';
+export {
+  DummyPlugin,
+  Plugin,
+  PluginFactory,
+  PluginOptions,
+  PluginsRunnerContext,
+  PluginsRunner,
+} from './plugin.js';
+export type { PluginResult } from './plugin.js';

--- a/packages/plugins/src/plugin.ts
+++ b/packages/plugins/src/plugin.ts
@@ -1,7 +1,7 @@
 import { ProgressBar } from '@rehearsal/utils';
-import { Reporter } from '@rehearsal/reporter';
-import { Logger } from 'winston';
-import { Service } from './rehearsal-service.js';
+import type { Service } from '@rehearsal/service';
+import type { Logger } from 'winston';
+import type { Reporter } from '@rehearsal/reporter';
 
 export abstract class Plugin<Options extends PluginOptions = PluginOptions> {
   fileName: string;

--- a/packages/plugins/src/plugins/diagnostic-comment.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-comment.plugin.ts
@@ -1,9 +1,9 @@
 import { createRequire } from 'node:module';
 import { DiagnosticWithContext, hints } from '@rehearsal/codefixes';
-import { PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { findNodeAtPosition } from '@rehearsal/ts-utils';
 import debug from 'debug';
 import ts from 'typescript';
+import { PluginOptions, Plugin } from '../plugin.js';
 import {
   findDiagnosticNode,
   getConditionalCommentPos,
@@ -11,7 +11,9 @@ import {
   inTemplateExpressionText,
   onMultilineConditionalTokenLine,
 } from './utils.js';
+
 import type MS from 'magic-string';
+import type { Service } from '@rehearsal/service';
 
 const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-fix.plugin.ts
@@ -9,9 +9,11 @@ import {
   type DiagnosticWithContext,
   applyCodeFix,
 } from '@rehearsal/codefixes';
-import { PluginOptions, PluginsRunnerContext, Service, Plugin } from '@rehearsal/service';
 import { findNodeAtPosition } from '@rehearsal/ts-utils';
+import { PluginOptions, PluginsRunnerContext, Plugin } from '../plugin.js';
 import { getFormatCodeSettingsForFile } from '../helpers.js';
+
+import type { Service } from '@rehearsal/service';
 import type MS from 'magic-string';
 
 const require = createRequire(import.meta.url);

--- a/packages/plugins/src/plugins/diagnostic-report.plugin.ts
+++ b/packages/plugins/src/plugins/diagnostic-report.plugin.ts
@@ -1,10 +1,12 @@
 import { DiagnosticWithContext, hints } from '@rehearsal/codefixes';
-import { PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { findNodeAtPosition } from '@rehearsal/ts-utils';
 import debug from 'debug';
 import ts from 'typescript';
+import { PluginOptions, Plugin } from '../plugin.js';
 import { getLocation } from '../helpers.js';
 import { getBoundaryOfCommentBlock } from './utils.js';
+
+import type { Service } from '@rehearsal/service';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:diagnostic-report');
 

--- a/packages/plugins/src/plugins/glint-comment.plugin.ts
+++ b/packages/plugins/src/plugins/glint-comment.plugin.ts
@@ -1,14 +1,16 @@
 import { extname } from 'node:path';
 import { createRequire } from 'node:module';
 import { DiagnosticWithContext, hints, getDiagnosticOrder } from '@rehearsal/codefixes';
-import { GlintService, PluginOptions, Service, PathUtils, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
 import ts from 'typescript';
 import debug from 'debug';
+import { PluginOptions, Plugin } from '../plugin.js';
 import { getLocation } from '../helpers.js';
 import { getConditionalCommentPos, onMultilineConditionalTokenLine } from './utils.js';
+
 import type { TransformManager } from '@glint/core';
 import type MS from 'magic-string';
+import type { Service, GlintService, PathUtils } from '@rehearsal/service';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-comment');
 

--- a/packages/plugins/src/plugins/glint-fix.plugin.ts
+++ b/packages/plugins/src/plugins/glint-fix.plugin.ts
@@ -7,13 +7,15 @@ import {
 } from '@rehearsal/codefixes';
 import debug from 'debug';
 import ts, { DiagnosticWithLocation, FormatCodeSettings } from 'typescript';
-import { Plugin, GlintService, PluginsRunnerContext } from '@rehearsal/service';
 import hash from 'object-hash';
 import { findNodeAtPosition, isSameChange, normalizeTextChanges } from '@rehearsal/ts-utils';
+import { Plugin, PluginsRunnerContext } from '../plugin.js';
 import { getFormatCodeSettingsForFile } from '../helpers.js';
+
 import type { Diagnostic } from 'vscode-languageserver';
 import type MS from 'magic-string';
 import type { TextChange } from 'typescript';
+import type { GlintService } from '@rehearsal/service';
 
 const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/plugins/src/plugins/glint-report.plugin.ts
+++ b/packages/plugins/src/plugins/glint-report.plugin.ts
@@ -1,9 +1,11 @@
 import { DiagnosticWithContext, hints } from '@rehearsal/codefixes';
-import { GlintService, PluginOptions, Service, Plugin } from '@rehearsal/service';
 import { type Location } from '@rehearsal/reporter';
 import debug from 'debug';
 import ts from 'typescript';
+import { PluginOptions, Plugin } from '../plugin.js';
 import { getLocation } from '../helpers.js';
+
+import type { GlintService, Service } from '@rehearsal/service';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:glint-report');
 

--- a/packages/plugins/src/plugins/lint.plugin.ts
+++ b/packages/plugins/src/plugins/lint.plugin.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { PluginOptions, type PluginResult, Plugin, PluginsRunnerContext } from '@rehearsal/service';
 import { ESLint } from 'eslint';
 import debug from 'debug';
+import { PluginOptions, type PluginResult, Plugin, PluginsRunnerContext } from '../plugin.js';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:formatting');
 

--- a/packages/plugins/src/plugins/prettier.plugin.ts
+++ b/packages/plugins/src/plugins/prettier.plugin.ts
@@ -1,7 +1,7 @@
-import { Plugin } from '@rehearsal/service';
 import prettier from 'prettier';
 
 import debug from 'debug';
+import { Plugin } from '../plugin.js';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:prettier');
 

--- a/packages/plugins/src/plugins/re-rehearse.plugin.ts
+++ b/packages/plugins/src/plugins/re-rehearse.plugin.ts
@@ -1,5 +1,5 @@
-import { PluginOptions, Plugin } from '@rehearsal/service';
 import debug from 'debug';
+import { PluginOptions, Plugin } from '../plugin.js';
 import { getBoundaryOfCommentBlock } from './utils.js';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:rerehearse');

--- a/packages/plugins/src/plugins/transform.plugin.ts
+++ b/packages/plugins/src/plugins/transform.plugin.ts
@@ -1,8 +1,9 @@
 import { extname } from 'node:path';
-import { GlintService, Plugin, PluginOptions } from '@rehearsal/service';
 import { applyTextChanges } from '@rehearsal/ts-utils';
 import ts, { TextChange } from 'typescript';
 import debug from 'debug';
+import { Plugin, PluginOptions } from '../../src/plugin.js';
+import type { GlintService } from '@rehearsal/service';
 
 const DEBUG_CALLBACK = debug('rehearsal:plugins:transform');
 

--- a/packages/plugins/test/plugin-runner.test.ts
+++ b/packages/plugins/test/plugin-runner.test.ts
@@ -1,7 +1,7 @@
 import { Reporter } from '@rehearsal/reporter';
 import { describe, expect, test, vi, afterEach, beforeEach, Mock } from 'vitest';
+import { RehearsalService } from '@rehearsal/service';
 import { Plugin, PluginOptions, PluginsRunner } from '../src/plugin.js';
-import { RehearsalService } from '../src/rehearsal-service.js';
 
 describe('PluginsRunner', () => {
   describe('filter', () => {

--- a/packages/plugins/test/utils.ts
+++ b/packages/plugins/test/utils.ts
@@ -1,8 +1,9 @@
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
-import { PluginsRunnerContext, RehearsalService } from '@rehearsal/service';
+import { RehearsalService } from '@rehearsal/service';
 import { Reporter } from '@rehearsal/reporter';
 import { Project } from 'fixturify-project';
+import { PluginsRunnerContext } from '../src/plugin.js';
 
 export async function initProject(
   name: string,

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -30,7 +30,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
@@ -39,9 +39,9 @@
   },
   "devDependencies": {
     "@types/sarif": "^2.1.4",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fs-extra": "^11.1.1",
-    "vitest": "^0.30.0",
+    "vitest": "^0.34.3",
     "vitest-mock-extended": "^1.1.3"
   },
   "peerDependencies": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -32,7 +32,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
@@ -45,9 +45,9 @@
   },
   "devDependencies": {
     "@rehearsal/reporter": "workspace:*",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "type-fest": "^3.8.0",
-    "vitest": "^0.30.0",
+    "vitest": "^0.34.3",
     "winston": "^3.8.2"
   },
   "peerDependencies": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -38,17 +38,17 @@
   },
   "dependencies": {
     "@glint/core": "^1.0.2",
-    "@rehearsal/reporter": "workspace:*",
     "@rehearsal/utils": "workspace:*",
     "find-up": "^6.3.0",
     "vscode-languageserver": "^8.1.0",
-    "vscode-uri": "^3.0.7",
-    "winston": "^3.8.2"
+    "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
+    "@rehearsal/reporter": "workspace:*",
     "@vitest/coverage-c8": "^0.33.0",
     "type-fest": "^3.8.0",
-    "vitest": "^0.30.0"
+    "vitest": "^0.30.0",
+    "winston": "^3.8.2"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,14 +1,4 @@
-export {
-  DummyPlugin,
-  Plugin,
-  PluginFactory,
-  PluginOptions,
-  PluginsRunnerContext,
-  PluginsRunner,
-} from './plugin.js';
 export { RehearsalService, type Service } from './rehearsal-service.js';
 export { RehearsalServiceHost } from './rehearsal-service-host.js';
 export { GlintService, type Range, type PathUtils } from './glint-service.js';
 export * from './glint-utils.js';
-
-export type { PluginResult } from './plugin.js';

--- a/packages/smoke-test/package.json
+++ b/packages/smoke-test/package.json
@@ -125,7 +125,7 @@
     "testem": "^3.0.3",
     "tracked-built-ins": "^3.1.1",
     "type-fest": "^3.10.0",
-    "vitest": "^0.30.0",
+    "vitest": "^0.34.3",
     "webpack": "^5.0.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",

--- a/packages/smoke-test/test/test-helpers/index.ts
+++ b/packages/smoke-test/test/test-helpers/index.ts
@@ -6,7 +6,7 @@ import { execa } from 'execa';
 import { Project } from 'fixturify-project';
 import { createLogger, format, transports } from 'winston';
 import JSON5 from 'json5';
-import { expect } from 'vitest';
+import { expect, type Assertion } from 'vitest';
 
 import type { ExecaChildProcess, Options } from 'execa';
 import type { TsConfigJson } from 'type-fest';
@@ -32,7 +32,7 @@ export function addWorkspaces(project: Project): Project {
   return project;
 }
 
-export function expectFile(filePath: string): Vi.Assertion<string> {
+export function expectFile(filePath: string): Assertion<string> {
   return expect(readFileSync(filePath, 'utf-8'));
 }
 

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -24,7 +24,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:slow": "vitest --run --config ./vitest.config.slow.ts",
     "version": "pnpm version"
   },
@@ -37,11 +37,11 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "ember-cli": "^4.11.0",
     "ember-data": "^4.11.3",
     "ember-source": "^5.1.2",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.3"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/ts-utils/package.json
+++ b/packages/ts-utils/package.json
@@ -34,13 +34,13 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --coverage",
+    "test": "vitest --run",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
   "devDependencies": {
-    "@vitest/coverage-c8": "^0.33.0",
-    "vitest": "^0.30.0"
+    "@vitest/coverage-v8": "^0.34.3",
+    "vitest": "^0.34.3"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
     "lint": "npm-run-all lint:*",
     "lint:tsc-src": "tsc --noEmit",
     "lint:tsc-test": "tsc --noEmit --project test/tsconfig.json",
-    "test": "vitest --run --config ./vitest.config.ts --coverage",
+    "test": "vitest --run --config ./vitest.config.ts",
     "test:watch": "vitest --coverage --watch",
     "version": "pnpm version"
   },
@@ -49,10 +49,10 @@
   },
   "devDependencies": {
     "@types/which": "^3.0.0",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "fixturify": "^3.0.0",
     "fixturify-project": "^5.2.0",
-    "vitest": "^0.30.0"
+    "vitest": "^0.34.3"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,11 +120,11 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^4.2.1
-        version: 4.4.3(@types/node@20.3.3)
+        specifier: ^4.4.9
+        version: 4.4.9(@types/node@20.3.3)
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
       walk-sync:
         specifier: ^3.0.0
         version: 3.0.0
@@ -222,9 +222,9 @@ importers:
       '@types/which':
         specifier: ^3.0.0
         version: 3.0.0
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify-project:
         specifier: ^5.2.0
         version: 5.2.0
@@ -235,8 +235,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/codefixes:
     dependencies:
@@ -262,9 +262,9 @@ importers:
       '@rehearsal/service':
         specifier: workspace:*
         version: link:../service
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -284,8 +284,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/migrate:
     dependencies:
@@ -332,9 +332,9 @@ importers:
         specifier: ^3.8.2
         version: 3.8.2
     devDependencies:
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify-project:
         specifier: ^5.2.0
         version: 5.2.0
@@ -342,8 +342,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/migration-graph:
     dependencies:
@@ -393,9 +393,9 @@ importers:
       '@rehearsal/test-support':
         specifier: workspace:*
         version: link:../test-support
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -406,8 +406,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/plugins:
     dependencies:
@@ -454,9 +454,9 @@ importers:
       '@types/eslint':
         specifier: ^8.37.0
         version: 8.37.0
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.34.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify-project:
         specifier: ^5.2.0
         version: 5.2.0
@@ -464,8 +464,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       vitest:
-        specifier: ^0.34.0
-        version: 0.34.0
+        specifier: ^0.34.3
+        version: 0.34.3
       winston:
         specifier: ^3.8.2
         version: 3.8.2
@@ -482,18 +482,18 @@ importers:
       '@types/sarif':
         specifier: ^2.1.4
         version: 2.1.4
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
       vitest-mock-extended:
         specifier: ^1.1.3
-        version: 1.2.0(typescript@5.2.2)(vitest@0.30.0)
+        version: 1.2.0(typescript@5.2.2)(vitest@0.34.3)
 
   packages/service:
     dependencies:
@@ -519,15 +519,15 @@ importers:
       '@rehearsal/reporter':
         specifier: workspace:*
         version: link:../reporter
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       type-fest:
         specifier: ^3.8.0
         version: 3.8.0
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
       winston:
         specifier: ^3.8.2
         version: 3.8.2
@@ -865,8 +865,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0(typescript@5.2.2)
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
       webpack:
         specifier: ^5.0.0
         version: 5.79.0(webpack-cli@3.3.11)
@@ -904,9 +904,9 @@ importers:
         specifier: ^5
         version: 5.2.2
     devDependencies:
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       ember-cli:
         specifier: ^4.11.0
         version: 4.12.0
@@ -917,8 +917,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2(@babel/core@7.22.9)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.1)
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/ts-utils:
     dependencies:
@@ -926,12 +926,12 @@ importers:
         specifier: ^5
         version: 5.2.2
     devDependencies:
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/utils:
     dependencies:
@@ -963,9 +963,9 @@ importers:
       '@types/which':
         specifier: ^3.0.0
         version: 3.0.0
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -973,8 +973,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.3
+        version: 0.34.3
 
 packages:
 
@@ -6295,105 +6295,59 @@ packages:
       eslint-visitor-keys: 3.4.1
     dev: true
 
-  /@vitest/coverage-c8@0.33.0(vitest@0.30.0):
-    resolution: {integrity: sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==}
-    deprecated: v8 coverage is moved to @vitest/coverage-v8 package
+  /@vitest/coverage-v8@0.34.3(vitest@0.34.3):
+    resolution: {integrity: sha512-bNjP0RHe8UxdklCigZlk6FVCNbOiqVjWnpZJ1zKixpvb7YHSaZiN/w+mzpvXIoqyxyePzKC+L+G1oj7SB20PJw==}
     peerDependencies:
-      vitest: '>=0.30.0 <1'
+      vitest: '>=0.32.0 <1'
     dependencies:
       '@ampproject/remapping': 2.2.1
-      c8: 7.14.0
+      '@bcoe/v8-coverage': 0.2.3
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.5
       magic-string: 0.30.2
       picocolors: 1.0.0
       std-env: 3.3.3
-      vitest: 0.30.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.1.0
+      vitest: 0.34.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@vitest/coverage-c8@0.33.0(vitest@0.34.0):
-    resolution: {integrity: sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==}
-    deprecated: v8 coverage is moved to @vitest/coverage-v8 package
-    peerDependencies:
-      vitest: '>=0.30.0 <1'
+  /@vitest/expect@0.34.3:
+    resolution: {integrity: sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==}
     dependencies:
-      '@ampproject/remapping': 2.2.1
-      c8: 7.14.0
-      magic-string: 0.30.2
-      picocolors: 1.0.0
-      std-env: 3.3.3
-      vitest: 0.34.0
-    dev: true
-
-  /@vitest/expect@0.30.0:
-    resolution: {integrity: sha512-b/jLWBqi6WQHfezWm8VjgXdIyfejAurtxqdyCdDqoToCim5W/nDxKjFAADitEHPz80oz+IP+c+wmkGKBucSpiw==}
-    dependencies:
-      '@vitest/spy': 0.30.0
-      '@vitest/utils': 0.30.0
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
       chai: 4.3.7
     dev: true
 
-  /@vitest/expect@0.34.0:
-    resolution: {integrity: sha512-d1ZU0XomWFAFyYIc6uNuY0N8NJIWESyO/6ZmwLvlHZw0GevH4AEEpq178KjXIvSCrbHN0GnzYzitd0yjfy7+Ow==}
+  /@vitest/runner@0.34.3:
+    resolution: {integrity: sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==}
     dependencies:
-      '@vitest/spy': 0.34.0
-      '@vitest/utils': 0.34.0
-      chai: 4.3.7
-    dev: true
-
-  /@vitest/runner@0.30.0:
-    resolution: {integrity: sha512-Xh4xkdRcymdeRNrSwjhgarCTSgnQu2J59wsFI6i4UhKrL5whzo5+vWyq7iWK1ht3fppPeNAtvkbqUDf+OJSCbQ==}
-    dependencies:
-      '@vitest/utils': 0.30.0
-      concordance: 5.0.4
+      '@vitest/utils': 0.34.3
       p-limit: 4.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/runner@0.34.0:
-    resolution: {integrity: sha512-xaqM+oArJothtYXzy/dwu/iHe93Khq5QkvnYbzTxiLA0enD2peft1cask3yE6cJpwMkr7C2D1uMJwnTt4mquDw==}
-    dependencies:
-      '@vitest/utils': 0.34.0
-      p-limit: 4.0.0
-      pathe: 1.1.1
-    dev: true
-
-  /@vitest/snapshot@0.30.0:
-    resolution: {integrity: sha512-e4eSGCy36Bw3/Tkir9qYJDlFsUz3NALFPNJSxzlY8CFl901TV9iZdKgpqXpyG1sAhLO0tPHThBAMHRi8hRA8cg==}
-    dependencies:
-      magic-string: 0.30.2
-      pathe: 1.1.1
-      pretty-format: 27.5.1
-    dev: true
-
-  /@vitest/snapshot@0.34.0:
-    resolution: {integrity: sha512-eGN5XBZHYOghxCOQbf8dcn6/3g7IW77GOOOC/mNFYwRXsPeoQgcgWnhj+6wgJ04pVv25wpxWL9jUkzaQ7LoFtg==}
+  /@vitest/snapshot@0.34.3:
+    resolution: {integrity: sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==}
     dependencies:
       magic-string: 0.30.2
       pathe: 1.1.1
       pretty-format: 29.6.3
     dev: true
 
-  /@vitest/spy@0.30.0:
-    resolution: {integrity: sha512-olTWyG5gVWdfhCrdgxWQb2K3JYtj1/ZwInFFOb4GZ2HFI91PUWHWHhLRPORxwRwVvoXD1MS1162vPJZuHlKJkg==}
+  /@vitest/spy@0.34.3:
+    resolution: {integrity: sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==}
     dependencies:
       tinyspy: 2.1.1
     dev: true
 
-  /@vitest/spy@0.34.0:
-    resolution: {integrity: sha512-0SZaWrQvL9ZiF/uJvyWSvsKjfuMvD1M6dE5BbE4Dmt8Vh3k4htwCV8g3ce8YOYmJSxkbh6TNOpippD6NVsxW6w==}
-    dependencies:
-      tinyspy: 2.1.1
-    dev: true
-
-  /@vitest/utils@0.30.0:
-    resolution: {integrity: sha512-qFZgoOKQ+rJV9xG4BBxgOSilnLQ2gkfG4I+z1wBuuQ3AD33zQrnB88kMFfzsot1E1AbF3dNK1e4CU7q3ojahRA==}
-    dependencies:
-      concordance: 5.0.4
-      loupe: 2.3.6
-      pretty-format: 27.5.1
-    dev: true
-
-  /@vitest/utils@0.34.0:
-    resolution: {integrity: sha512-IktrDLhBKf3dEUUxH+lcHiPnaw952+GdGvoxg99liMscgP6IePf6LuMY7B9dEIHkFunB1R8VMR/wmI/4UGg1aw==}
+  /@vitest/utils@0.34.3:
+    resolution: {integrity: sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==}
     dependencies:
       diff-sequences: 29.6.3
       loupe: 2.3.6
@@ -7515,10 +7469,6 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: true
 
-  /blueimp-md5@2.19.0:
-    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
-    dev: true
-
   /body-parser@1.20.1(supports-color@6.1.0):
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -8229,25 +8179,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /c8@7.14.0:
-    resolution: {integrity: sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==}
-    engines: {node: '>=10.12.0'}
-    hasBin: true
-    dependencies:
-      '@bcoe/v8-coverage': 0.2.3
-      '@istanbuljs/schema': 0.1.3
-      find-up: 5.0.0
-      foreground-child: 2.0.0
-      istanbul-lib-coverage: 3.2.0
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.1.5
-      rimraf: 3.0.2
-      test-exclude: 6.0.0
-      v8-to-istanbul: 9.1.0
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
-    dev: true
-
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -8761,20 +8692,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
-    dev: true
-
-  /concordance@5.0.4:
-    resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
-    engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
-    dependencies:
-      date-time: 3.1.0
-      esutils: 2.0.3
-      fast-diff: 1.2.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      md5-hex: 3.0.1
-      semver: 7.5.4
-      well-known-symbols: 2.0.0
     dev: true
 
   /concurrently@8.2.0:
@@ -9448,13 +9365,6 @@ packages:
   /date-time@2.1.0:
     resolution: {integrity: sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==}
     engines: {node: '>=4'}
-    dependencies:
-      time-zone: 1.0.0
-    dev: true
-
-  /date-time@3.1.0:
-    resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
-    engines: {node: '>=6'}
     dependencies:
       time-zone: 1.0.0
     dev: true
@@ -12339,14 +12249,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /foreground-child@2.0.0:
-    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 3.0.7
-    dev: true
-
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -13872,6 +13774,17 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4(supports-color@6.1.0)
+      istanbul-lib-coverage: 3.2.0
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /istanbul-reports@3.1.5:
     resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
     engines: {node: '>=8'}
@@ -14613,13 +14526,6 @@ packages:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
-
-  /md5-hex@3.0.1:
-    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
-    engines: {node: '>=8'}
-    dependencies:
-      blueimp-md5: 2.19.0
-    dev: true
 
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
@@ -15965,15 +15871,6 @@ packages:
       renderkid: 2.0.7
     dev: true
 
-  /pretty-format@27.5.1:
-    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      ansi-regex: 5.0.1
-      ansi-styles: 5.2.0
-      react-is: 17.0.2
-    dev: true
-
   /pretty-format@29.6.3:
     resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -16183,10 +16080,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
-
-  /react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
   /react-is@18.2.0:
@@ -17968,11 +17861,6 @@ packages:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
-  /tinypool@0.4.0:
-    resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
-    engines: {node: '>=14.0.0'}
-    dev: true
-
   /tinypool@0.7.0:
     resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
@@ -18603,8 +18491,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@0.30.0(@types/node@20.3.3):
-    resolution: {integrity: sha512-23X5Ggylx0kU/bMf8MCcEEl55d/gsTtU81mMZjm7Z0FSpgKZexUqmX3mJtgglP9SySQQs9ydYg/GEahi/cKHaA==}
+  /vite-node@0.34.3(@types/node@20.3.3):
+    resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
@@ -18623,64 +18511,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite-node@0.34.0(@types/node@20.3.3):
-    resolution: {integrity: sha512-rGZMvpb052rjUwJA/a17xMfOibzNF7byMdRSTcN2Lw8uxX08s5EfjWW5mBkm3MSFTPctMSVtT2yC+8ShrZbT5g==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4(supports-color@6.1.0)
-      mlly: 1.4.1
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.3.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vite@4.4.3(@types/node@20.3.3):
-    resolution: {integrity: sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.3.3
-      esbuild: 0.18.11
-      postcss: 8.4.29
-      rollup: 3.28.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.9(@types/node@20.3.3):
@@ -18719,7 +18549,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest-mock-extended@1.2.0(typescript@5.2.2)(vitest@0.30.0):
+  /vitest-mock-extended@1.2.0(typescript@5.2.2)(vitest@0.34.3):
     resolution: {integrity: sha512-/UwFogR1XFvLHmdru+IDbfEywwqKQ8QuaKPEyoWg1ElbZFck/y/jikeOu/EjAVEoYxS9pB/FKFHAidkNBtwEFA==}
     peerDependencies:
       typescript: 3.x || 4.x || 5.x
@@ -18727,11 +18557,11 @@ packages:
     dependencies:
       ts-essentials: 9.3.2(typescript@5.2.2)
       typescript: 5.2.2
-      vitest: 0.30.0
+      vitest: 0.34.3
     dev: true
 
-  /vitest@0.30.0:
-    resolution: {integrity: sha512-2WW4WeTHtrLFeoiuotWvEW6khozx1NvMGYoGsNz2btdddEbqvEdPJIouIdoiC5i61Rl1ctZvm9cn2R9TcPQlzw==}
+  /vitest@0.34.3:
+    resolution: {integrity: sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -18764,78 +18594,11 @@ packages:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 20.3.3
-      '@vitest/expect': 0.30.0
-      '@vitest/runner': 0.30.0
-      '@vitest/snapshot': 0.30.0
-      '@vitest/spy': 0.30.0
-      '@vitest/utils': 0.30.0
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      concordance: 5.0.4
-      debug: 4.3.4(supports-color@6.1.0)
-      local-pkg: 0.4.3
-      magic-string: 0.30.2
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      source-map: 0.6.1
-      std-env: 3.3.3
-      strip-literal: 1.0.1
-      tinybench: 2.5.0
-      tinypool: 0.4.0
-      vite: 4.4.3(@types/node@20.3.3)
-      vite-node: 0.30.0(@types/node@20.3.3)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@0.34.0:
-    resolution: {integrity: sha512-8Pnc1fVt1P6uBncdUZ++hgiJGgxIRKuz4bmS/PQziaEcUj0D1g9cGiR1MbLrcsvFTC6fgrqDhYoTAdBG356WMA==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.5
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.3.3
-      '@vitest/expect': 0.34.0
-      '@vitest/runner': 0.34.0
-      '@vitest/snapshot': 0.34.0
-      '@vitest/spy': 0.34.0
-      '@vitest/utils': 0.34.0
+      '@vitest/expect': 0.34.3
+      '@vitest/runner': 0.34.3
+      '@vitest/snapshot': 0.34.3
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
       acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
@@ -18850,7 +18613,7 @@ packages:
       tinybench: 2.5.0
       tinypool: 0.7.0
       vite: 4.4.9(@types/node@20.3.3)
-      vite-node: 0.34.0(@types/node@20.3.3)
+      vite-node: 0.34.3(@types/node@20.3.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -19158,11 +18921,6 @@ packages:
   /websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
-    dev: true
-
-  /well-known-symbols@2.0.0:
-    resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
-    engines: {node: '>=6'}
     dev: true
 
   /whatwg-fetch@3.6.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,15 +417,12 @@ importers:
       '@rehearsal/codefixes':
         specifier: workspace:*
         version: link:../codefixes
-      '@rehearsal/reporter':
-        specifier: workspace:*
-        version: link:../reporter
-      '@rehearsal/service':
-        specifier: workspace:*
-        version: link:../service
       '@rehearsal/ts-utils':
         specifier: workspace:*
         version: link:../ts-utils
+      '@rehearsal/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@types/object-hash':
         specifier: ^3.0.2
         version: 3.0.2
@@ -448,12 +445,18 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0
     devDependencies:
+      '@rehearsal/reporter':
+        specifier: workspace:*
+        version: link:../reporter
+      '@rehearsal/service':
+        specifier: workspace:*
+        version: link:../service
       '@types/eslint':
         specifier: ^8.37.0
         version: 8.37.0
       '@vitest/coverage-c8':
         specifier: ^0.33.0
-        version: 0.33.0(vitest@0.30.0)
+        version: 0.33.0(vitest@0.34.0)
       fixturify-project:
         specifier: ^5.2.0
         version: 5.2.0
@@ -461,8 +464,11 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       vitest:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.34.0
+        version: 0.34.0
+      winston:
+        specifier: ^3.8.2
+        version: 3.8.2
 
   packages/reporter:
     dependencies:
@@ -494,9 +500,6 @@ importers:
       '@glint/core':
         specifier: ^1.0.2
         version: 1.0.2(typescript@5.2.2)
-      '@rehearsal/reporter':
-        specifier: workspace:*
-        version: link:../reporter
       '@rehearsal/utils':
         specifier: workspace:*
         version: link:../utils
@@ -512,10 +515,10 @@ importers:
       vscode-uri:
         specifier: ^3.0.7
         version: 3.0.7
-      winston:
-        specifier: ^3.8.2
-        version: 3.8.2
     devDependencies:
+      '@rehearsal/reporter':
+        specifier: workspace:*
+        version: link:../reporter
       '@vitest/coverage-c8':
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.30.0)
@@ -525,6 +528,9 @@ importers:
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
+      winston:
+        specifier: ^3.8.2
+        version: 3.8.2
 
   packages/smoke-test:
     devDependencies:
@@ -5191,6 +5197,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -5312,6 +5325,10 @@ packages:
 
   /@simple-dom/interface@1.4.0:
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
+
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
 
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
@@ -6292,11 +6309,33 @@ packages:
       vitest: 0.30.0
     dev: true
 
+  /@vitest/coverage-c8@0.33.0(vitest@0.34.0):
+    resolution: {integrity: sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==}
+    deprecated: v8 coverage is moved to @vitest/coverage-v8 package
+    peerDependencies:
+      vitest: '>=0.30.0 <1'
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      c8: 7.14.0
+      magic-string: 0.30.2
+      picocolors: 1.0.0
+      std-env: 3.3.3
+      vitest: 0.34.0
+    dev: true
+
   /@vitest/expect@0.30.0:
     resolution: {integrity: sha512-b/jLWBqi6WQHfezWm8VjgXdIyfejAurtxqdyCdDqoToCim5W/nDxKjFAADitEHPz80oz+IP+c+wmkGKBucSpiw==}
     dependencies:
       '@vitest/spy': 0.30.0
       '@vitest/utils': 0.30.0
+      chai: 4.3.7
+    dev: true
+
+  /@vitest/expect@0.34.0:
+    resolution: {integrity: sha512-d1ZU0XomWFAFyYIc6uNuY0N8NJIWESyO/6ZmwLvlHZw0GevH4AEEpq178KjXIvSCrbHN0GnzYzitd0yjfy7+Ow==}
+    dependencies:
+      '@vitest/spy': 0.34.0
+      '@vitest/utils': 0.34.0
       chai: 4.3.7
     dev: true
 
@@ -6309,6 +6348,14 @@ packages:
       pathe: 1.1.1
     dev: true
 
+  /@vitest/runner@0.34.0:
+    resolution: {integrity: sha512-xaqM+oArJothtYXzy/dwu/iHe93Khq5QkvnYbzTxiLA0enD2peft1cask3yE6cJpwMkr7C2D1uMJwnTt4mquDw==}
+    dependencies:
+      '@vitest/utils': 0.34.0
+      p-limit: 4.0.0
+      pathe: 1.1.1
+    dev: true
+
   /@vitest/snapshot@0.30.0:
     resolution: {integrity: sha512-e4eSGCy36Bw3/Tkir9qYJDlFsUz3NALFPNJSxzlY8CFl901TV9iZdKgpqXpyG1sAhLO0tPHThBAMHRi8hRA8cg==}
     dependencies:
@@ -6317,8 +6364,22 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@vitest/snapshot@0.34.0:
+    resolution: {integrity: sha512-eGN5XBZHYOghxCOQbf8dcn6/3g7IW77GOOOC/mNFYwRXsPeoQgcgWnhj+6wgJ04pVv25wpxWL9jUkzaQ7LoFtg==}
+    dependencies:
+      magic-string: 0.30.2
+      pathe: 1.1.1
+      pretty-format: 29.6.3
+    dev: true
+
   /@vitest/spy@0.30.0:
     resolution: {integrity: sha512-olTWyG5gVWdfhCrdgxWQb2K3JYtj1/ZwInFFOb4GZ2HFI91PUWHWHhLRPORxwRwVvoXD1MS1162vPJZuHlKJkg==}
+    dependencies:
+      tinyspy: 2.1.1
+    dev: true
+
+  /@vitest/spy@0.34.0:
+    resolution: {integrity: sha512-0SZaWrQvL9ZiF/uJvyWSvsKjfuMvD1M6dE5BbE4Dmt8Vh3k4htwCV8g3ce8YOYmJSxkbh6TNOpippD6NVsxW6w==}
     dependencies:
       tinyspy: 2.1.1
     dev: true
@@ -6329,6 +6390,14 @@ packages:
       concordance: 5.0.4
       loupe: 2.3.6
       pretty-format: 27.5.1
+    dev: true
+
+  /@vitest/utils@0.34.0:
+    resolution: {integrity: sha512-IktrDLhBKf3dEUUxH+lcHiPnaw952+GdGvoxg99liMscgP6IePf6LuMY7B9dEIHkFunB1R8VMR/wmI/4UGg1aw==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.6
+      pretty-format: 29.6.3
     dev: true
 
   /@webassemblyjs/ast@1.11.1:
@@ -6603,12 +6672,12 @@ packages:
       acorn: 8.10.0
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.8.2):
+  /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
 
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -6625,12 +6694,12 @@ packages:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
@@ -9274,13 +9343,13 @@ packages:
     peerDependencies:
       webpack: ^4.27.0 || ^5.0.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.25)
+      icss-utils: 5.1.0(postcss@8.4.29)
       loader-utils: 2.0.4
-      postcss: 8.4.25
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.25)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.25)
-      postcss-modules-scope: 3.0.0(postcss@8.4.25)
-      postcss-modules-values: 4.0.0(postcss@8.4.25)
+      postcss: 8.4.29
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.29)
+      postcss-modules-local-by-default: 4.0.3(postcss@8.4.29)
+      postcss-modules-scope: 3.0.0(postcss@8.4.29)
+      postcss-modules-values: 4.0.0(postcss@8.4.29)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.4
@@ -9293,13 +9362,13 @@ packages:
     peerDependencies:
       webpack: ^4.27.0 || ^5.0.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.25)
+      icss-utils: 5.1.0(postcss@8.4.29)
       loader-utils: 2.0.4
-      postcss: 8.4.25
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.25)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.25)
-      postcss-modules-scope: 3.0.0(postcss@8.4.25)
-      postcss-modules-values: 4.0.0(postcss@8.4.25)
+      postcss: 8.4.29
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.29)
+      postcss-modules-local-by-default: 4.0.3(postcss@8.4.29)
+      postcss-modules-scope: 3.0.0(postcss@8.4.29)
+      postcss-modules-values: 4.0.0(postcss@8.4.29)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.4
@@ -9618,6 +9687,11 @@ packages:
 
   /detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff@4.0.2:
@@ -11620,8 +11694,8 @@ packages:
     resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
       eslint-visitor-keys: 3.4.1
 
   /esprima@3.0.0:
@@ -13170,13 +13244,13 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /icss-utils@5.1.0(postcss@8.4.25):
+  /icss-utils@5.1.0(postcss@8.4.29):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.25
+      postcss: 8.4.29
     dev: true
 
   /ieee754@1.2.1:
@@ -15743,13 +15817,13 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-modules-extract-imports@3.0.0(postcss@8.4.25):
+  /postcss-modules-extract-imports@3.0.0(postcss@8.4.29):
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.25
+      postcss: 8.4.29
     dev: true
 
   /postcss-modules-local-by-default@4.0.3(postcss@8.4.21):
@@ -15764,14 +15838,14 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-local-by-default@4.0.3(postcss@8.4.25):
+  /postcss-modules-local-by-default@4.0.3(postcss@8.4.29):
     resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.25)
-      postcss: 8.4.25
+      icss-utils: 5.1.0(postcss@8.4.29)
+      postcss: 8.4.29
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
     dev: true
@@ -15786,13 +15860,13 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-modules-scope@3.0.0(postcss@8.4.25):
+  /postcss-modules-scope@3.0.0(postcss@8.4.29):
     resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.25
+      postcss: 8.4.29
       postcss-selector-parser: 6.0.11
     dev: true
 
@@ -15806,14 +15880,14 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-modules-values@4.0.0(postcss@8.4.25):
+  /postcss-modules-values@4.0.0(postcss@8.4.29):
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.25)
-      postcss: 8.4.25
+      icss-utils: 5.1.0(postcss@8.4.29)
+      postcss: 8.4.29
     dev: true
 
   /postcss-selector-parser@6.0.11:
@@ -15837,8 +15911,8 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /postcss@8.4.25:
-    resolution: {integrity: sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==}
+  /postcss@8.4.29:
+    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -15898,6 +15972,15 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+    dev: true
+
+  /pretty-format@29.6.3:
+    resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
     dev: true
 
   /pretty-ms@3.2.0:
@@ -16104,6 +16187,10 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
   /read-cmd-shim@3.0.1:
@@ -16529,8 +16616,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup@3.26.2:
-    resolution: {integrity: sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==}
+  /rollup@3.28.1:
+    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -17886,6 +17973,11 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /tinyspy@2.1.1:
     resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
     engines: {node: '>=14.0.0'}
@@ -18521,7 +18613,29 @@ packages:
       mlly: 1.4.1
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.3(@types/node@20.3.3)
+      vite: 4.4.9(@types/node@20.3.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@0.34.0(@types/node@20.3.3):
+    resolution: {integrity: sha512-rGZMvpb052rjUwJA/a17xMfOibzNF7byMdRSTcN2Lw8uxX08s5EfjWW5mBkm3MSFTPctMSVtT2yC+8ShrZbT5g==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@6.1.0)
+      mlly: 1.4.1
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.4.9(@types/node@20.3.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18563,8 +18677,44 @@ packages:
     dependencies:
       '@types/node': 20.3.3
       esbuild: 0.18.11
-      postcss: 8.4.25
-      rollup: 3.26.2
+      postcss: 8.4.29
+      rollup: 3.28.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@4.4.9(@types/node@20.3.3):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.3.3
+      esbuild: 0.18.11
+      postcss: 8.4.29
+      rollup: 3.28.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -18636,6 +18786,71 @@ packages:
       tinypool: 0.4.0
       vite: 4.4.3(@types/node@20.3.3)
       vite-node: 0.30.0(@types/node@20.3.3)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@0.34.0:
+    resolution: {integrity: sha512-8Pnc1fVt1P6uBncdUZ++hgiJGgxIRKuz4bmS/PQziaEcUj0D1g9cGiR1MbLrcsvFTC6fgrqDhYoTAdBG356WMA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.5
+      '@types/chai-subset': 1.3.3
+      '@types/node': 20.3.3
+      '@vitest/expect': 0.34.0
+      '@vitest/runner': 0.34.0
+      '@vitest/snapshot': 0.34.0
+      '@vitest/spy': 0.34.0
+      '@vitest/utils': 0.34.0
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      debug: 4.3.4(supports-color@6.1.0)
+      local-pkg: 0.4.3
+      magic-string: 0.30.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.3.3
+      strip-literal: 1.0.1
+      tinybench: 2.5.0
+      tinypool: 0.7.0
+      vite: 4.4.9(@types/node@20.3.3)
+      vite-node: 0.34.0(@types/node@20.3.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
This PR resolves circular deps we had with monorepo imports. 

- moves the Plugin class into the plugins package `packages/service/src/plugin.ts` > `packages/plugins/src/plugin.ts`
- swaps deps for dev-deps where needed
- updates imports based on new location of plugin class