### PR TITLE
feat(codefix): support TOC type from `@ember/component/template-only`

### DIFF
--- a/packages/codefixes/src/fixes/glint/addMissingArgToComponentSignature.ts
+++ b/packages/codefixes/src/fixes/glint/addMissingArgToComponentSignature.ts
@@ -310,13 +310,28 @@ export class AddMissingArgToComponentSignature implements CodeFix {
     targetNode: ts.Node,
     argName: string
   ): ts.CodeFixAction | undefined {
-    const toc = getNearestTemplateOnlyComponentVariableDeclaration(targetNode);
+    let toc: LikeTemplateOnlyComponentVariableDeclaration | undefined;
+
+    const TOC_TYPE_IDENTIFIERS = ['TemplateOnlyComponent', 'TOC'];
+
+    let tocIdentifierName: string | undefined;
+
+    for (const maybeIdentifier of TOC_TYPE_IDENTIFIERS) {
+      toc = getNearestTemplateOnlyComponentVariableDeclaration(targetNode, maybeIdentifier);
+      if (toc) {
+        tocIdentifierName = maybeIdentifier;
+        break;
+      }
+    }
 
     if (!toc) {
       return;
     }
 
-    const signatureIdentifier = getComponentSignatureNameFromTemplateOnlyComponent(toc);
+    const signatureIdentifier = getComponentSignatureNameFromTemplateOnlyComponent(
+      toc,
+      tocIdentifierName
+    );
 
     if (!signatureIdentifier) {
       return this.fixMissingComponentSignatureInterfaceForTemplate(d, sourceFile, toc);
@@ -345,7 +360,7 @@ export class AddMissingArgToComponentSignature implements CodeFix {
     toc: LikeTemplateOnlyComponentVariableDeclaration
   ): ts.CodeFixAction | undefined {
     if (!toc.type) {
-      // Case where the TOC does not have the TemplateOnlyComponent type applied.
+      // Case where the TOC does not have a TemplateOnlyComponent/TOC type applied.
       return;
     }
 

--- a/packages/codefixes/src/fixes/glint/glint-parsing-utils.ts
+++ b/packages/codefixes/src/fixes/glint/glint-parsing-utils.ts
@@ -268,9 +268,10 @@ export function getNearestTemplateOnlyComponentVariableDeclaration(
 }
 
 export function getComponentSignatureNameFromTemplateOnlyComponent(
-  target: ts.Node
+  target: ts.Node,
+  identifierName = 'TemplateOnlyComponent'
 ): ts.Identifier | undefined {
-  if (isTemplateOnlyComponent(target)) {
+  if (isTemplateOnlyComponent(target, identifierName)) {
     const typeArguments = target?.type?.typeArguments ?? [];
 
     if (typeArguments.length < 1) {

--- a/packages/migrate/test/__snapshots__/migrate.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/migrate.test.ts.snap
@@ -378,8 +378,7 @@ export default class WithMissingInterface extends Component<WithMissingInterface
 `;
 
 exports[`fix > .gts > component signature codefix > template only 1`] = `
-"// @ts-expect-error @rehearsal TODO TS2307: Cannot find module '@ember/component/template-only' or its corresponding type declarations.
-import { type TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+"import { type TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 // Missing arugment in Args
 interface HelloSignature {
@@ -409,6 +408,17 @@ export interface SalutationSignature {
 export const Salutation: TemplateOnlyComponent<SalutationSignature> = <template>
   <span>Salutation, {{@name}}!</span>
 </template>;
+"
+`;
+
+exports[`fix > .gts > component signature codefix > template only 2`] = `
+"import type { TOC } from \\"@ember/component/template-only\\";
+
+export interface SalutationSignature {
+  Args: { name: any };
+}
+
+export const Salutation: TOC<SalutationSignature> = <template>Salutation, {{@name}}!</template>;
 "
 `;
 

--- a/packages/migrate/test/fixtures/project/package-lock.json
+++ b/packages/migrate/test/fixtures/project/package-lock.json
@@ -17,6 +17,7 @@
         "@glint/environment-ember-template-imports": "1.0.2",
         "@glint/environment-glimmerx": "^1.0.2",
         "@glint/template": "1.0.2",
+        "@types/ember__component": "^4.0.2",
         "@types/ember__service": "^4.0.2",
         "@types/node": "^18.13.0",
         "@types/qunit": "^2.19.4",

--- a/packages/migrate/test/fixtures/project/package.json
+++ b/packages/migrate/test/fixtures/project/package.json
@@ -19,6 +19,7 @@
     "@glint/environment-glimmerx": "^1.1.0",
     "@glint/template": "^1.1.0",
     "@types/ember__service": "^4.0.2",
+    "@types/ember__component": "^4.0.2",
     "@types/node": "^18.13.0",
     "@types/qunit": "^2.19.4",
     "@typescript-eslint/eslint-plugin": "^5.50.0",

--- a/packages/migrate/test/fixtures/project/src/gts/signatures/template-only/with-toc.gts
+++ b/packages/migrate/test/fixtures/project/src/gts/signatures/template-only/with-toc.gts
@@ -1,0 +1,3 @@
+import type { TOC } from "@ember/component/template-only";
+
+export const Salutation: TOC = <template>Salutation, {{@name}}!</template>;

--- a/packages/migrate/test/migrate.test.ts
+++ b/packages/migrate/test/migrate.test.ts
@@ -438,6 +438,7 @@ describe('fix', () => {
       test('template only', async () => {
         const [inputs, outputs] = prepareInputFiles(project, [
           'gts/signatures/template-only/with-missing-args.gts',
+          'gts/signatures/template-only/with-toc.gts',
         ]);
 
         const input: MigrateInput = {
@@ -453,6 +454,7 @@ describe('fix', () => {
         }
 
         expectFile(outputs[0]).toMatchSnapshot();
+        expectFile(outputs[1]).toMatchSnapshot();
       });
 
       test('with typedef for component signature interface', async () => {


### PR DESCRIPTION
- Adds support for the convenience TOC type from `@ember/component/template-only`.
- Passes found type identifier to glint methods.
- Adds `@types/ember__component` to migrate test fixture, allows for test for toc to not show rehearsal TODOS.
- Depends on #1278
- This should close out the work to complete #1227 